### PR TITLE
feat(units): implement fd5.units module with physical quantity helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Physical units convention helpers** ([#13](https://github.com/vig-os/fd5/issues/13))
+  - `write_quantity` creates a sub-group with `value`, `units`, `unitSI` attrs
+  - `read_quantity` returns `(value, units, unit_si)` from a quantity sub-group
+  - `set_dataset_units` sets `units` and `unitSI` attrs on an HDF5 dataset
+
 ### Changed
 
 ### Removed

--- a/docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md
+++ b/docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md
@@ -1,0 +1,80 @@
+# DES-001 — fd5 SDK Architecture
+
+| Field       | Value                          |
+|-------------|--------------------------------|
+| ID          | DES-001                        |
+| Date        | 2026-02-25                     |
+| Status      | Draft                          |
+| Epic        | #11                            |
+
+## Overview
+
+This document captures high-level architecture decisions for the fd5 Python SDK.
+Each module section describes its public API, storage layout, and rationale.
+
+## `fd5.units` — Physical quantity convention
+
+**Issue:** [#13](../../issues/13)
+
+### Motivation
+
+Every numerical attribute or dataset with physical meaning must carry units
+information so that readers (human or automated) can interpret values without
+ambiguity. The fd5 format uses two patterns, both inspired by NeXus/OpenPMD
+conventions (see [white-paper.md § Units convention](../../white-paper.md#units-convention)).
+
+### Storage layout
+
+**Attributes with units** use a sub-group pattern:
+
+```
+<name>/
+    attrs: {value: <scalar_or_array>, units: "<str>", unitSI: <float>}
+```
+
+Deleting the group deletes everything — no orphaned attrs.
+Any sub-group carrying `value` + `units` + `unitSI` is programmatically
+identifiable as a physical quantity.
+
+**Datasets with units** carry attrs directly on the dataset:
+
+```
+<dataset>
+    attrs: {units: "<str>", unitSI: <float>, ...}
+```
+
+### Public API
+
+```python
+def write_quantity(
+    group: h5py.Group,
+    name: str,
+    value: float | int | list,
+    units: str,
+    unit_si: float,
+) -> h5py.Group:
+    """Create a sub-group ``name/`` with value, units, unitSI attrs."""
+
+def read_quantity(
+    group: h5py.Group,
+    name: str,
+) -> tuple[float | int | list, str, float]:
+    """Return (value, units, unit_si) from a quantity sub-group."""
+
+def set_dataset_units(
+    dataset: h5py.Dataset,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Set units and unitSI attrs on an existing dataset."""
+```
+
+### Design decisions
+
+1. **Snake-case API, camelCase HDF5 attrs** — Python callers use `unit_si`;
+   the HDF5 attribute is stored as `unitSI` to match the NeXus/OpenPMD
+   convention from the white paper.
+2. **Return a plain tuple** rather than a dataclass — keeps the module a leaf
+   with zero internal dependencies. A richer type can wrap this later.
+3. **No implicit SI conversion** — the module stores and retrieves; conversion
+   is the caller's responsibility (`value_si = value * unit_si`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ name = "fd5"
 version = "0.1.0"
 description = "fd5 project"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "h5py>=3.10",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/fd5/units.py
+++ b/src/fd5/units.py
@@ -1,0 +1,103 @@
+"""Physical quantity convention helpers for HDF5 files.
+
+Implements the value/units/unitSI sub-group pattern for attributes
+and the units/unitSI attribute pattern for datasets. See
+`docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md#fd5units--physical-quantity-convention`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import h5py
+
+
+def write_quantity(
+    group: h5py.Group,
+    name: str,
+    value: float | int | list,
+    units: str,
+    unit_si: float,
+) -> h5py.Group:
+    """Create a sub-group *name/* with ``value``, ``units``, ``unitSI`` attrs.
+
+    Parameters
+    ----------
+    group:
+        Parent HDF5 group.
+    name:
+        Name for the new quantity sub-group.
+    value:
+        Scalar, integer, or array-like value.
+    units:
+        Human-readable unit string (e.g. ``"mm"``, ``"s"``, ``"MBq"``).
+    unit_si:
+        Numeric conversion factor to SI base units.
+
+    Returns
+    -------
+    h5py.Group
+        The newly created sub-group.
+
+    Raises
+    ------
+    ValueError
+        If *name* already exists in *group*.
+    """
+    if name in group:
+        msg = f"Quantity '{name}' already exists in {group.name}"
+        raise ValueError(msg)
+
+    sub = group.create_group(name)
+    sub.attrs["value"] = value
+    sub.attrs["units"] = units
+    sub.attrs["unitSI"] = unit_si
+    return sub
+
+
+def read_quantity(
+    group: h5py.Group,
+    name: str,
+) -> tuple[float | int | list, str, float]:
+    """Read a physical quantity from a sub-group.
+
+    Parameters
+    ----------
+    group:
+        Parent HDF5 group containing the quantity sub-group.
+    name:
+        Name of the quantity sub-group.
+
+    Returns
+    -------
+    tuple[float | int | list, str, float]
+        ``(value, units, unit_si)``
+
+    Raises
+    ------
+    KeyError
+        If *name* does not exist or lacks required attrs.
+    """
+    sub = group[name]
+    return sub.attrs["value"], str(sub.attrs["units"]), float(sub.attrs["unitSI"])
+
+
+def set_dataset_units(
+    dataset: h5py.Dataset,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Set ``units`` and ``unitSI`` attributes on a dataset.
+
+    Parameters
+    ----------
+    dataset:
+        An existing HDF5 dataset.
+    units:
+        Human-readable unit string.
+    unit_si:
+        Numeric conversion factor to SI base units.
+    """
+    dataset.attrs["units"] = units
+    dataset.attrs["unitSI"] = unit_si

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,149 @@
+"""Tests for fd5.units — physical quantity convention helpers."""
+
+import numpy as np
+import h5py
+import pytest
+
+from fd5.units import read_quantity, set_dataset_units, write_quantity
+
+
+@pytest.fixture()
+def h5_group(tmp_path):
+    """Yield a writable HDF5 group backed by a temp file."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+class TestWriteQuantity:
+    """Tests for write_quantity."""
+
+    def test_creates_subgroup_with_attrs(self, h5_group):
+        write_quantity(h5_group, "z_min", -450.2, "mm", 0.001)
+
+        grp = h5_group["z_min"]
+        assert grp.attrs["value"] == pytest.approx(-450.2)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_returns_created_group(self, h5_group):
+        result = write_quantity(h5_group, "duration", 367.0, "s", 1.0)
+        assert isinstance(result, h5py.Group)
+        assert result.name.endswith("/duration")
+
+    def test_integer_value(self, h5_group):
+        write_quantity(h5_group, "kvp", 120, "kV", 1000.0)
+
+        grp = h5_group["kvp"]
+        assert grp.attrs["value"] == 120
+        assert grp.attrs["units"] == "kV"
+        assert grp.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_list_value(self, h5_group):
+        write_quantity(h5_group, "grid_spacing", [4.0, 4.0, 4.0], "mm", 0.001)
+
+        grp = h5_group["grid_spacing"]
+        np.testing.assert_array_almost_equal(grp.attrs["value"], [4.0, 4.0, 4.0])
+        assert grp.attrs["units"] == "mm"
+
+    def test_numpy_array_value(self, h5_group):
+        arr = np.array([120.0, 120.0, 120.0, 120.0])
+        write_quantity(h5_group, "frame_durations", arr, "s", 1.0)
+
+        grp = h5_group["frame_durations"]
+        np.testing.assert_array_almost_equal(grp.attrs["value"], arr)
+
+    def test_overwrites_existing_group_raises(self, h5_group):
+        write_quantity(h5_group, "z_min", -450.2, "mm", 0.001)
+        with pytest.raises(ValueError, match="already exists"):
+            write_quantity(h5_group, "z_min", -450.2, "mm", 0.001)
+
+
+class TestReadQuantity:
+    """Tests for read_quantity."""
+
+    def test_round_trip_scalar(self, h5_group):
+        write_quantity(h5_group, "duration", 367.0, "s", 1.0)
+
+        value, units, unit_si = read_quantity(h5_group, "duration")
+        assert value == pytest.approx(367.0)
+        assert units == "s"
+        assert unit_si == pytest.approx(1.0)
+
+    def test_round_trip_integer(self, h5_group):
+        write_quantity(h5_group, "kvp", 120, "kV", 1000.0)
+
+        value, units, unit_si = read_quantity(h5_group, "kvp")
+        assert value == 120
+        assert units == "kV"
+        assert unit_si == pytest.approx(1000.0)
+
+    def test_round_trip_list(self, h5_group):
+        write_quantity(h5_group, "grid_spacing", [4.0, 4.0, 4.0], "mm", 0.001)
+
+        value, units, unit_si = read_quantity(h5_group, "grid_spacing")
+        np.testing.assert_array_almost_equal(value, [4.0, 4.0, 4.0])
+        assert units == "mm"
+        assert unit_si == pytest.approx(0.001)
+
+    def test_missing_quantity_raises(self, h5_group):
+        with pytest.raises(KeyError):
+            read_quantity(h5_group, "nonexistent")
+
+    def test_missing_attrs_raises(self, h5_group):
+        h5_group.create_group("bad_group")
+        with pytest.raises(KeyError):
+            read_quantity(h5_group, "bad_group")
+
+
+class TestSetDatasetUnits:
+    """Tests for set_dataset_units."""
+
+    def test_sets_units_and_unit_si(self, h5_group):
+        ds = h5_group.create_dataset("volume", data=np.zeros((2, 3, 4)))
+        set_dataset_units(ds, "Bq/mL", 1000.0)
+
+        assert ds.attrs["units"] == "Bq/mL"
+        assert ds.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_preserves_existing_attrs(self, h5_group):
+        ds = h5_group.create_dataset("signal", data=np.zeros(100))
+        ds.attrs["description"] = "Raw ECG signal"
+
+        set_dataset_units(ds, "mV", 0.001)
+
+        assert ds.attrs["description"] == "Raw ECG signal"
+        assert ds.attrs["units"] == "mV"
+        assert ds.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_overwrites_existing_units(self, h5_group):
+        ds = h5_group.create_dataset("time", data=np.zeros(50))
+        set_dataset_units(ds, "ms", 0.001)
+        set_dataset_units(ds, "s", 1.0)
+
+        assert ds.attrs["units"] == "s"
+        assert ds.attrs["unitSI"] == pytest.approx(1.0)
+
+
+class TestIdempotency:
+    """Verify write-then-read returns identical values."""
+
+    @pytest.mark.parametrize(
+        "name,value,units,unit_si",
+        [
+            ("activity", 350.0, "MBq", 1e6),
+            ("half_life", 6586.2, "s", 1.0),
+            ("ctdi_vol", 12.5, "mGy", 0.001),
+            ("angular_range", [-30, 30], "mrad", 0.001),
+        ],
+    )
+    def test_round_trip_parametrized(self, h5_group, name, value, units, unit_si):
+        write_quantity(h5_group, name, value, units, unit_si)
+        got_value, got_units, got_unit_si = read_quantity(h5_group, name)
+
+        if isinstance(value, list):
+            np.testing.assert_array_almost_equal(got_value, value)
+        else:
+            assert got_value == pytest.approx(value)
+        assert got_units == units
+        assert got_unit_si == pytest.approx(unit_si)

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,9 @@ wheels = [
 name = "fd5"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "h5py" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -549,6 +552,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fd5", extras = ["dev", "science"], marker = "extra == 'all'" },
+    { name = "h5py", specifier = ">=3.10" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.9" },
@@ -623,6 +627,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b8/c0d9aa013ecfa8b7057946c080c0c07f6fa41e231d2e9bd306a2f8110bdc/h5py-3.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:316dd0f119734f324ca7ed10b5627a2de4ea42cc4dfbcedbee026aaa361c238c", size = 3399089, upload-time = "2025-10-16T10:34:12.135Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5e/3c6f6e0430813c7aefe784d00c6711166f46225f5d229546eb53032c3707/h5py-3.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b51469890e58e85d5242e43aab29f5e9c7e526b951caab354f3ded4ac88e7b76", size = 2847803, upload-time = "2025-10-16T10:34:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/ba36273b888a4a48d78f9268d2aee05787e4438557450a8442946ab8f3ec/h5py-3.15.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a33bfd5dfcea037196f7778534b1ff7e36a7f40a89e648c8f2967292eb6898e", size = 4914884, upload-time = "2025-10-16T10:34:18.452Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/30/d1c94066343a98bb2cea40120873193a4fed68c4ad7f8935c11caf74c681/h5py-3.15.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25c8843fec43b2cc368aa15afa1cdf83fc5e17b1c4e10cd3771ef6c39b72e5ce", size = 5109965, upload-time = "2025-10-16T10:34:21.853Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3d/d28172116eafc3bc9f5991b3cb3fd2c8a95f5984f50880adfdf991de9087/h5py-3.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a308fd8681a864c04423c0324527237a0484e2611e3441f8089fd00ed56a8171", size = 4561870, upload-time = "2025-10-16T10:34:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/393a7226024238b0f51965a7156004eaae1fcf84aa4bfecf7e582676271b/h5py-3.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4a016df3f4a8a14d573b496e4d1964deb380e26031fc85fb40e417e9131888a", size = 5037161, upload-time = "2025-10-16T10:34:30.383Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/329e7436bf87ca6b0fe06dd0a3795c34bebe4ed8d6c44450a20565d57832/h5py-3.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:59b25cf02411bf12e14f803fef0b80886444c7fe21a5ad17c6a28d3f08098a1e", size = 2874165, upload-time = "2025-10-16T10:34:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/2d02b10a66747c54446e932171dd89b8b4126c0111b440e6bc05a7c852ec/h5py-3.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:61d5a58a9851e01ee61c932bbbb1c98fe20aba0a5674776600fb9a361c0aa652", size = 2458214, upload-time = "2025-10-16T10:34:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/40207e0192415cbff7ea1d37b9f24b33f6d38a5a2f5d18a678de78f967ae/h5py-3.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8440fd8bee9500c235ecb7aa1917a0389a2adb80c209fa1cc485bd70e0d94a5", size = 3376511, upload-time = "2025-10-16T10:34:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/31/96/ba99a003c763998035b0de4c299598125df5fc6c9ccf834f152ddd60e0fb/h5py-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab2219dbc6fcdb6932f76b548e2b16f34a1f52b7666e998157a4dfc02e2c4123", size = 2826143, upload-time = "2025-10-16T10:34:41.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c2/fc6375d07ea3962df7afad7d863fe4bde18bb88530678c20d4c90c18de1d/h5py-3.15.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8cb02c3a96255149ed3ac811eeea25b655d959c6dd5ce702c9a95ff11859eb5", size = 4908316, upload-time = "2025-10-16T10:34:44.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/4402ea66272dacc10b298cca18ed73e1c0791ff2ae9ed218d3859f9698ac/h5py-3.15.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:121b2b7a4c1915d63737483b7bff14ef253020f617c2fb2811f67a4bed9ac5e8", size = 5103710, upload-time = "2025-10-16T10:34:48.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f6/11f1e2432d57d71322c02a97a5567829a75f223a8c821764a0e71a65cde8/h5py-3.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59b0d63b318bf3cc06687def2b45afd75926bbc006f7b8cd2b1a231299fc8599", size = 4556042, upload-time = "2025-10-16T10:34:51.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/3eda3ef16bfe7a7dbc3d8d6836bbaa7986feb5ff091395e140dc13927bcc/h5py-3.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e02fe77a03f652500d8bff288cbf3675f742fc0411f5a628fa37116507dc7cc0", size = 5030639, upload-time = "2025-10-16T10:34:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ea/fbb258a98863f99befb10ed727152b4ae659f322e1d9c0576f8a62754e81/h5py-3.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dea78b092fd80a083563ed79a3171258d4a4d307492e7cf8b2313d464c82ba52", size = 2864363, upload-time = "2025-10-16T10:34:58.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c9/35021cc9cd2b2915a7da3026e3d77a05bed1144a414ff840953b33937fb9/h5py-3.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:c256254a8a81e2bddc0d376e23e2a6d2dc8a1e8a2261835ed8c1281a0744cd97", size = 2449570, upload-time = "2025-10-16T10:35:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2c/926eba1514e4d2e47d0e9eb16c784e717d8b066398ccfca9b283917b1bfb/h5py-3.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5f4fb0567eb8517c3ecd6b3c02c4f4e9da220c8932604960fd04e24ee1254763", size = 3380368, upload-time = "2025-10-16T10:35:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4b/d715ed454d3baa5f6ae1d30b7eca4c7a1c1084f6a2edead9e801a1541d62/h5py-3.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:954e480433e82d3872503104f9b285d369048c3a788b2b1a00e53d1c47c98dd2", size = 2833793, upload-time = "2025-10-16T10:35:05.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd125c131889ebbef0849f4a0e29cf363b48aba42f228d08b4079913b576bb3a", size = 4903199, upload-time = "2025-10-16T10:35:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28a20e1a4082a479b3d7db2169f3a5034af010b90842e75ebbf2e9e49eb4183e", size = 5097224, upload-time = "2025-10-16T10:35:12.808Z" },
+    { url = "https://files.pythonhosted.org/packages/30/30/5273218400bf2da01609e1292f562c94b461fcb73c7a9e27fdadd43abc0a/h5py-3.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa8df5267f545b4946df8ca0d93d23382191018e4cda2deda4c2cedf9a010e13", size = 4551207, upload-time = "2025-10-16T10:35:16.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implement `fd5.units` module with `write_quantity`, `read_quantity`, and `set_dataset_units` helpers following the `value`/`units`/`unitSI` sub-group pattern from the [whitepaper § Units convention](white-paper.md#units-convention)
- Add DES-001 design document with `fd5.units` API specification and rationale
- 18 tests covering happy paths, error paths, round-trips, and edge cases — 100% coverage

## Test plan

- [x] `write_quantity` creates sub-group with `value`, `units`, `unitSI` attrs (scalar, integer, list, numpy array)
- [x] `write_quantity` raises `ValueError` when name already exists
- [x] `read_quantity` returns `(value, units, unit_si)` tuple
- [x] `read_quantity` raises `KeyError` for missing group or attrs
- [x] `set_dataset_units` sets `units` and `unitSI` on dataset, preserves existing attrs
- [x] Round-trip parametrized tests confirm write→read identity
- [x] Coverage: 100% (17/17 statements)

Closes #13


Made with [Cursor](https://cursor.com)