### PR TITLE
feat(registry): implement product schema registry with entry-point discovery

### DIFF
--- a/src/fd5/registry.py
+++ b/src/fd5/registry.py
@@ -1,0 +1,83 @@
+"""Product schema registry with entry-point discovery.
+
+Discovers product schemas from ``importlib.metadata`` entry points
+(group ``fd5.schemas``), allows lookup by product-type string, and
+provides a ``register_schema`` escape-hatch for testing.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProductSchema(Protocol):
+    """Structural interface every product schema must satisfy."""
+
+    product_type: str
+    schema_version: str
+
+    def json_schema(self) -> dict[str, Any]: ...
+    def required_root_attrs(self) -> dict[str, Any]: ...
+    def write(self, target: Any, data: Any) -> None: ...
+    def id_inputs(self) -> list[str]: ...
+
+
+_registry: dict[str, ProductSchema] = {}
+_ep_loaded: bool = False
+
+_EP_GROUP = "fd5.schemas"
+
+
+def _load_entry_points() -> dict[str, ProductSchema]:
+    """Load all entry points in the ``fd5.schemas`` group.
+
+    Each entry point must be a callable returning a ``ProductSchema``
+    instance.  The entry-point *name* is used as the product-type key.
+    """
+    schemas: dict[str, ProductSchema] = {}
+    for ep in importlib.metadata.entry_points(group=_EP_GROUP):
+        factory = ep.load()
+        schemas[ep.name] = factory()
+    return schemas
+
+
+def _load_and_merge() -> None:
+    """Merge entry-point schemas into the registry (once)."""
+    global _ep_loaded  # noqa: PLW0603
+    ep_schemas = _load_entry_points()
+    for name, schema in ep_schemas.items():
+        _registry.setdefault(name, schema)
+    _ep_loaded = True
+
+
+def _ensure_loaded() -> None:
+    if not _ep_loaded:
+        _load_and_merge()
+
+
+def register_schema(product_type: str, schema: ProductSchema) -> None:
+    """Register *schema* under *product_type* (overwrites existing)."""
+    _registry[product_type] = schema
+
+
+def get_schema(product_type: str) -> ProductSchema:
+    """Return the schema registered for *product_type*.
+
+    Raises:
+        ValueError: If no schema is registered for *product_type*.
+    """
+    _ensure_loaded()
+    try:
+        return _registry[product_type]
+    except KeyError:
+        raise ValueError(
+            f"No schema registered for product type {product_type!r}"
+        ) from None
+
+
+def list_schemas() -> list[str]:
+    """Return all registered product-type strings."""
+    _ensure_loaded()
+    return list(_registry)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,136 @@
+"""Tests for fd5.registry module."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fd5.registry import ProductSchema, get_schema, list_schemas, register_schema
+
+
+class _StubSchema:
+    """Minimal implementation satisfying the ProductSchema protocol."""
+
+    product_type: str = "pet/static"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {"type": "object"}
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product_type": "pet/static"}
+
+    def write(self, target: Any, data: Any) -> None:
+        pass
+
+    def id_inputs(self) -> list[str]:
+        return ["/scan/start_time"]
+
+
+def _assert_satisfies_protocol(obj: object) -> None:
+    """Verify *obj* is structurally compatible with ProductSchema."""
+    schema: ProductSchema = obj  # type: ignore[assignment]
+    assert hasattr(schema, "product_type")
+    assert hasattr(schema, "schema_version")
+    assert callable(schema.json_schema)
+    assert callable(schema.required_root_attrs)
+    assert callable(schema.write)
+    assert callable(schema.id_inputs)
+
+
+class TestProductSchemaProtocol:
+    """ProductSchema is a typing.Protocol — verify structural subtyping."""
+
+    def test_stub_satisfies_protocol(self):
+        _assert_satisfies_protocol(_StubSchema())
+
+    def test_protocol_has_required_members(self):
+        import inspect
+
+        methods = {
+            name
+            for name, _ in inspect.getmembers(ProductSchema)
+            if not name.startswith("_")
+        }
+        annotations = set(ProductSchema.__protocol_attrs__)
+        all_members = methods | annotations
+        assert all_members >= {
+            "product_type",
+            "schema_version",
+            "json_schema",
+            "required_root_attrs",
+            "write",
+            "id_inputs",
+        }
+
+
+class TestRegisterSchema:
+    """Tests for register_schema."""
+
+    def test_registers_and_retrieves(self):
+        stub = _StubSchema()
+        register_schema("test/register", stub)
+        assert get_schema("test/register") is stub
+
+    def test_overwrites_existing(self):
+        stub_a = _StubSchema()
+        stub_b = _StubSchema()
+        register_schema("test/overwrite", stub_a)
+        register_schema("test/overwrite", stub_b)
+        assert get_schema("test/overwrite") is stub_b
+
+    def test_appears_in_list(self):
+        stub = _StubSchema()
+        register_schema("test/listed", stub)
+        assert "test/listed" in list_schemas()
+
+
+class TestGetSchema:
+    """Tests for get_schema."""
+
+    def test_returns_registered_schema(self):
+        stub = _StubSchema()
+        register_schema("test/get", stub)
+        assert get_schema("test/get") is stub
+
+    def test_unknown_product_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="no-such-product"):
+            get_schema("no-such-product")
+
+
+class TestListSchemas:
+    """Tests for list_schemas."""
+
+    def test_returns_list_of_strings(self):
+        result = list_schemas()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_contains_registered_types(self):
+        register_schema("test/list-a", _StubSchema())
+        register_schema("test/list-b", _StubSchema())
+        result = list_schemas()
+        assert "test/list-a" in result
+        assert "test/list-b" in result
+
+
+class TestEntryPointDiscovery:
+    """Entry point loading uses importlib.metadata group 'fd5.schemas'."""
+
+    def test_loads_entry_points_on_first_access(self, monkeypatch):
+        """Schemas from entry points are available via get_schema."""
+        import fd5.registry as reg
+
+        stub = _StubSchema()
+        stub.product_type = "ep/test"
+
+        monkeypatch.setattr(
+            reg,
+            "_load_entry_points",
+            lambda: {"ep/test": stub},
+        )
+        reg._registry.clear()
+        reg._load_and_merge()
+
+        assert get_schema("ep/test") is stub


### PR DESCRIPTION
## Summary

- Implement `fd5.registry` module with `ProductSchema` Protocol, `register_schema`, `get_schema`, `list_schemas`
- Entry-point discovery via `importlib.metadata` (group `fd5.schemas`)
- 100% coverage, 10 tests

Closes #17

## Test plan

- [x] ProductSchema Protocol structural subtyping verified
- [x] register_schema / get_schema round-trip
- [x] list_schemas returns registered types
- [x] Unknown product type raises ValueError
- [x] Entry-point discovery via monkeypatched loader


Made with [Cursor](https://cursor.com)