### PR TITLE
chore: update devcontainer config and devc-remote script

### DIFF
--- a/.devcontainer/justfile.base
+++ b/.devcontainer/justfile.base
@@ -373,10 +373,10 @@ sidecar name *args:
 # -------------------------------------------------------------------------------
 
 # Start a devcontainer on a remote host and open Cursor/VS Code
-# Usage: just devc-remote <ssh-host>[:<remote-path>]
-# Example: just devc-remote myserver
-#          just devc-remote user@host:/opt/projects/myrepo
-#          just devc-remote myserver:/home/user/repo
+# Auto-clones the repo and runs init-workspace if needed
+# Usage: just devc-remote myserver
+#        just devc-remote myserver:/home/user/repo
+#        just devc-remote --repo git@github.com:org/repo.git myserver
 [group('devcontainer')]
-devc-remote host_path:
-    bash scripts/devc-remote.sh {{host_path}}
+devc-remote *args:
+    bash scripts/devc-remote.sh {{args}}

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -210,8 +210,11 @@ remote_compose_up() {
     else
         log_info "Starting devcontainer on $SSH_HOST..."
         # shellcheck disable=SC2029
-        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
-        # Health poll (simplified: assume success for now)
+        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+            log_error "Failed to start devcontainer on $SSH_HOST."
+            log_error "Debug with: ssh $SSH_HOST 'cd $REMOTE_PATH && $COMPOSE_CMD logs'"
+            exit 1
+        fi
         sleep 2
     fi
 }

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -243,11 +243,23 @@ open_editor() {
 
 main() {
     parse_args "$@"
+
+    log_info "Detecting local editor CLI..."
     detect_editor_cli
+    log_success "Using $EDITOR_CLI"
+
+    log_info "Checking SSH connectivity to $SSH_HOST..."
     check_ssh
+    log_success "SSH connection OK"
+
+    log_info "Running pre-flight checks on $SSH_HOST..."
     remote_preflight
+    log_success "Pre-flight OK (runtime: $RUNTIME)"
+
     remote_compose_up
     open_editor
+
+    log_success "Done — opened $EDITOR_CLI for $SSH_HOST:$REMOTE_PATH"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Updated `justfile.base` devc-remote recipe to accept variadic args and improved usage comments to reflect auto-clone and `--repo` flag support
- Improved `devc-remote.sh` with proper error handling for `docker compose up`, added progress logging throughout the `main()` flow

## Test plan

- [ ] Run `just devc-remote myserver` against a remote host and verify it connects and opens the editor
- [ ] Verify error messaging when compose up fails on the remote