### PR TITLE
feat(naming): implement fd5.naming module with generate_filename

### DIFF
--- a/docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md
+++ b/docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md
@@ -1,0 +1,73 @@
+# DES-001 — fd5 SDK Architecture
+
+| Field   | Value                    |
+|---------|--------------------------|
+| ID      | DES-001                  |
+| Date    | 2026-02-25               |
+| Status  | Draft                    |
+| Epic    | #11                      |
+
+## Overview
+
+This document describes the module layout and public API surface of the `fd5`
+Python SDK.  Each section maps to one importable sub-module under `src/fd5/`.
+
+## fd5.naming — Filename Generation
+
+### Purpose
+
+Generate deterministic, human-scannable HDF5 filenames that follow the
+convention defined in [white-paper.md § File Naming Convention](../../white-paper.md#file-naming-convention):
+
+```
+YYYY-MM-DD_HH-MM-SS_<product>-<id>_<descriptors>.h5
+```
+
+### Public API
+
+```python
+def generate_filename(
+    product: str,
+    id_hash: str,
+    timestamp: datetime | None = None,
+    descriptors: Sequence[str] = (),
+) -> str: ...
+```
+
+#### Parameters
+
+| Parameter     | Type                    | Description |
+|---------------|-------------------------|-------------|
+| `product`     | `str`                   | Domain-defined product type (e.g. `recon`, `listmode`, `sim`). |
+| `id_hash`     | `str`                   | Full identity hash with algorithm prefix, e.g. `"sha256:a1b2c3d4e5f6..."`. Only the first 8 hex chars after the prefix appear in the filename. |
+| `timestamp`   | `datetime \| None`      | Acquisition/creation timestamp. When `None`, the datetime prefix is omitted (simulations, synthetic data, calibration). |
+| `descriptors` | `Sequence[str]`         | Freeform human-readable labels. Joined with underscores. |
+
+#### Returns
+
+A filename string ending in `.h5`.
+
+#### Rules
+
+1. Timestamp, when present, formatted as `YYYY-MM-DD_HH-MM-SS`.
+2. `id_hash` is split on `:` and the hex portion truncated to 8 characters.
+3. Descriptors are joined with `_`.
+4. Products without a timestamp omit the datetime prefix entirely (no leading
+   underscore).
+
+#### Examples
+
+```
+generate_filename("recon", "sha256:87f032f6abc...", datetime(2024,7,24,18,14,0), ["ct","thorax","dlir"])
+→ "2024-07-24_18-14-00_recon-87f032f6_ct_thorax_dlir.h5"
+
+generate_filename("sim", "sha256:xyz99999...", None, ["pet","nema","gate"])
+→ "sim-xyz99999_pet_nema_gate.h5"
+```
+
+### Design Decisions
+
+- **Stdlib only** — no external dependencies; uses `datetime.strftime`.
+- **Leaf module** — depends on nothing else in `fd5`.
+- **Filename is convenience, not identity** — the full hash lives inside the
+  HDF5 file.  See [white-paper.md](../../white-paper.md#file-naming-convention).

--- a/src/fd5/naming.py
+++ b/src/fd5/naming.py
@@ -1,0 +1,47 @@
+"""Filename generation following the fd5 naming convention.
+
+See docs/designs/DES-001-2026-02-25-fd5-sdk-architecture.md#fd5naming--filename-generation
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+_TIMESTAMP_FMT = "%Y-%m-%d_%H-%M-%S"
+_HASH_DISPLAY_LEN = 8
+
+
+def generate_filename(
+    product: str,
+    id_hash: str,
+    timestamp: datetime | None = None,
+    descriptors: Sequence[str] = (),
+) -> str:
+    """Generate an fd5-convention filename.
+
+    Format: ``YYYY-MM-DD_HH-MM-SS_<product>-<id>_<descriptors>.h5``
+
+    Products without a timestamp omit the datetime prefix.
+    """
+    if not product:
+        raise ValueError("product must be a non-empty string")
+
+    if ":" not in id_hash:
+        raise ValueError("id_hash must include an algorithm prefix (e.g. 'sha256:...')")
+
+    hex_part = id_hash.split(":", 1)[1]
+    if not hex_part:
+        raise ValueError("id_hash must contain hex characters after the prefix")
+
+    short_id = hex_part[:_HASH_DISPLAY_LEN]
+
+    parts: list[str] = []
+
+    if timestamp is not None:
+        parts.append(timestamp.strftime(_TIMESTAMP_FMT))
+
+    parts.append(f"{product}-{short_id}")
+    parts.extend(descriptors)
+
+    return "_".join(parts) + ".h5"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,166 @@
+"""Tests for fd5.naming.generate_filename."""
+
+from datetime import datetime
+
+import pytest
+
+from fd5.naming import generate_filename
+
+
+class TestHappyPath:
+    """Expected inputs produce correctly formatted filenames."""
+
+    def test_full_filename_with_timestamp_and_descriptors(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:87f032f6abcdef01",
+            timestamp=datetime(2024, 7, 24, 18, 14, 0),
+            descriptors=["ct", "thorax", "dlir"],
+        )
+        assert result == "2024-07-24_18-14-00_recon-87f032f6_ct_thorax_dlir.h5"
+
+    def test_no_timestamp_omits_datetime_prefix(self):
+        result = generate_filename(
+            product="sim",
+            id_hash="sha256:xyz99999aabbccdd",
+            timestamp=None,
+            descriptors=["pet", "nema", "gate"],
+        )
+        assert result == "sim-xyz99999_pet_nema_gate.h5"
+
+    def test_single_descriptor(self):
+        result = generate_filename(
+            product="spectrum",
+            id_hash="sha256:44556677aabbccdd",
+            timestamp=datetime(2024, 7, 24, 19, 30, 0),
+            descriptors=["pet"],
+        )
+        assert result == "2024-07-24_19-30-00_spectrum-44556677_pet.h5"
+
+    def test_no_descriptors(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd11223344",
+            timestamp=datetime(2025, 1, 1, 0, 0, 0),
+            descriptors=[],
+        )
+        assert result == "2025-01-01_00-00-00_recon-aabbccdd.h5"
+
+    def test_no_timestamp_no_descriptors(self):
+        result = generate_filename(
+            product="calibration",
+            id_hash="sha256:11223344aabbccdd",
+        )
+        assert result == "calibration-11223344.h5"
+
+    def test_defaults_for_optional_params(self):
+        result = generate_filename("sim", "sha256:deadbeef12345678")
+        assert result == "sim-deadbeef.h5"
+
+
+class TestIdHashTruncation:
+    """id_hash is split on ':' and truncated to 8 hex chars."""
+
+    def test_truncates_long_hash_to_8_chars(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:2a3ac438e7f1b9d0c6a5",
+            timestamp=datetime(2024, 7, 24, 19, 6, 10),
+            descriptors=["pet", "qclear", "wb"],
+        )
+        assert result == "2024-07-24_19-06-10_recon-2a3ac438_pet_qclear_wb.h5"
+
+    def test_hash_exactly_8_chars(self):
+        result = generate_filename(
+            product="sim",
+            id_hash="sha256:abcdef01",
+            descriptors=["test"],
+        )
+        assert result == "sim-abcdef01_test.h5"
+
+    def test_hash_shorter_than_8_chars_used_as_is(self):
+        result = generate_filename(
+            product="sim",
+            id_hash="sha256:abc",
+            descriptors=["test"],
+        )
+        assert result == "sim-abc_test.h5"
+
+
+class TestTimestampFormatting:
+    """Timestamp formatted as YYYY-MM-DD_HH-MM-SS."""
+
+    def test_midnight(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=datetime(2025, 12, 31, 0, 0, 0),
+        )
+        assert result == "2025-12-31_00-00-00_recon-aabbccdd.h5"
+
+    def test_end_of_day(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=datetime(2025, 12, 31, 23, 59, 59),
+        )
+        assert result == "2025-12-31_23-59-59_recon-aabbccdd.h5"
+
+
+class TestEdgeCases:
+    """Boundary and unusual inputs."""
+
+    def test_empty_descriptors_tuple(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            descriptors=(),
+        )
+        assert result == "2025-01-01_12-00-00_recon-aabbccdd.h5"
+
+    def test_many_descriptors(self):
+        result = generate_filename(
+            product="features",
+            id_hash="sha256:a1b2c3d4e5f6",
+            timestamp=datetime(2025, 6, 1, 12, 0, 0),
+            descriptors=["satellite", "band4", "ndvi"],
+        )
+        assert result == "2025-06-01_12-00-00_features-a1b2c3d4_satellite_band4_ndvi.h5"
+
+    def test_whitepaper_example_calibration_no_timestamp(self):
+        result = generate_filename(
+            product="calibration",
+            id_hash="sha256:11223344aabbccdd",
+            descriptors=["detector", "energy", "hpge"],
+        )
+        assert result == "calibration-11223344_detector_energy_hpge.h5"
+
+
+class TestInputValidation:
+    """Invalid inputs raise appropriate errors."""
+
+    def test_empty_product_raises(self):
+        with pytest.raises(ValueError, match="product"):
+            generate_filename(product="", id_hash="sha256:aabbccdd")
+
+    def test_id_hash_missing_prefix_raises(self):
+        with pytest.raises(ValueError, match="id_hash"):
+            generate_filename(product="recon", id_hash="aabbccdd")
+
+    def test_id_hash_empty_hex_after_prefix_raises(self):
+        with pytest.raises(ValueError, match="id_hash"):
+            generate_filename(product="recon", id_hash="sha256:")
+
+
+class TestIdempotency:
+    """Calling generate_filename twice with the same inputs produces the same result."""
+
+    def test_same_inputs_same_output(self):
+        kwargs = dict(
+            product="recon",
+            id_hash="sha256:87f032f6abcdef01",
+            timestamp=datetime(2024, 7, 24, 18, 14, 0),
+            descriptors=["ct", "thorax", "dlir"],
+        )
+        assert generate_filename(**kwargs) == generate_filename(**kwargs)


### PR DESCRIPTION
## Summary

- Add `fd5.naming.generate_filename()` producing filenames in the `YYYY-MM-DD_HH-MM-SS_<product>-<id>_<descriptors>.h5` convention
- Truncate `id_hash` to first 8 hex chars after the algorithm prefix; omit datetime prefix when `timestamp is None`
- Add DES-001 design doc with `fd5.naming` specification referencing the white-paper § File Naming Convention

## Test plan

- [x] 18 unit tests covering happy path, id_hash truncation, timestamp formatting, edge cases, input validation, and idempotency
- [x] 100% line coverage on `src/fd5/naming.py`
- [x] All existing tests pass (20/20)

Closes #18

Made with [Cursor](https://cursor.com)