### PR TITLE
feat(registry): implement product schema registry with entry-point discovery

### DIFF
--- a/.cursor/skills/pr_create/SKILL.md
+++ b/.cursor/skills/pr_create/SKILL.md
@@ -17,6 +17,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 - Run `git status` and `git fetch origin`. If the current branch has a remote tracking branch, run `git pull --rebase origin <current-branch>` (or `git pull` if the user prefers merge) so the branch is up to date with the remote.
 - If there are uncommitted changes, list them and ask the user to commit or stash before submitting the PR. Do not prepare the PR until the working tree is clean (or the user explicitly says to proceed with uncommitted changes).
+- **Merge the base branch:** Once the base branch is confirmed (step 2), run `git merge origin/<base_branch>` to integrate the latest base before creating the PR. **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them manually before proceeding.
 
 ### 2. Verify target branch
 

--- a/.cursor/skills/pr_solve/SKILL.md
+++ b/.cursor/skills/pr_solve/SKILL.md
@@ -108,6 +108,7 @@ Show the user a structured summary before any fixes:
 
 ### 5. Execute fixes
 
+- **Merge the base branch** before the first push: run `git fetch origin` and `git merge origin/<base_branch>` (use `baseRefName` from step 1's PR metadata). **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them before proceeding.
 - Work through approved tasks one at a time.
 - Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
 - Commit each fix via [git_commit](../git_commit/SKILL.md).

--- a/.devcontainer/justfile.base
+++ b/.devcontainer/justfile.base
@@ -73,7 +73,7 @@ clean-artifacts:
 [group('info')]
 check *args:
     #!/usr/bin/env bash
-    SCRIPT_DIR="$(cd "$(dirname "{{justfile_directory()}}")/.devcontainer/scripts" && pwd)" || {
+    SCRIPT_DIR="$(cd "{{source_directory()}}/scripts" && pwd)" || {
         echo "Error: Could not locate .devcontainer/scripts directory"
         exit 1
     }

--- a/.devcontainer/justfile.base
+++ b/.devcontainer/justfile.base
@@ -373,10 +373,10 @@ sidecar name *args:
 # -------------------------------------------------------------------------------
 
 # Start a devcontainer on a remote host and open Cursor/VS Code
-# Usage: just devc-remote <ssh-host>[:<remote-path>]
-# Example: just devc-remote myserver
-#          just devc-remote user@host:/opt/projects/myrepo
-#          just devc-remote myserver:/home/user/repo
+# Auto-clones the repo and runs init-workspace if needed
+# Usage: just devc-remote myserver
+#        just devc-remote myserver:/home/user/repo
+#        just devc-remote --repo git@github.com:org/repo.git myserver
 [group('devcontainer')]
-devc-remote host_path:
-    bash scripts/devc-remote.sh {{host_path}}
+devc-remote *args:
+    bash scripts/devc-remote.sh {{args}}

--- a/.devcontainer/justfile.gh
+++ b/.devcontainer/justfile.gh
@@ -7,4 +7,4 @@ _gh_scripts := source_directory() / "scripts"
 # List open issues and PRs grouped by milestone
 [group('github')]
 gh-issues:
-    python3 {{ _gh_scripts }}/gh_issues.py
+    uv run python {{ _gh_scripts }}/gh_issues.py

--- a/.devcontainer/justfile.worktree
+++ b/.devcontainer/justfile.worktree
@@ -11,6 +11,9 @@
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
+# Scripts path: resolves to scripts/ in devcontainer repo, .devcontainer/scripts/ in workspace
+_scripts := source_directory() / "scripts"
+
 # -------------------------------------------------------------------------------
 # START
 # -------------------------------------------------------------------------------
@@ -114,10 +117,11 @@ worktree-start issue prompt="" reviewer="":
             echo "    tmux session '$SESSION' is running. Use: just worktree-attach $ISSUE"
         else
             echo "    No tmux session found. Starting one..."
+            AGENT_MODEL=$(_read_model "autonomous")
             if [ -n "$PROMPT" ]; then
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --yolo --approve-mcps \"$PROMPT\""
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --yolo --approve-mcps \"$PROMPT\""
             else
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
             fi
             sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
             echo "[OK] tmux session '$SESSION' started. Use: just worktree-attach $ISSUE"
@@ -126,7 +130,7 @@ worktree-start issue prompt="" reviewer="":
     fi
 
     # Resolve the issue's linked branch (may already exist from issue:claim)
-    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
 
     if [ -z "$BRANCH" ]; then
         echo "[*] No linked branch for issue #${ISSUE}. Creating one..."
@@ -144,11 +148,16 @@ worktree-start issue prompt="" reviewer="":
         fi
 
         # Use agent ONLY for the intelligent part: deriving the short summary
+        # Try lightweight first; on failure retry with standard model (#183)
         NAMING_RULE="$(pwd)/.cursor/rules/branch-naming.mdc"
-        SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" 2>/dev/null) || true
+        SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
 
         if [ -z "$SUMMARY" ]; then
-            "$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" >/dev/null || true
+            echo "[!] Lightweight model failed. Retrying with standard model..."
+            SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
+        fi
+
+        if [ -z "$SUMMARY" ]; then
             echo "        Create one manually: gh issue develop ${ISSUE} --base dev --name ${TYPE}/${ISSUE}-<summary>"
             exit 1
         fi
@@ -157,7 +166,7 @@ worktree-start issue prompt="" reviewer="":
         OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
         PARENT=$(gh api "repos/${OWNER_REPO}/issues/${ISSUE}/parent" --jq '.number' 2>/dev/null || true)
         if [ -n "$PARENT" ]; then
-            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
             BASE="${BASE:-dev}"
         else
             BASE="dev"
@@ -213,10 +222,11 @@ worktree-start issue prompt="" reviewer="":
 
     # Start tmux session
     # --yolo: auto-approve all shell commands (autonomous agent, no human at the terminal)
+    AGENT_MODEL=$(_read_model "autonomous")
     if [ -n "$PROMPT" ]; then
-        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --yolo --approve-mcps \"$PROMPT\""
+        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --yolo --approve-mcps \"$PROMPT\""
     else
-        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
     fi
     sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
 
@@ -299,6 +309,12 @@ worktree-attach issue:
         fi
     }
 
+    _read_model() {
+        local tier="$1"
+        local cfg="$(git rev-parse --show-toplevel)/.cursor/agent-models.toml"
+        grep "^${tier}" "$cfg" | sed 's/.*= *"//' | sed 's/".*//'
+    }
+
     ISSUE="{{ issue }}"
     SESSION="wt-${ISSUE}"
     WT_DIR="{{ _wt_base }}/${ISSUE}"
@@ -307,11 +323,12 @@ worktree-attach issue:
         if [ -d "$WT_DIR" ]; then
             echo "[!] tmux session '$SESSION' stopped. Restarting..."
             _wt_ensure_trust "$WT_DIR"
-            REVIEWER=$(gh api user --jq '.login' 2>/dev/null || echo "")
             if [ -n "${WORKTREE_ATTACH_RESTART_CMD:-}" ]; then
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "$WORKTREE_ATTACH_RESTART_CMD"
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" "$WORKTREE_ATTACH_RESTART_CMD"
             else
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+                REVIEWER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+                AGENT_MODEL=$(_read_model "autonomous")
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
             fi
             sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
             echo "[OK] tmux session '$SESSION' restarted"

--- a/.devcontainer/scripts/check-skill-names.sh
+++ b/.devcontainer/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/.devcontainer/scripts/derive-branch-summary.sh
+++ b/.devcontainer/scripts/derive-branch-summary.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Derive a kebab-case branch summary from an issue title.
+# Used by worktree-start when no linked branch exists.
+#
+# Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]
+#   TITLE: issue title
+#   NAMING_RULE: path to branch-naming.mdc (default: .cursor/rules/branch-naming.mdc)
+#   MODEL_TIER: agent-models.toml tier (default: lightweight). Use standard for retry.
+#
+# Env: BRANCH_SUMMARY_CMD — override for tests (e.g. "echo test-summary")
+#      When set, runs instead of agent. Must output summary to stdout.
+#      BRANCH_SUMMARY_MODEL — override model tier (e.g. "standard"). Ignored if BRANCH_SUMMARY_CMD set.
+#      DERIVE_BRANCH_TIMEOUT — timeout in seconds (default: 30). Use 2 for tests.
+set -euo pipefail
+
+TITLE="${1:?Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NAMING_RULE="${2:-${REPO_ROOT}/.cursor/rules/branch-naming.mdc}"
+MODEL_TIER="${3:-${BRANCH_SUMMARY_MODEL:-lightweight}}"
+TIMEOUT="${DERIVE_BRANCH_TIMEOUT:-30}"
+
+if [ -n "${BRANCH_SUMMARY_CMD:-}" ]; then
+    SUMMARY=$(timeout "$TIMEOUT" sh -c "$BRANCH_SUMMARY_CMD" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+else
+    MODEL=$(grep "^${MODEL_TIER}" "${REPO_ROOT}/.cursor/agent-models.toml" | sed 's/.*= *"//' | sed 's/".*//')
+    SUMMARY=$(timeout "$TIMEOUT" agent --print --yolo --trust --model "$MODEL" \
+        "Read the branch naming rules in ${NAMING_RULE}. " \
+        "The issue title is: ${TITLE} " \
+        "Output ONLY a kebab-case short summary suitable for a branch name (a few words). " \
+        "Omit prefixes like FEATURE, BUG, Add, Implement, Support. " \
+        "Example: 'Standardize and Enforce Commit Message Format' -> 'standardize-commit-messages'. " \
+        "No explanation. No quotes. Just the summary." 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+fi
+
+if [ -z "$SUMMARY" ]; then
+    echo "[ERROR] Failed to derive branch summary from title: ${TITLE}" >&2
+    echo "        Create one manually: gh issue develop <ISSUE> --base dev --name <type>/<issue>-<summary>" >&2
+    exit 1
+fi
+
+echo "$SUMMARY"

--- a/.devcontainer/scripts/gh_issues.py
+++ b/.devcontainer/scripts/gh_issues.py
@@ -374,13 +374,34 @@ def _infer_review(pr: dict) -> tuple[str, str]:
     return ("", "—")
 
 
+def _dedupe_status_checks(rollup: list[dict]) -> list[dict]:
+    """Deduplicate statusCheckRollup by check name, keeping latest by completedAt.
+
+    GitHub includes re-runs of the same check; we keep only the latest result
+    per check name so the CI column matches what GitHub shows on the PR page.
+    Ref: #176
+    """
+    by_name: dict[str, dict] = {}
+    for check in rollup:
+        name = check.get("name") or "?"
+        completed = check.get("completedAt") or ""
+        existing = by_name.get(name)
+        if existing is None:
+            by_name[name] = check
+        else:
+            existing_completed = existing.get("completedAt") or ""
+            if completed >= existing_completed:
+                by_name[name] = check
+    return list(by_name.values())
+
+
 def _format_ci_status(pr: dict, owner_repo: str) -> str:
     """Return Rich markup for CI status cell: pass/fail/pending summary with link.
 
     Uses statusCheckRollup from gh pr list. Links to PR checks tab.
     Ref: #143
     """
-    rollup = pr.get("statusCheckRollup") or []
+    rollup = _dedupe_status_checks(pr.get("statusCheckRollup") or [])
     if not rollup:
         return _styled("—", "dim")
 
@@ -485,7 +506,9 @@ def _build_pr_table(
 
         linked = pr_to_issues.get(pr["number"], [])
         issues_cell = (
-            " ".join(_styled(f"#{n}", "cyan") for n in sorted(linked)) if linked else ""
+            " ".join(_gh_link(owner_repo, n, "issues") for n in sorted(linked))
+            if linked
+            else ""
         )
 
         ci_cell = _format_ci_status(pr, owner_repo)

--- a/.devcontainer/scripts/resolve-branch.sh
+++ b/.devcontainer/scripts/resolve-branch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Extract the branch name from `gh issue develop --list` output.
+# Input:  tab-separated lines on stdin (branch<TAB>URL)
+# Output: first branch name (first field of first line)
+head -1 | cut -f1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,7 +123,7 @@ repos:
     hooks:
       - id: check-skill-names
         name: check-skill-names (enforce naming convention)
-        entry: scripts/check-skill-names.sh .cursor/skills
+        entry: .devcontainer/scripts/check-skill-names.sh .cursor/skills
         language: script
         files: ^\.cursor/skills/
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,5 @@ packages = ["src/fd5"]
 [dependency-groups]
 dev = [
     "hatchling>=1.25",
+    "rich>=13.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,16 @@ name = "fd5"
 version = "0.1.0"
 description = "fd5 project"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "h5py>=3.10",
+    "numpy>=2.0",
+    "jsonschema>=4.20",
+    "tomli-w>=1.0",
+    "click>=8.0",
+]
+
+[project.scripts]
+fd5 = "fd5.cli:cli"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/check-skill-names.sh
+++ b/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -210,8 +210,11 @@ remote_compose_up() {
     else
         log_info "Starting devcontainer on $SSH_HOST..."
         # shellcheck disable=SC2029
-        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
-        # Health poll (simplified: assume success for now)
+        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+            log_error "Failed to start devcontainer on $SSH_HOST."
+            log_error "Debug with: ssh $SSH_HOST 'cd $REMOTE_PATH && $COMPOSE_CMD logs'"
+            exit 1
+        fi
         sleep 2
     fi
 }

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -243,11 +243,23 @@ open_editor() {
 
 main() {
     parse_args "$@"
+
+    log_info "Detecting local editor CLI..."
     detect_editor_cli
+    log_success "Using $EDITOR_CLI"
+
+    log_info "Checking SSH connectivity to $SSH_HOST..."
     check_ssh
+    log_success "SSH connection OK"
+
+    log_info "Running pre-flight checks on $SSH_HOST..."
     remote_preflight
+    log_success "Pre-flight OK (runtime: $RUNTIME)"
+
     remote_compose_up
     open_editor
+
+    log_success "Done — opened $EDITOR_CLI for $SSH_HOST:$REMOTE_PATH"
 }
 
 main "$@"

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+###############################################################################
+# devc-remote.sh - Remote devcontainer orchestrator
+#
+# Starts a devcontainer on a remote host via SSH and opens Cursor/VS Code.
+# Handles SSH connectivity, pre-flight checks, container state detection,
+# and compose lifecycle. URI construction delegated to Python helper.
+#
+# USAGE:
+#   ./scripts/devc-remote.sh <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh --help
+#
+# Examples:
+#   ./scripts/devc-remote.sh myserver
+#   ./scripts/devc-remote.sh user@host:/opt/projects/myrepo
+#   ./scripts/devc-remote.sh myserver:/home/user/repo
+#
+# Part of #70. See issue #152 for design.
+###############################################################################
+
+set -euo pipefail
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LOGGING (matches init.sh patterns)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+log_info() {
+    echo -e "${BLUE}ℹ${NC}  $1"
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC}  $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠${NC}  $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${NC}  $1"
+}
+
+show_help() {
+    sed -n '/^###############################################################################$/,/^###############################################################################$/p' "$0" | sed '1d;$d'
+    exit 0
+}
+
+parse_args() {
+    SSH_HOST=""
+    REMOTE_PATH="~"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help|-h)
+                show_help
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                echo "Use --help for usage information"
+                exit 1
+                ;;
+            *)
+                if [[ -n "$SSH_HOST" ]]; then
+                    log_error "Unexpected argument: $1"
+                    exit 1
+                fi
+                # Parse SSH-style format: user@host:path or host:path
+                if [[ "$1" =~ ^([^:]+):(.+)$ ]]; then
+                    SSH_HOST="${BASH_REMATCH[1]}"
+                    REMOTE_PATH="${BASH_REMATCH[2]}"
+                else
+                    SSH_HOST="$1"
+                    # Default to ~ (expanded by remote shell) if no path specified
+                    REMOTE_PATH="~"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$SSH_HOST" ]]; then
+        log_error "Missing required argument: <ssh-host>[:<remote-path>]"
+        echo "Use --help for usage information"
+        exit 1
+    fi
+}
+
+detect_editor_cli() {
+    if command -v cursor &>/dev/null; then
+        # shellcheck disable=SC2034
+        EDITOR_CLI="cursor"
+    elif command -v code &>/dev/null; then
+        # shellcheck disable=SC2034
+        EDITOR_CLI="code"
+    else
+        log_error "Neither cursor nor code CLI found. Install Cursor or VS Code and enable the shell command."
+        exit 1
+    fi
+}
+
+check_ssh() {
+    if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$SSH_HOST" true 2>/dev/null; then
+        log_error "Cannot connect to $SSH_HOST. Check your SSH config and network."
+        exit 1
+    fi
+}
+
+remote_preflight() {
+    local preflight_output
+    # shellcheck disable=SC2029
+    preflight_output=$(ssh "$SSH_HOST" "bash -s" "$REMOTE_PATH" << 'REMOTEEOF'
+REPO_PATH="${1:-$HOME}"
+if command -v podman &>/dev/null; then
+    echo "RUNTIME=podman"
+elif command -v docker &>/dev/null; then
+    echo "RUNTIME=docker"
+else
+    echo "RUNTIME="
+fi
+if (command -v podman &>/dev/null && podman compose version &>/dev/null) || \
+   (command -v docker &>/dev/null && docker compose version &>/dev/null); then
+    echo "COMPOSE_AVAILABLE=1"
+else
+    echo "COMPOSE_AVAILABLE=0"
+fi
+if [ -d "$REPO_PATH" ]; then
+    echo "REPO_PATH_EXISTS=1"
+else
+    echo "REPO_PATH_EXISTS=0"
+fi
+if [ -d "$REPO_PATH/.devcontainer" ]; then
+    echo "DEVCONTAINER_EXISTS=1"
+else
+    echo "DEVCONTAINER_EXISTS=0"
+fi
+AVAIL_GB=$(df -BG "$REPO_PATH" 2>/dev/null | awk 'NR==2 {gsub(/G/,""); print $4}')
+echo "DISK_AVAILABLE_GB=${AVAIL_GB:-0}"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "OS_TYPE=macos"
+else
+    echo "OS_TYPE=linux"
+fi
+REMOTEEOF
+    )
+
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            RUNTIME) RUNTIME="${BASH_REMATCH[2]}" ;;
+            COMPOSE_AVAILABLE) COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            REPO_PATH_EXISTS) REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_EXISTS) DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
+            DISK_AVAILABLE_GB) DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
+            OS_TYPE) OS_TYPE="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$preflight_output"
+
+    if [[ -z "${RUNTIME:-}" ]]; then
+        log_error "No container runtime found on $SSH_HOST. Install podman or docker."
+        exit 1
+    fi
+    if [[ "$RUNTIME" == "podman" ]]; then
+        COMPOSE_CMD="podman compose"
+    else
+        COMPOSE_CMD="docker compose"
+    fi
+    if [[ "${COMPOSE_AVAILABLE:-0}" != "1" ]]; then
+        log_error "Compose not available on $SSH_HOST. Install docker-compose or podman-compose."
+        exit 1
+    fi
+    if [[ "${REPO_PATH_EXISTS:-0}" != "1" ]]; then
+        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST."
+        exit 1
+    fi
+    if [[ "${DEVCONTAINER_EXISTS:-0}" != "1" ]]; then
+        log_error "No .devcontainer/ found in $REMOTE_PATH. Is this a devcontainer-enabled project?"
+        exit 1
+    fi
+    if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
+        log_warning "Low disk space on $SSH_HOST (${DISK_AVAILABLE_GB:-0}GB). At least 2GB recommended."
+    fi
+    if [[ "${OS_TYPE:-}" == "macos" ]]; then
+        log_warning "Remote host is macOS. Devcontainer support may be limited."
+    fi
+}
+
+remote_compose_up() {
+    local ps_output state health
+    # shellcheck disable=SC2029
+    ps_output=$(ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD ps --format json 2>/dev/null" || true)
+    state=$(echo "$ps_output" | grep -o '"State":"[^"]*"' | head -1 | cut -d'"' -f4)
+    health=$(echo "$ps_output" | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+    if [[ "$state" == "running" && "${health:-}" == "healthy" ]]; then
+        log_success "Devcontainer already running on $SSH_HOST. Opening..."
+    else
+        log_info "Starting devcontainer on $SSH_HOST..."
+        # shellcheck disable=SC2029
+        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
+        # Health poll (simplified: assume success for now)
+        sleep 2
+    fi
+}
+
+open_editor() {
+    local container_workspace uri
+    # Read workspaceFolder from devcontainer.json on remote host
+    # shellcheck disable=SC2029
+    container_workspace=$(ssh "$SSH_HOST" \
+        "grep -o '\"workspaceFolder\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' \
+         ${REMOTE_PATH}/.devcontainer/devcontainer.json 2>/dev/null" \
+        | sed 's/.*: *"//;s/"//' || echo "/workspace")
+
+    # Default to /workspace if workspaceFolder not found
+    container_workspace="${container_workspace:-/workspace}"
+
+    # Build URI using Python helper
+    uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
+        "$REMOTE_PATH" \
+        "$SSH_HOST" \
+        "$container_workspace")
+
+    "$EDITOR_CLI" --folder-uri "$uri"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+main() {
+    parse_args "$@"
+    detect_editor_cli
+    check_ssh
+    remote_preflight
+    remote_compose_up
+    open_editor
+}
+
+main "$@"

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -6,14 +6,19 @@
 # Handles SSH connectivity, pre-flight checks, container state detection,
 # and compose lifecycle. URI construction delegated to Python helper.
 #
+# When no :<path> is given, derives the remote path from the local repo name
+# (~/repo-name). If the repo doesn't exist on the remote, clones it. If
+# .devcontainer/ is missing, runs init-workspace via the container image.
+#
 # USAGE:
-#   ./scripts/devc-remote.sh <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh [--repo <url>] <ssh-host>[:<remote-path>]
 #   ./scripts/devc-remote.sh --help
 #
 # Examples:
 #   ./scripts/devc-remote.sh myserver
 #   ./scripts/devc-remote.sh user@host:/opt/projects/myrepo
 #   ./scripts/devc-remote.sh myserver:/home/user/repo
+#   ./scripts/devc-remote.sh --repo git@github.com:org/repo.git myserver
 #
 # Part of #70. See issue #152 for design.
 ###############################################################################
@@ -61,12 +66,22 @@ show_help() {
 
 parse_args() {
     SSH_HOST=""
-    REMOTE_PATH="~"
+    REMOTE_PATH=""
+    REPO_URL=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --help|-h)
                 show_help
+                ;;
+            --repo)
+                shift
+                REPO_URL="${1:-}"
+                if [[ -z "$REPO_URL" ]]; then
+                    log_error "--repo requires a URL argument"
+                    exit 1
+                fi
+                shift
                 ;;
             -*)
                 log_error "Unknown option: $1"
@@ -84,8 +99,6 @@ parse_args() {
                     REMOTE_PATH="${BASH_REMATCH[2]}"
                 else
                     SSH_HOST="$1"
-                    # Default to ~ (expanded by remote shell) if no path specified
-                    REMOTE_PATH="~"
                 fi
                 shift
                 ;;
@@ -96,6 +109,25 @@ parse_args() {
         log_error "Missing required argument: <ssh-host>[:<remote-path>]"
         echo "Use --help for usage information"
         exit 1
+    fi
+
+    # Auto-derive REMOTE_PATH from local repo name when not explicitly given
+    if [[ -z "$REMOTE_PATH" ]]; then
+        local local_repo_name
+        local_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
+        if [[ -n "$local_repo_name" ]]; then
+            # Tilde is intentional; expanded by the remote shell
+            # shellcheck disable=SC2088
+            REMOTE_PATH="~/${local_repo_name}"
+        else
+            log_error "No remote path given and not inside a git repository."
+            exit 1
+        fi
+    fi
+
+    # Auto-derive REPO_URL from local git remote when not explicitly given
+    if [[ -z "$REPO_URL" ]]; then
+        REPO_URL=$(git remote get-url origin 2>/dev/null || echo "")
     fi
 }
 
@@ -137,6 +169,11 @@ if (command -v podman &>/dev/null && podman compose version &>/dev/null) || \
 else
     echo "COMPOSE_AVAILABLE=0"
 fi
+if command -v git &>/dev/null; then
+    echo "GIT_AVAILABLE=1"
+else
+    echo "GIT_AVAILABLE=0"
+fi
 if [ -d "$REPO_PATH" ]; then
     echo "REPO_PATH_EXISTS=1"
 else
@@ -162,6 +199,7 @@ REMOTEEOF
         case "${BASH_REMATCH[1]}" in
             RUNTIME) RUNTIME="${BASH_REMATCH[2]}" ;;
             COMPOSE_AVAILABLE) COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            GIT_AVAILABLE) GIT_AVAILABLE="${BASH_REMATCH[2]}" ;;
             REPO_PATH_EXISTS) REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
             DEVCONTAINER_EXISTS) DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
             DISK_AVAILABLE_GB) DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
@@ -169,6 +207,7 @@ REMOTEEOF
         esac
     done <<< "$preflight_output"
 
+    # Hard errors: runtime and compose are always required
     if [[ -z "${RUNTIME:-}" ]]; then
         log_error "No container runtime found on $SSH_HOST. Install podman or docker."
         exit 1
@@ -182,20 +221,58 @@ REMOTEEOF
         log_error "Compose not available on $SSH_HOST. Install docker-compose or podman-compose."
         exit 1
     fi
-    if [[ "${REPO_PATH_EXISTS:-0}" != "1" ]]; then
-        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST."
-        exit 1
-    fi
-    if [[ "${DEVCONTAINER_EXISTS:-0}" != "1" ]]; then
-        log_error "No .devcontainer/ found in $REMOTE_PATH. Is this a devcontainer-enabled project?"
-        exit 1
-    fi
+
+    # Soft checks: repo and devcontainer are handled by clone/init steps
     if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
         log_warning "Low disk space on $SSH_HOST (${DISK_AVAILABLE_GB:-0}GB). At least 2GB recommended."
     fi
     if [[ "${OS_TYPE:-}" == "macos" ]]; then
         log_warning "Remote host is macOS. Devcontainer support may be limited."
     fi
+}
+
+remote_clone_if_needed() {
+    [[ "${REPO_PATH_EXISTS:-0}" == "1" ]] && return 0
+
+    if [[ -z "$REPO_URL" ]]; then
+        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST and no repo URL available."
+        log_error "Provide a path (host:path) or use --repo <url>."
+        exit 1
+    fi
+    if [[ "${GIT_AVAILABLE:-0}" != "1" ]]; then
+        log_error "git not found on $SSH_HOST. Install git to enable auto-clone."
+        exit 1
+    fi
+
+    log_info "Cloning $REPO_URL to $REMOTE_PATH on $SSH_HOST..."
+    # shellcheck disable=SC2029
+    if ! ssh "$SSH_HOST" "git clone '$REPO_URL' '$REMOTE_PATH'"; then
+        log_error "git clone failed on $SSH_HOST."
+        exit 1
+    fi
+    log_success "Repository cloned to $REMOTE_PATH"
+    REPO_PATH_EXISTS=1
+}
+
+remote_init_if_needed() {
+    [[ "${DEVCONTAINER_EXISTS:-0}" == "1" ]] && return 0
+
+    local project_name
+    project_name=$(basename "$REMOTE_PATH" | tr '[:upper:]' '[:lower:]' | sed 's/[ -]/_/g; s/[^a-z0-9_]/_/g')
+
+    log_info "No .devcontainer/ found. Running init-workspace for '$project_name'..."
+    # shellcheck disable=SC2029
+    if ! ssh "$SSH_HOST" "$RUNTIME run --rm \
+        -e SHORT_NAME='$project_name' \
+        -e ORG_NAME='vigOS' \
+        -v '$REMOTE_PATH:/workspace' \
+        ghcr.io/vig-os/devcontainer:latest \
+        /root/assets/init-workspace.sh --no-prompts --force"; then
+        log_error "init-workspace failed on $SSH_HOST."
+        exit 1
+    fi
+    log_success "Workspace initialized"
+    DEVCONTAINER_EXISTS=1
 }
 
 remote_compose_up() {
@@ -210,8 +287,11 @@ remote_compose_up() {
     else
         log_info "Starting devcontainer on $SSH_HOST..."
         # shellcheck disable=SC2029
-        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
-        # Health poll (simplified: assume success for now)
+        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+            log_error "Failed to start devcontainer on $SSH_HOST."
+            log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH && $COMPOSE_CMD logs\"' for details."
+            exit 1
+        fi
         sleep 2
     fi
 }
@@ -229,12 +309,18 @@ open_editor() {
     container_workspace="${container_workspace:-/workspace}"
 
     # Build URI using Python helper
-    uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
+    if ! uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
         "$REMOTE_PATH" \
         "$SSH_HOST" \
-        "$container_workspace")
+        "$container_workspace"); then
+        log_error "Failed to build editor URI. Is devc_remote_uri.py present in $SCRIPT_DIR?"
+        exit 1
+    fi
 
-    "$EDITOR_CLI" --folder-uri "$uri"
+    if ! "$EDITOR_CLI" --folder-uri "$uri"; then
+        log_error "Failed to open $EDITOR_CLI. URI: $uri"
+        exit 1
+    fi
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -246,6 +332,8 @@ main() {
     detect_editor_cli
     check_ssh
     remote_preflight
+    remote_clone_if_needed
+    remote_init_if_needed
     remote_compose_up
     open_editor
 }

--- a/scripts/devc_remote_uri.py
+++ b/scripts/devc_remote_uri.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build Cursor/VS Code nested authority URI for remote devcontainers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def hex_encode(s: str) -> str:
+    """Hex-encode a string (UTF-8)."""
+    return s.encode().hex()
+
+
+def build_uri(
+    workspace_path: str,
+    devcontainer_path: str,
+    ssh_host: str,
+    container_workspace: str,
+) -> str:
+    """Build vscode-remote URI for dev-container over SSH.
+
+    Format: vscode-remote://dev-container+{DC_HEX}@ssh-remote+{SSH_SPEC}/{container_workspace}
+    """
+    if not workspace_path:
+        raise ValueError("workspace_path cannot be empty")
+    if not devcontainer_path:
+        raise ValueError("devcontainer_path cannot be empty")
+    if not ssh_host:
+        raise ValueError("ssh_host cannot be empty")
+    if not container_workspace:
+        raise ValueError("container_workspace cannot be empty")
+    spec = {
+        "settingType": "config",
+        "workspacePath": workspace_path,
+        "devcontainerPath": devcontainer_path,
+    }
+    dc_hex = hex_encode(json.dumps(spec, separators=(",", ":")))
+    path = "/" + container_workspace.lstrip("/")
+    return f"vscode-remote://dev-container+{dc_hex}@ssh-remote+{ssh_host}{path}"
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Build Cursor/VS Code URI for remote devcontainers"
+    )
+    parser.add_argument("workspace_path", help="Workspace path on the remote host")
+    parser.add_argument("ssh_host", help="SSH host from ~/.ssh/config")
+    parser.add_argument("container_workspace", help="Container workspace path")
+    parser.add_argument(
+        "--devcontainer-path",
+        help="Path to devcontainer.json (default: {workspace_path}/.devcontainer/devcontainer.json)",
+    )
+    args = parser.parse_args()
+
+    devcontainer_path = args.devcontainer_path or (
+        f"{args.workspace_path.rstrip('/')}/.devcontainer/devcontainer.json"
+    )
+    uri = build_uri(
+        workspace_path=args.workspace_path,
+        devcontainer_path=devcontainer_path,
+        ssh_host=args.ssh_host,
+        container_workspace=args.container_workspace,
+    )
+    print(uri)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+###############################################################################
+# setup-labels.sh — Provision GitHub labels from label-taxonomy.toml
+#
+# Reads the canonical label definitions from .github/label-taxonomy.toml and
+# creates or updates them on the target repository.  Idempotent: safe to run
+# repeatedly.
+#
+# USAGE:
+#   ./scripts/setup-labels.sh                  # current repo
+#   ./scripts/setup-labels.sh --repo owner/repo
+#   ./scripts/setup-labels.sh --prune          # also delete unlisted labels
+#   ./scripts/setup-labels.sh --dry-run        # show what would happen
+#
+# REQUIRES: gh (GitHub CLI), authenticated
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAXONOMY_FILE="${SCRIPT_DIR}/../.github/label-taxonomy.toml"
+
+REPO_ARGS=()
+PRUNE=false
+DRY_RUN=false
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            REPO_ARGS=(--repo "$2")
+            shift 2
+            ;;
+        --prune)
+            PRUNE=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '/^###############################################################################$/,/^###############################################################################$/p' "$0" | sed '1d;$d'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$TAXONOMY_FILE" ]]; then
+    echo "Error: taxonomy file not found: $TAXONOMY_FILE" >&2
+    exit 1
+fi
+
+# ── Parse TOML ───────────────────────────────────────────────────────────────
+# Minimal parser: extracts name/description/color from [[labels]] blocks.
+
+NAMES=()
+DESCRIPTIONS=()
+COLORS=()
+
+current_name=""
+current_desc=""
+current_color=""
+
+flush_label() {
+    if [[ -n "$current_name" ]]; then
+        NAMES+=("$current_name")
+        DESCRIPTIONS+=("$current_desc")
+        COLORS+=("$current_color")
+    fi
+    current_name=""
+    current_desc=""
+    current_color=""
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+
+    if [[ "$line" =~ ^\[\[labels\]\] ]]; then
+        flush_label
+        continue
+    fi
+
+    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_name="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^description[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_desc="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^color[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_color="${BASH_REMATCH[1]}"
+    fi
+done < "$TAXONOMY_FILE"
+flush_label
+
+echo "Taxonomy: ${#NAMES[@]} labels defined in $(basename "$TAXONOMY_FILE")"
+
+# ── Fetch existing labels ────────────────────────────────────────────────────
+
+mapfile -t EXISTING < <(gh label list "${REPO_ARGS[@]}" --limit 100 --json name --jq '.[].name')
+
+echo "Remote:   ${#EXISTING[@]} labels on repo"
+echo ""
+
+# ── Create / update ──────────────────────────────────────────────────────────
+
+for i in "${!NAMES[@]}"; do
+    name="${NAMES[$i]}"
+    desc="${DESCRIPTIONS[$i]}"
+    color="${COLORS[$i]}"
+
+    found=false
+    for existing in "${EXISTING[@]}"; do
+        if [[ "$existing" == "$name" ]]; then
+            found=true
+            break
+        fi
+    done
+
+    if $found; then
+        if $DRY_RUN; then
+            echo "[DRY-RUN]  update  $name"
+        else
+            gh label edit "$name" --description "$desc" --color "$color" "${REPO_ARGS[@]}"
+            echo "[UPDATED]  $name"
+        fi
+    else
+        if $DRY_RUN; then
+            echo "[DRY-RUN]  create  $name"
+        else
+            gh label create "$name" --description "$desc" --color "$color" "${REPO_ARGS[@]}"
+            echo "[CREATED]  $name"
+        fi
+    fi
+done
+
+# ── Prune ────────────────────────────────────────────────────────────────────
+
+if $PRUNE; then
+    for existing in "${EXISTING[@]}"; do
+        is_canonical=false
+        for name in "${NAMES[@]}"; do
+            if [[ "$existing" == "$name" ]]; then
+                is_canonical=true
+                break
+            fi
+        done
+
+        if ! $is_canonical; then
+            if $DRY_RUN; then
+                echo "[DRY-RUN]  delete  $existing"
+            else
+                gh label delete "$existing" --yes "${REPO_ARGS[@]}"
+                echo "[DELETED]  $existing"
+            fi
+        fi
+    done
+fi
+
+echo ""
+echo "Done."

--- a/scripts/spike_chunk_hash.py
+++ b/scripts/spike_chunk_hash.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Spike #24 — Inline SHA-256 hashing during h5py chunked writes.
+
+Tests two approaches:
+  1. write_direct_chunk(): write pre-serialised chunks with known boundaries.
+  2. Standard chunked writes with pre-hash of each chunk slice.
+
+Measures SHA-256 overhead on a realistic chunk size (1 slice of 512×512 float32 ≈ 1 MB).
+
+Usage:
+    python scripts/spike_chunk_hash.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+ROWS = 512
+COLS = 512
+NUM_SLICES = 64
+DTYPE = np.float32
+CHUNK_SHAPE = (1, ROWS, COLS)  # 1 slice per chunk ≈ 1 MiB
+DATASET_SHAPE = (NUM_SLICES, ROWS, COLS)
+
+
+@dataclass
+class BenchResult:
+    label: str
+    write_s: float = 0.0
+    hash_s: float = 0.0
+    total_s: float = 0.0
+    chunk_hashes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Approach 1: write_direct_chunk() with inline SHA-256
+# ---------------------------------------------------------------------------
+def approach_write_direct_chunk(path: Path) -> BenchResult:
+    """Write raw (uncompressed) chunks via write_direct_chunk and hash each."""
+    result = BenchResult(label="write_direct_chunk")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+            raw = chunk.tobytes()
+
+            t_h0 = time.perf_counter()
+            digest = hashlib.sha256(raw).hexdigest()
+            t_h1 = time.perf_counter()
+            result.hash_s += t_h1 - t_h0
+            result.chunk_hashes.append(digest)
+
+            t_w0 = time.perf_counter()
+            ds.id.write_direct_chunk((i, 0, 0), raw)
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Approach 2: standard chunked write with pre-hash of each slice
+# ---------------------------------------------------------------------------
+def approach_standard_chunked(path: Path) -> BenchResult:
+    """Write via normal slice assignment, hashing each slice before write."""
+    result = BenchResult(label="standard_chunked (pre-hash)")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+
+            t_h0 = time.perf_counter()
+            digest = hashlib.sha256(chunk.tobytes()).hexdigest()
+            t_h1 = time.perf_counter()
+            result.hash_s += t_h1 - t_h0
+            result.chunk_hashes.append(digest)
+
+            t_w0 = time.perf_counter()
+            ds[i : i + 1, :, :] = chunk
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Baseline: standard chunked write, NO hashing
+# ---------------------------------------------------------------------------
+def baseline_no_hash(path: Path) -> BenchResult:
+    """Write via normal slice assignment, no hashing (baseline)."""
+    result = BenchResult(label="standard_chunked (no hash)")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+
+            t_w0 = time.perf_counter()
+            ds[i : i + 1, :, :] = chunk
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Verification: read back and re-hash to confirm data integrity
+# ---------------------------------------------------------------------------
+def verify_hashes(path: Path, expected: list[str]) -> bool:
+    """Re-read each chunk and verify SHA-256 matches."""
+    with h5py.File(path, "r") as f:
+        ds = f["data"]
+        for i, expected_hash in enumerate(expected):
+            raw = ds[i : i + 1, :, :].tobytes()
+            actual = hashlib.sha256(raw).hexdigest()
+            if actual != expected_hash:
+                print(f"  MISMATCH at slice {i}: {actual} != {expected_hash}")
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+def print_report(results: list[BenchResult]) -> None:
+    chunk_bytes = int(np.prod(CHUNK_SHAPE)) * np.dtype(DTYPE).itemsize
+    total_bytes = chunk_bytes * NUM_SLICES
+    total_mib = total_bytes / (1024 * 1024)
+
+    print("=" * 72)
+    print("Spike #24 — Inline SHA-256 hashing during h5py chunked writes")
+    print(f"  Shape: {DATASET_SHAPE}  dtype={DTYPE.__name__}")
+    print(f"  Chunk: {CHUNK_SHAPE}  ({chunk_bytes / 1024:.0f} KiB per chunk)")
+    print(f"  Total: {NUM_SLICES} chunks, {total_mib:.1f} MiB")
+    print("=" * 72)
+
+    for r in results:
+        hash_pct = (r.hash_s / r.total_s * 100) if r.total_s > 0 else 0
+        throughput = total_mib / r.total_s if r.total_s > 0 else 0
+        print(f"\n  {r.label}")
+        print(f"    write:      {r.write_s * 1000:8.1f} ms")
+        print(f"    SHA-256:    {r.hash_s * 1000:8.1f} ms  ({hash_pct:.1f}% of total)")
+        print(f"    total:      {r.total_s * 1000:8.1f} ms")
+        print(f"    throughput: {throughput:8.1f} MiB/s")
+
+    print("\n" + "=" * 72)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    results: list[BenchResult] = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        # Approach 1: write_direct_chunk
+        p1 = tmp / "direct_chunk.h5"
+        r1 = approach_write_direct_chunk(p1)
+        results.append(r1)
+
+        # Approach 2: standard chunked with pre-hash
+        p2 = tmp / "standard_chunked.h5"
+        r2 = approach_standard_chunked(p2)
+        results.append(r2)
+
+        # Baseline: no hash
+        p3 = tmp / "baseline.h5"
+        r3 = baseline_no_hash(p3)
+        results.append(r3)
+
+        print_report(results)
+
+        # Verify data integrity for hashed approaches
+        print("\nVerification (read-back SHA-256 check):")
+        # write_direct_chunk writes raw bytes; read-back via h5py slice
+        # should yield identical bytes for uncompressed data.
+        ok1 = verify_hashes(p1, r1.chunk_hashes)
+        print(f"  write_direct_chunk:       {'PASS' if ok1 else 'FAIL'}")
+
+        ok2 = verify_hashes(p2, r2.chunk_hashes)
+        print(f"  standard_chunked:         {'PASS' if ok2 else 'FAIL'}")
+
+        # Both approaches used same RNG seed — hashes must match
+        hashes_match = r1.chunk_hashes == r2.chunk_hashes
+        print(f"  cross-approach hash match: {'PASS' if hashes_match else 'FAIL'}")
+
+    print("\nConclusion:")
+    hash_overhead_pct = (r2.hash_s / r3.total_s * 100) if r3.total_s > 0 else 0
+    print(f"  SHA-256 adds ~{hash_overhead_pct:.1f}% overhead vs no-hash baseline.")
+    print("  write_direct_chunk gives explicit control over chunk boundaries.")
+    print("  Standard chunked write + pre-hash is simpler and equally correct")
+    print("  for uncompressed data when chunk shape == slice shape.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -1,0 +1,9 @@
+"""fd5 command-line interface."""
+
+import click
+
+
+@click.group()
+@click.version_option(package_name="fd5")
+def cli() -> None:
+    """fd5 – Fusion Data Format 5 toolkit."""

--- a/src/fd5/h5io.py
+++ b/src/fd5/h5io.py
@@ -1,0 +1,105 @@
+"""fd5.h5io — lossless round-trip between Python dicts and HDF5 groups/attrs.
+
+Type mapping follows white-paper.md § Implementation Notes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+def dict_to_h5(group: h5py.Group, d: dict[str, Any]) -> None:
+    """Write a Python dict as HDF5 attributes and sub-groups.
+
+    Keys are written in sorted order for deterministic layout.
+    ``None`` values are skipped (absence encodes None).
+    """
+    for key in sorted(d.keys()):
+        value = d[key]
+        if value is None:
+            continue
+        _write_value(group, key, value)
+
+
+def h5_to_dict(group: h5py.Group) -> dict[str, Any]:
+    """Read HDF5 attrs and sub-groups back to a Python dict.
+
+    Datasets are never read — only attributes and groups.
+    """
+    result: dict[str, Any] = {}
+    for key in sorted(group.attrs.keys()):
+        result[key] = _read_attr(group.attrs[key])
+    for key in sorted(group.keys()):
+        item = group[key]
+        if isinstance(item, h5py.Group):
+            result[key] = h5_to_dict(item)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_value(group: h5py.Group, key: str, value: Any) -> None:
+    if isinstance(value, dict):
+        sub = group.create_group(key)
+        dict_to_h5(sub, value)
+    elif isinstance(value, bool):
+        group.attrs[key] = np.bool_(value)
+    elif isinstance(value, int):
+        group.attrs[key] = np.int64(value)
+    elif isinstance(value, float):
+        group.attrs[key] = np.float64(value)
+    elif isinstance(value, str):
+        group.attrs[key] = value
+    elif isinstance(value, list):
+        _write_list(group, key, value)
+    else:
+        raise TypeError(f"Unsupported type {type(value).__name__!r} for key {key!r}")
+
+
+def _write_list(group: h5py.Group, key: str, lst: list[Any]) -> None:
+    if len(lst) == 0:
+        group.attrs.create(key, data=np.array([], dtype=np.float64))
+        return
+
+    first = lst[0]
+    if isinstance(first, bool):
+        group.attrs[key] = np.array(lst, dtype=np.bool_)
+    elif isinstance(first, (int, float)):
+        group.attrs[key] = np.array(lst)
+    elif isinstance(first, str):
+        dt = h5py.special_dtype(vlen=str)
+        group.attrs.create(key, data=lst, dtype=dt)
+    else:
+        raise TypeError(
+            f"Unsupported type {type(first).__name__!r} in list for key {key!r}"
+        )
+
+
+def _read_attr(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, np.ndarray):
+        return _read_array(value)
+    return value
+
+
+def _read_array(arr: np.ndarray) -> list[Any]:
+    if arr.dtype.kind in ("U", "S", "O"):
+        return [str(v) for v in arr]
+    if arr.dtype == np.bool_:
+        return [bool(v) for v in arr]
+    return arr.tolist()

--- a/src/fd5/naming.py
+++ b/src/fd5/naming.py
@@ -1,0 +1,44 @@
+"""Filename generation following the fd5 naming convention.
+
+See white-paper.md § File Naming Convention.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+_SHA256_PREFIX = "sha256:"
+_ID_HEX_LENGTH = 8
+_EXTENSION = ".h5"
+_TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
+
+def generate_filename(
+    product: str,
+    id_hash: str,
+    timestamp: datetime | None,
+    descriptors: list[str],
+) -> str:
+    """Generate an fd5-compliant filename.
+
+    Format: ``YYYY-MM-DD_HH-MM-SS_<product>-<id>_<descriptors>.h5``
+
+    When *timestamp* is ``None`` the datetime prefix is omitted.
+    The *id_hash* is truncated to the first 8 hex characters; a
+    ``sha256:`` prefix is stripped automatically if present.
+    """
+    short_id = _truncate_id(id_hash)
+    parts: list[str] = []
+
+    if timestamp is not None:
+        parts.append(timestamp.strftime(_TIMESTAMP_FORMAT))
+
+    parts.append(f"{product}-{short_id}")
+    parts.extend(descriptors)
+
+    return "_".join(parts) + _EXTENSION
+
+
+def _truncate_id(id_hash: str) -> str:
+    raw = id_hash.removeprefix(_SHA256_PREFIX)
+    return raw[:_ID_HEX_LENGTH]

--- a/src/fd5/registry.py
+++ b/src/fd5/registry.py
@@ -1,0 +1,83 @@
+"""Product schema registry with entry-point discovery.
+
+Discovers product schemas from ``importlib.metadata`` entry points
+(group ``fd5.schemas``), allows lookup by product-type string, and
+provides a ``register_schema`` escape-hatch for testing.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProductSchema(Protocol):
+    """Structural interface every product schema must satisfy."""
+
+    product_type: str
+    schema_version: str
+
+    def json_schema(self) -> dict[str, Any]: ...
+    def required_root_attrs(self) -> dict[str, Any]: ...
+    def write(self, target: Any, data: Any) -> None: ...
+    def id_inputs(self) -> list[str]: ...
+
+
+_registry: dict[str, ProductSchema] = {}
+_ep_loaded: bool = False
+
+_EP_GROUP = "fd5.schemas"
+
+
+def _load_entry_points() -> dict[str, ProductSchema]:
+    """Load all entry points in the ``fd5.schemas`` group.
+
+    Each entry point must be a callable returning a ``ProductSchema``
+    instance.  The entry-point *name* is used as the product-type key.
+    """
+    schemas: dict[str, ProductSchema] = {}
+    for ep in importlib.metadata.entry_points(group=_EP_GROUP):
+        factory = ep.load()
+        schemas[ep.name] = factory()
+    return schemas
+
+
+def _load_and_merge() -> None:
+    """Merge entry-point schemas into the registry (once)."""
+    global _ep_loaded  # noqa: PLW0603
+    ep_schemas = _load_entry_points()
+    for name, schema in ep_schemas.items():
+        _registry.setdefault(name, schema)
+    _ep_loaded = True
+
+
+def _ensure_loaded() -> None:
+    if not _ep_loaded:
+        _load_and_merge()
+
+
+def register_schema(product_type: str, schema: ProductSchema) -> None:
+    """Register *schema* under *product_type* (overwrites existing)."""
+    _registry[product_type] = schema
+
+
+def get_schema(product_type: str) -> ProductSchema:
+    """Return the schema registered for *product_type*.
+
+    Raises:
+        ValueError: If no schema is registered for *product_type*.
+    """
+    _ensure_loaded()
+    try:
+        return _registry[product_type]
+    except KeyError:
+        raise ValueError(
+            f"No schema registered for product type {product_type!r}"
+        ) from None
+
+
+def list_schemas() -> list[str]:
+    """Return all registered product-type strings."""
+    _ensure_loaded()
+    return list(_registry)

--- a/src/fd5/template_project/__init__.py
+++ b/src/fd5/template_project/__init__.py
@@ -1,3 +1,0 @@
-"""fd5 - A new Python project."""
-
-__version__ = "0.1.0"

--- a/src/fd5/units.py
+++ b/src/fd5/units.py
@@ -1,0 +1,62 @@
+"""Physical units convention helpers.
+
+Implements the value/units/unitSI sub-group pattern for attributes and
+the units/unitSI attribute pattern for datasets as defined in the fd5
+white paper (see white-paper.md § Units convention).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import h5py
+    import numpy as np
+
+type Scalar = int | float
+type QuantityValue = Scalar | list[Scalar] | np.ndarray
+
+
+def write_quantity(
+    group: h5py.Group,
+    name: str,
+    value: QuantityValue,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Create a sub-group with ``value``, ``units``, and ``unitSI`` attrs.
+
+    If a sub-group with *name* already exists it is replaced.
+    """
+    if name in group:
+        del group[name]
+    sub = group.create_group(name)
+    sub.attrs["value"] = value
+    sub.attrs["units"] = units
+    sub.attrs["unitSI"] = unit_si
+
+
+def read_quantity(
+    group: h5py.Group,
+    name: str,
+) -> tuple[QuantityValue, str, float]:
+    """Read a physical quantity sub-group.
+
+    Returns:
+        ``(value, units, unit_si)`` tuple.
+
+    Raises:
+        KeyError: If *name* does not exist in *group*.
+    """
+    sub = group[name]
+    return sub.attrs["value"], sub.attrs["units"], sub.attrs["unitSI"]
+
+
+def set_dataset_units(
+    dataset: h5py.Dataset,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Set ``units`` and ``unitSI`` attributes on a dataset."""
+    dataset.attrs["units"] = units
+    dataset.attrs["unitSI"] = unit_si

--- a/tests/test_h5io.py
+++ b/tests/test_h5io.py
@@ -1,0 +1,294 @@
+"""Tests for fd5.h5io — dict_to_h5 and h5_to_dict round-trip helpers."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.h5io import dict_to_h5, h5_to_dict
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def h5group(tmp_path):
+    """Yield a writable HDF5 group, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — scalar types
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Scalars:
+    def test_str(self, h5group):
+        dict_to_h5(h5group, {"name": "Alice"})
+        assert h5group.attrs["name"] == "Alice"
+
+    def test_int(self, h5group):
+        dict_to_h5(h5group, {"count": 42})
+        assert h5group.attrs["count"] == 42
+
+    def test_float(self, h5group):
+        dict_to_h5(h5group, {"ratio": 3.14})
+        assert h5group.attrs["ratio"] == pytest.approx(3.14)
+
+    def test_bool_true(self, h5group):
+        dict_to_h5(h5group, {"flag": True})
+        assert h5group.attrs["flag"] is np.True_
+
+    def test_bool_false(self, h5group):
+        dict_to_h5(h5group, {"flag": False})
+        assert h5group.attrs["flag"] is np.False_
+
+    def test_none_skipped(self, h5group):
+        dict_to_h5(h5group, {"missing": None})
+        assert "missing" not in h5group.attrs
+
+    def test_none_mixed_with_values(self, h5group):
+        dict_to_h5(h5group, {"a": 1, "b": None, "c": "hello"})
+        assert "a" in h5group.attrs
+        assert "b" not in h5group.attrs
+        assert "c" in h5group.attrs
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — nested dicts (sub-groups)
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Nested:
+    def test_nested_dict_creates_subgroup(self, h5group):
+        dict_to_h5(h5group, {"sub": {"x": 1}})
+        assert "sub" in h5group
+        assert h5group["sub"].attrs["x"] == 1
+
+    def test_deeply_nested(self, h5group):
+        dict_to_h5(h5group, {"a": {"b": {"c": 99}}})
+        assert h5group["a"]["b"].attrs["c"] == 99
+
+    def test_empty_dict_creates_empty_group(self, h5group):
+        dict_to_h5(h5group, {"empty": {}})
+        assert "empty" in h5group
+        assert len(h5group["empty"].attrs) == 0
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — sorted keys
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5SortedKeys:
+    def test_keys_written_in_sorted_order(self, h5group):
+        dict_to_h5(h5group, {"z": 1, "a": 2, "m": 3})
+        assert list(h5group.attrs.keys()) == ["a", "m", "z"]
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — list types
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Lists:
+    def test_list_int(self, h5group):
+        dict_to_h5(h5group, {"vals": [1, 2, 3]})
+        result = h5group.attrs["vals"]
+        np.testing.assert_array_equal(result, [1, 2, 3])
+
+    def test_list_float(self, h5group):
+        dict_to_h5(h5group, {"vals": [1.1, 2.2, 3.3]})
+        result = h5group.attrs["vals"]
+        np.testing.assert_array_almost_equal(result, [1.1, 2.2, 3.3])
+
+    def test_list_str(self, h5group):
+        dict_to_h5(h5group, {"tags": ["a", "b", "c"]})
+        result = list(h5group.attrs["tags"])
+        assert result == ["a", "b", "c"]
+
+    def test_list_bool(self, h5group):
+        dict_to_h5(h5group, {"flags": [True, False, True]})
+        result = h5group.attrs["flags"]
+        np.testing.assert_array_equal(result, [True, False, True])
+        assert result.dtype == np.bool_
+
+    def test_empty_list(self, h5group):
+        dict_to_h5(h5group, {"empty": []})
+        result = h5group.attrs["empty"]
+        assert len(result) == 0
+
+    def test_list_mixed_numeric(self, h5group):
+        dict_to_h5(h5group, {"mixed": [1, 2.5, 3]})
+        result = h5group.attrs["mixed"]
+        np.testing.assert_array_almost_equal(result, [1, 2.5, 3])
+
+
+# ---------------------------------------------------------------------------
+# h5_to_dict — reading attrs
+# ---------------------------------------------------------------------------
+
+
+class TestH5ToDict:
+    def test_read_str(self, h5group):
+        h5group.attrs["name"] = "Alice"
+        result = h5_to_dict(h5group)
+        assert result == {"name": "Alice"}
+        assert isinstance(result["name"], str)
+
+    def test_read_int(self, h5group):
+        h5group.attrs["count"] = np.int64(42)
+        result = h5_to_dict(h5group)
+        assert result == {"count": 42}
+        assert isinstance(result["count"], int)
+
+    def test_read_float(self, h5group):
+        h5group.attrs["ratio"] = np.float64(3.14)
+        result = h5_to_dict(h5group)
+        assert result["ratio"] == pytest.approx(3.14)
+        assert isinstance(result["ratio"], float)
+
+    def test_read_bool(self, h5group):
+        h5group.attrs["flag"] = np.bool_(True)
+        result = h5_to_dict(h5group)
+        assert result == {"flag": True}
+        assert isinstance(result["flag"], bool)
+
+    def test_read_subgroup(self, h5group):
+        sub = h5group.create_group("sub")
+        sub.attrs["x"] = np.int64(1)
+        result = h5_to_dict(h5group)
+        assert result == {"sub": {"x": 1}}
+
+    def test_empty_group(self, h5group):
+        result = h5_to_dict(h5group)
+        assert result == {}
+
+    def test_read_numeric_array(self, h5group):
+        h5group.attrs["vals"] = np.array([1, 2, 3], dtype=np.int64)
+        result = h5_to_dict(h5group)
+        assert result["vals"] == [1, 2, 3]
+        assert isinstance(result["vals"], list)
+
+    def test_read_float_array(self, h5group):
+        h5group.attrs["vals"] = np.array([1.1, 2.2], dtype=np.float64)
+        result = h5_to_dict(h5group)
+        assert result["vals"] == pytest.approx([1.1, 2.2])
+
+    def test_read_string_array(self, h5group):
+        dt = h5py.special_dtype(vlen=str)
+        h5group.attrs.create("tags", data=["a", "b"], dtype=dt)
+        result = h5_to_dict(h5group)
+        assert result["tags"] == ["a", "b"]
+
+    def test_read_bool_array(self, h5group):
+        h5group.attrs["flags"] = np.array([True, False], dtype=np.bool_)
+        result = h5_to_dict(h5group)
+        assert result["flags"] == [True, False]
+        assert all(isinstance(v, bool) for v in result["flags"])
+
+    def test_datasets_skipped(self, h5group):
+        h5group.attrs["meta"] = "value"
+        h5group.create_dataset("volume", data=np.zeros((10, 10)))
+        result = h5_to_dict(h5group)
+        assert "volume" not in result
+        assert result == {"meta": "value"}
+
+    def test_datasets_in_subgroup_skipped(self, h5group):
+        sub = h5group.create_group("sub")
+        sub.attrs["x"] = np.int64(1)
+        sub.create_dataset("data", data=np.zeros(5))
+        result = h5_to_dict(h5group)
+        assert "data" not in result["sub"]
+        assert result == {"sub": {"x": 1}}
+
+    def test_absent_attr_means_missing_key(self, h5group):
+        h5group.attrs["present"] = "yes"
+        result = h5_to_dict(h5group)
+        assert "present" in result
+        assert "absent" not in result
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_complex_nested(self, h5group):
+        original = {
+            "acquisition": {
+                "date": "2026-01-15",
+                "duration_s": 300.5,
+                "num_frames": 100,
+                "is_gated": True,
+            },
+            "instrument": {
+                "model": "Scanner-X",
+                "calibration": {
+                    "date": "2025-12-01",
+                    "version": 3,
+                },
+            },
+            "processing": {
+                "algorithm": "osem",
+                "iterations": 4,
+                "subsets": 21,
+                "use_tof": False,
+                "voxel_size": [2.0, 2.0, 2.0],
+            },
+            "tags": ["clinical", "brain"],
+        }
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == original
+
+    def test_round_trip_empty_dict(self, h5group):
+        dict_to_h5(h5group, {})
+        assert h5_to_dict(h5group) == {}
+
+    def test_round_trip_scalars(self, h5group):
+        original = {"a": 1, "b": 2.0, "c": "three", "d": True}
+        dict_to_h5(h5group, original)
+        assert h5_to_dict(h5group) == original
+
+    def test_round_trip_with_none_values(self, h5group):
+        original = {"present": "yes", "absent": None}
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == {"present": "yes"}
+
+    def test_round_trip_list_types(self, h5group):
+        original = {
+            "bools": [True, False, True],
+            "floats": [1.1, 2.2],
+            "ints": [10, 20, 30],
+            "strings": ["x", "y"],
+        }
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == original
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_unsupported_type_raises_typeerror(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"bad": object()})
+
+    def test_unsupported_type_in_nested(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"sub": {"bad": set()}})
+
+    def test_unsupported_list_element_type(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"bad": [object()]})

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,98 @@
+"""Tests for fd5.naming module."""
+
+from datetime import datetime, timezone
+
+
+from fd5.naming import generate_filename
+
+
+class TestGenerateFilename:
+    """Tests for generate_filename."""
+
+    def test_full_filename_with_timestamp(self):
+        ts = datetime(2024, 7, 24, 18, 14, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:87f032f6abcdef1234567890",
+            timestamp=ts,
+            descriptors=["ct", "thorax", "dlir"],
+        )
+        assert result == "2024-07-24_18-14-00_recon-87f032f6_ct_thorax_dlir.h5"
+
+    def test_id_hash_truncated_to_8_hex_chars(self):
+        ts = datetime(2025, 3, 15, 9, 22, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="alignment",
+            id_hash="sha256:c4f2a1b8deadbeef",
+            timestamp=ts,
+            descriptors=["wgs", "sample01", "bwamem2"],
+        )
+        assert (
+            result == "2025-03-15_09-22-00_alignment-c4f2a1b8_wgs_sample01_bwamem2.h5"
+        )
+
+    def test_no_timestamp_omits_datetime_prefix(self):
+        result = generate_filename(
+            product="sim",
+            id_hash="sha256:xyz99999aabbccdd",
+            timestamp=None,
+            descriptors=["pet", "nema", "gate"],
+        )
+        assert result == "sim-xyz99999_pet_nema_gate.h5"
+
+    def test_single_descriptor(self):
+        ts = datetime(2024, 7, 24, 19, 6, 10, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="listmode",
+            id_hash="sha256:def67890aabb1122",
+            timestamp=ts,
+            descriptors=["coinc"],
+        )
+        assert result == "2024-07-24_19-06-10_listmode-def67890_coinc.h5"
+
+    def test_empty_descriptors(self):
+        ts = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd11223344",
+            timestamp=ts,
+            descriptors=[],
+        )
+        assert result == "2024-01-01_00-00-00_recon-aabbccdd.h5"
+
+    def test_calibration_no_timestamp(self):
+        result = generate_filename(
+            product="calibration",
+            id_hash="sha256:11223344aabbccdd",
+            timestamp=None,
+            descriptors=["detector", "energy", "hpge"],
+        )
+        assert result == "calibration-11223344_detector_energy_hpge.h5"
+
+    def test_id_hash_without_prefix(self):
+        ts = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="features",
+            id_hash="a1b2c3d4e5f6a7b8",
+            timestamp=ts,
+            descriptors=["satellite", "band4", "ndvi"],
+        )
+        assert result == "2025-06-01_12-00-00_features-a1b2c3d4_satellite_band4_ndvi.h5"
+
+    def test_return_type_is_str(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=None,
+            descriptors=[],
+        )
+        assert isinstance(result, str)
+
+    def test_extension_is_h5(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=None,
+            descriptors=["x"],
+        )
+        assert result.endswith(".h5")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,140 @@
+"""Tests for fd5.registry module."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fd5.registry import ProductSchema, get_schema, list_schemas, register_schema
+
+
+class _StubSchema:
+    """Minimal implementation satisfying the ProductSchema protocol."""
+
+    product_type: str = "pet/static"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {"type": "object"}
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product_type": "pet/static"}
+
+    def write(self, target: Any, data: Any) -> None:
+        pass
+
+    def id_inputs(self) -> list[str]:
+        return ["/scan/start_time"]
+
+
+def _assert_satisfies_protocol(obj: object) -> None:
+    """Verify *obj* is structurally compatible with ProductSchema."""
+    schema: ProductSchema = obj  # type: ignore[assignment]
+    assert hasattr(schema, "product_type")
+    assert hasattr(schema, "schema_version")
+    assert callable(schema.json_schema)
+    assert callable(schema.required_root_attrs)
+    assert callable(schema.write)
+    assert callable(schema.id_inputs)
+
+
+class TestProductSchemaProtocol:
+    """ProductSchema is a typing.Protocol — verify structural subtyping."""
+
+    def test_stub_satisfies_protocol(self):
+        _assert_satisfies_protocol(_StubSchema())
+
+    def test_protocol_has_required_members(self):
+        import inspect
+
+        members = {
+            name
+            for name, _ in inspect.getmembers(ProductSchema)
+            if not name.startswith("_")
+        }
+        assert members >= {
+            "product_type",
+            "schema_version",
+            "json_schema",
+            "required_root_attrs",
+            "write",
+            "id_inputs",
+        }
+
+
+class TestRegisterSchema:
+    """Tests for register_schema."""
+
+    def test_registers_and_retrieves(self):
+        stub = _StubSchema()
+        register_schema("test/register", stub)
+        assert get_schema("test/register") is stub
+
+    def test_overwrites_existing(self):
+        stub_a = _StubSchema()
+        stub_b = _StubSchema()
+        register_schema("test/overwrite", stub_a)
+        register_schema("test/overwrite", stub_b)
+        assert get_schema("test/overwrite") is stub_b
+
+    def test_appears_in_list(self):
+        stub = _StubSchema()
+        register_schema("test/listed", stub)
+        assert "test/listed" in list_schemas()
+
+
+class TestGetSchema:
+    """Tests for get_schema."""
+
+    def test_returns_registered_schema(self):
+        stub = _StubSchema()
+        register_schema("test/get", stub)
+        assert get_schema("test/get") is stub
+
+    def test_unknown_product_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="no-such-product"):
+            get_schema("no-such-product")
+
+
+class TestListSchemas:
+    """Tests for list_schemas."""
+
+    def test_returns_list_of_strings(self):
+        result = list_schemas()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_contains_registered_types(self):
+        register_schema("test/list-a", _StubSchema())
+        register_schema("test/list-b", _StubSchema())
+        result = list_schemas()
+        assert "test/list-a" in result
+        assert "test/list-b" in result
+
+
+class TestEntryPointDiscovery:
+    """Entry point loading uses importlib.metadata group 'fd5.schemas'."""
+
+    def test_loads_entry_points_on_first_access(self, monkeypatch):
+        """Schemas from entry points are available via get_schema."""
+        import fd5.registry as reg
+
+        stub = _StubSchema()
+        stub.product_type = "ep/test"
+
+        class FakeEntryPoint:
+            name = "ep/test"
+
+            def load(self):
+                return lambda: stub
+
+        monkeypatch.setattr(
+            reg,
+            "_load_entry_points",
+            lambda: {"ep/test": stub},
+        )
+        reg._registry.clear()
+        reg._load_and_merge()
+
+        assert get_schema("ep/test") is stub

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -48,12 +48,14 @@ class TestProductSchemaProtocol:
     def test_protocol_has_required_members(self):
         import inspect
 
-        members = {
+        methods = {
             name
             for name, _ in inspect.getmembers(ProductSchema)
             if not name.startswith("_")
         }
-        assert members >= {
+        annotations = set(ProductSchema.__protocol_attrs__)
+        all_members = methods | annotations
+        assert all_members >= {
             "product_type",
             "schema_version",
             "json_schema",

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,126 @@
+"""Tests for fd5.units module."""
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.units import read_quantity, set_dataset_units, write_quantity
+
+
+@pytest.fixture()
+def h5_group(tmp_path):
+    """Yield an open HDF5 group backed by a temp file."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+class TestWriteQuantity:
+    """Tests for write_quantity."""
+
+    def test_creates_subgroup_with_attrs(self, h5_group):
+        write_quantity(h5_group, "z_min", -450.2, "mm", 0.001)
+
+        grp = h5_group["z_min"]
+        assert grp.attrs["value"] == pytest.approx(-450.2)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_integer_value(self, h5_group):
+        write_quantity(h5_group, "kvp", 120, "kV", 1000.0)
+
+        grp = h5_group["kvp"]
+        assert grp.attrs["value"] == 120
+        assert grp.attrs["units"] == "kV"
+        assert grp.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_list_value(self, h5_group):
+        write_quantity(h5_group, "grid_spacing", [4.0, 4.0, 4.0], "mm", 0.001)
+
+        grp = h5_group["grid_spacing"]
+        np.testing.assert_array_equal(grp.attrs["value"], [4.0, 4.0, 4.0])
+        assert grp.attrs["units"] == "mm"
+
+    def test_numpy_array_value(self, h5_group):
+        arr = np.array([1.0, 2.0, 3.0])
+        write_quantity(h5_group, "offsets", arr, "mm", 0.001)
+
+        grp = h5_group["offsets"]
+        np.testing.assert_array_equal(grp.attrs["value"], arr)
+
+    def test_overwrites_existing_quantity(self, h5_group):
+        write_quantity(h5_group, "duration", 100.0, "s", 1.0)
+        write_quantity(h5_group, "duration", 200.0, "s", 1.0)
+
+        assert h5_group["duration"].attrs["value"] == pytest.approx(200.0)
+
+
+class TestReadQuantity:
+    """Tests for read_quantity."""
+
+    def test_reads_back_scalar(self, h5_group):
+        write_quantity(h5_group, "duration", 367.0, "s", 1.0)
+
+        value, units, unit_si = read_quantity(h5_group, "duration")
+        assert value == pytest.approx(367.0)
+        assert units == "s"
+        assert unit_si == pytest.approx(1.0)
+
+    def test_reads_back_array(self, h5_group):
+        write_quantity(h5_group, "frame_durations", [120.0, 120.0], "s", 1.0)
+
+        value, units, unit_si = read_quantity(h5_group, "frame_durations")
+        np.testing.assert_array_equal(value, [120.0, 120.0])
+        assert units == "s"
+
+    def test_missing_quantity_raises_keyerror(self, h5_group):
+        with pytest.raises(KeyError):
+            read_quantity(h5_group, "nonexistent")
+
+
+class TestSetDatasetUnits:
+    """Tests for set_dataset_units."""
+
+    def test_sets_units_and_unitsi_attrs(self, h5_group):
+        ds = h5_group.create_dataset("volume", data=np.zeros((2, 2, 2)))
+        set_dataset_units(ds, "Bq/mL", 1000.0)
+
+        assert ds.attrs["units"] == "Bq/mL"
+        assert ds.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_overwrites_existing_units(self, h5_group):
+        ds = h5_group.create_dataset("signal", data=np.zeros(10))
+        set_dataset_units(ds, "mV", 0.001)
+        set_dataset_units(ds, "V", 1.0)
+
+        assert ds.attrs["units"] == "V"
+        assert ds.attrs["unitSI"] == pytest.approx(1.0)
+
+
+class TestRoundTrip:
+    """Round-trip: write then read returns identical values."""
+
+    def test_scalar_round_trip(self, h5_group):
+        write_quantity(h5_group, "activity", 350.0, "MBq", 1e6)
+        value, units, unit_si = read_quantity(h5_group, "activity")
+
+        assert value == pytest.approx(350.0)
+        assert units == "MBq"
+        assert unit_si == pytest.approx(1e6)
+
+    def test_array_round_trip(self, h5_group):
+        original = [4.0, 4.0, 4.0]
+        write_quantity(h5_group, "grid_spacing", original, "mm", 0.001)
+        value, units, unit_si = read_quantity(h5_group, "grid_spacing")
+
+        np.testing.assert_array_equal(value, original)
+        assert units == "mm"
+        assert unit_si == pytest.approx(0.001)
+
+    def test_negative_value_round_trip(self, h5_group):
+        write_quantity(h5_group, "z_min", -850.0, "mm", 0.001)
+        value, units, unit_si = read_quantity(h5_group, "z_min")
+
+        assert value == pytest.approx(-850.0)
+        assert units == "mm"
+        assert unit_si == pytest.approx(0.001)

--- a/uv.lock
+++ b/uv.lock
@@ -543,6 +543,7 @@ science = [
 [package.dev-dependencies]
 dev = [
     { name = "hatchling" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -560,7 +561,10 @@ requires-dist = [
 provides-extras = ["dev", "science", "all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "hatchling", specifier = ">=1.25" }]
+dev = [
+    { name = "hatchling", specifier = ">=1.25" },
+    { name = "rich", specifier = ">=13.0.0" },
+]
 
 [[package]]
 name = "fonttools"
@@ -1129,6 +1133,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1255,6 +1271,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1918,6 +1943,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,6 +278,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +527,13 @@ wheels = [
 name = "fd5"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "h5py" },
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "tomli-w" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -548,15 +567,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "fd5", extras = ["dev", "science"], marker = "extra == 'all'" },
+    { name = "h5py", specifier = ">=3.10" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "jsonschema", specifier = ">=4.20" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.9" },
+    { name = "numpy", specifier = ">=2.0" },
     { name = "numpy", marker = "extra == 'science'", specifier = ">=2.0" },
     { name = "pandas", marker = "extra == 'science'", specifier = ">=2.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = ">=1.14" },
+    { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["dev", "science", "all"]
 
@@ -623,6 +647,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b8/c0d9aa013ecfa8b7057946c080c0c07f6fa41e231d2e9bd306a2f8110bdc/h5py-3.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:316dd0f119734f324ca7ed10b5627a2de4ea42cc4dfbcedbee026aaa361c238c", size = 3399089, upload-time = "2025-10-16T10:34:12.135Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5e/3c6f6e0430813c7aefe784d00c6711166f46225f5d229546eb53032c3707/h5py-3.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b51469890e58e85d5242e43aab29f5e9c7e526b951caab354f3ded4ac88e7b76", size = 2847803, upload-time = "2025-10-16T10:34:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/ba36273b888a4a48d78f9268d2aee05787e4438557450a8442946ab8f3ec/h5py-3.15.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a33bfd5dfcea037196f7778534b1ff7e36a7f40a89e648c8f2967292eb6898e", size = 4914884, upload-time = "2025-10-16T10:34:18.452Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/30/d1c94066343a98bb2cea40120873193a4fed68c4ad7f8935c11caf74c681/h5py-3.15.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25c8843fec43b2cc368aa15afa1cdf83fc5e17b1c4e10cd3771ef6c39b72e5ce", size = 5109965, upload-time = "2025-10-16T10:34:21.853Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3d/d28172116eafc3bc9f5991b3cb3fd2c8a95f5984f50880adfdf991de9087/h5py-3.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a308fd8681a864c04423c0324527237a0484e2611e3441f8089fd00ed56a8171", size = 4561870, upload-time = "2025-10-16T10:34:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/393a7226024238b0f51965a7156004eaae1fcf84aa4bfecf7e582676271b/h5py-3.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4a016df3f4a8a14d573b496e4d1964deb380e26031fc85fb40e417e9131888a", size = 5037161, upload-time = "2025-10-16T10:34:30.383Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/329e7436bf87ca6b0fe06dd0a3795c34bebe4ed8d6c44450a20565d57832/h5py-3.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:59b25cf02411bf12e14f803fef0b80886444c7fe21a5ad17c6a28d3f08098a1e", size = 2874165, upload-time = "2025-10-16T10:34:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/2d02b10a66747c54446e932171dd89b8b4126c0111b440e6bc05a7c852ec/h5py-3.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:61d5a58a9851e01ee61c932bbbb1c98fe20aba0a5674776600fb9a361c0aa652", size = 2458214, upload-time = "2025-10-16T10:34:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/40207e0192415cbff7ea1d37b9f24b33f6d38a5a2f5d18a678de78f967ae/h5py-3.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8440fd8bee9500c235ecb7aa1917a0389a2adb80c209fa1cc485bd70e0d94a5", size = 3376511, upload-time = "2025-10-16T10:34:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/31/96/ba99a003c763998035b0de4c299598125df5fc6c9ccf834f152ddd60e0fb/h5py-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab2219dbc6fcdb6932f76b548e2b16f34a1f52b7666e998157a4dfc02e2c4123", size = 2826143, upload-time = "2025-10-16T10:34:41.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c2/fc6375d07ea3962df7afad7d863fe4bde18bb88530678c20d4c90c18de1d/h5py-3.15.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8cb02c3a96255149ed3ac811eeea25b655d959c6dd5ce702c9a95ff11859eb5", size = 4908316, upload-time = "2025-10-16T10:34:44.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/4402ea66272dacc10b298cca18ed73e1c0791ff2ae9ed218d3859f9698ac/h5py-3.15.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:121b2b7a4c1915d63737483b7bff14ef253020f617c2fb2811f67a4bed9ac5e8", size = 5103710, upload-time = "2025-10-16T10:34:48.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f6/11f1e2432d57d71322c02a97a5567829a75f223a8c821764a0e71a65cde8/h5py-3.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59b0d63b318bf3cc06687def2b45afd75926bbc006f7b8cd2b1a231299fc8599", size = 4556042, upload-time = "2025-10-16T10:34:51.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/3eda3ef16bfe7a7dbc3d8d6836bbaa7986feb5ff091395e140dc13927bcc/h5py-3.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e02fe77a03f652500d8bff288cbf3675f742fc0411f5a628fa37116507dc7cc0", size = 5030639, upload-time = "2025-10-16T10:34:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ea/fbb258a98863f99befb10ed727152b4ae659f322e1d9c0576f8a62754e81/h5py-3.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dea78b092fd80a083563ed79a3171258d4a4d307492e7cf8b2313d464c82ba52", size = 2864363, upload-time = "2025-10-16T10:34:58.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c9/35021cc9cd2b2915a7da3026e3d77a05bed1144a414ff840953b33937fb9/h5py-3.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:c256254a8a81e2bddc0d376e23e2a6d2dc8a1e8a2261835ed8c1281a0744cd97", size = 2449570, upload-time = "2025-10-16T10:35:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2c/926eba1514e4d2e47d0e9eb16c784e717d8b066398ccfca9b283917b1bfb/h5py-3.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5f4fb0567eb8517c3ecd6b3c02c4f4e9da220c8932604960fd04e24ee1254763", size = 3380368, upload-time = "2025-10-16T10:35:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4b/d715ed454d3baa5f6ae1d30b7eca4c7a1c1084f6a2edead9e801a1541d62/h5py-3.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:954e480433e82d3872503104f9b285d369048c3a788b2b1a00e53d1c47c98dd2", size = 2833793, upload-time = "2025-10-16T10:35:05.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd125c131889ebbef0849f4a0e29cf363b48aba42f228d08b4079913b576bb3a", size = 4903199, upload-time = "2025-10-16T10:35:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28a20e1a4082a479b3d7db2169f3a5034af010b90842e75ebbf2e9e49eb4183e", size = 5097224, upload-time = "2025-10-16T10:35:12.808Z" },
+    { url = "https://files.pythonhosted.org/packages/30/30/5273218400bf2da01609e1292f562c94b461fcb73c7a9e27fdadd43abc0a/h5py-3.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa8df5267f545b4946df8ca0d93d23382191018e4cda2deda4c2cedf9a010e13", size = 4551207, upload-time = "2025-10-16T10:35:16.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
 ]
 
 [[package]]
@@ -2174,6 +2233,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `fd5.registry` module with `ProductSchema` Protocol, `get_schema()`, `list_schemas()`, and `register_schema()` functions
- Entry-point discovery uses `importlib.metadata` with group `fd5.schemas` for plugin-based schema registration
- 94% test coverage (10 tests) including protocol verification, CRUD operations, and monkeypatched entry-point loading

## Test plan

- [x] `ProductSchema` protocol structurally validates stub implementations
- [x] `register_schema` stores and overwrites schemas correctly
- [x] `get_schema` returns registered schema or raises `ValueError` for unknown types
- [x] `list_schemas` returns all registered product-type strings
- [x] Entry-point discovery loads schemas via monkeypatched `_load_entry_points`
- [x] Full test suite (72 tests) passes with no regressions

Closes #17

Made with [Cursor](https://cursor.com)