### PR TITLE
feat(schema): implement JSON Schema embedding and validation

### DIFF
--- a/src/fd5/schema.py
+++ b/src/fd5/schema.py
@@ -1,0 +1,19 @@
+"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files."""
+
+from __future__ import annotations
+
+
+def embed_schema(file, schema_dict, *, schema_version=1):
+    raise NotImplementedError
+
+
+def dump_schema(path):
+    raise NotImplementedError
+
+
+def validate(path):
+    raise NotImplementedError
+
+
+def generate_schema(product_type):
+    raise NotImplementedError

--- a/src/fd5/schema.py
+++ b/src/fd5/schema.py
@@ -1,19 +1,70 @@
-"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files."""
+"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files.
+
+Stores ``_schema`` as a JSON string attribute at file root for single-read
+self-description (see white-paper.md § 9).
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
 
-def embed_schema(file, schema_dict, *, schema_version=1):
-    raise NotImplementedError
+import h5py
+import jsonschema
+import numpy as np
+
+from fd5.h5io import h5_to_dict
+from fd5.registry import get_schema
 
 
-def dump_schema(path):
-    raise NotImplementedError
+def embed_schema(
+    file: h5py.File,
+    schema_dict: dict[str, Any],
+    *,
+    schema_version: int = 1,
+) -> None:
+    """Write ``_schema`` (JSON string) and ``_schema_version`` (int) to *file* root."""
+    file.attrs["_schema"] = json.dumps(schema_dict, separators=(",", ":"))
+    file.attrs["_schema_version"] = np.int64(schema_version)
 
 
-def validate(path):
-    raise NotImplementedError
+def dump_schema(path: str | Path) -> dict[str, Any]:
+    """Extract and parse the ``_schema`` attribute from an fd5 file.
+
+    Raises:
+        KeyError: If the file has no ``_schema`` attribute.
+        json.JSONDecodeError: If the stored string is not valid JSON.
+    """
+    with h5py.File(path, "r") as f:
+        raw = f.attrs["_schema"]
+    return json.loads(raw)
 
 
-def generate_schema(product_type):
-    raise NotImplementedError
+def validate(path: str | Path) -> list[jsonschema.ValidationError]:
+    """Validate file structure against its embedded JSON Schema.
+
+    Returns a list of :class:`jsonschema.ValidationError` — empty when valid.
+
+    Raises:
+        KeyError: If the file has no ``_schema`` attribute.
+    """
+    with h5py.File(path, "r") as f:
+        raw = f.attrs["_schema"]
+        schema_dict = json.loads(raw)
+        instance = h5_to_dict(f)
+
+    validator = jsonschema.Draft202012Validator(schema_dict)
+    return list(validator.iter_errors(instance))
+
+
+def generate_schema(product_type: str) -> dict[str, Any]:
+    """Produce a JSON Schema Draft 2020-12 document for *product_type*.
+
+    Delegates to the product schema registry.
+
+    Raises:
+        ValueError: If *product_type* is not registered.
+    """
+    product_schema = get_schema(product_type)
+    return product_schema.json_schema()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,204 @@
+"""Tests for fd5.schema — embed, validate, dump, and generate JSON Schema."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import h5py
+import pytest
+
+from fd5.registry import register_schema
+from fd5.schema import dump_schema, embed_schema, generate_schema, validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubSchema:
+    """Minimal ProductSchema for testing."""
+
+    product_type: str = "test/schema"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "test/schema"},
+                "name": {"type": "string"},
+            },
+            "required": ["_schema_version", "product", "name"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product": "test/schema"}
+
+    def write(self, target: Any, data: Any) -> None:
+        pass
+
+    def id_inputs(self) -> list[str]:
+        return ["/name"]
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    """Yield a writable HDF5 file, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path):
+    """Return a path for an HDF5 file (closed between write and read)."""
+    return tmp_path / "test.h5"
+
+
+@pytest.fixture(autouse=True)
+def _register_stub():
+    """Register the stub schema for every test."""
+    register_schema("test/schema", _StubSchema())
+
+
+# ---------------------------------------------------------------------------
+# embed_schema
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedSchema:
+    def test_writes_schema_attr_as_json_string(self, h5file):
+        schema_dict = {"type": "object", "properties": {}}
+        embed_schema(h5file, schema_dict)
+        raw = h5file.attrs["_schema"]
+        assert isinstance(raw, str)
+        assert json.loads(raw) == schema_dict
+
+    def test_writes_schema_version_as_int(self, h5file):
+        embed_schema(h5file, {"type": "object"}, schema_version=2)
+        assert h5file.attrs["_schema_version"] == 2
+
+    def test_default_schema_version_is_one(self, h5file):
+        embed_schema(h5file, {"type": "object"})
+        assert h5file.attrs["_schema_version"] == 1
+
+    def test_schema_readable_by_h5_tools(self, h5path):
+        """Schema stored as plain JSON string is human-readable via h5dump."""
+        schema_dict = {"type": "object", "description": "test"}
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+        with h5py.File(h5path, "r") as f:
+            raw = f.attrs["_schema"]
+            parsed = json.loads(raw)
+            assert parsed == schema_dict
+
+    def test_idempotent_overwrites(self, h5file):
+        embed_schema(h5file, {"v": 1})
+        embed_schema(h5file, {"v": 2}, schema_version=3)
+        assert json.loads(h5file.attrs["_schema"]) == {"v": 2}
+        assert h5file.attrs["_schema_version"] == 3
+
+
+# ---------------------------------------------------------------------------
+# dump_schema
+# ---------------------------------------------------------------------------
+
+
+class TestDumpSchema:
+    def test_extracts_embedded_schema(self, h5path):
+        schema_dict = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+        result = dump_schema(h5path)
+        assert result == schema_dict
+
+    def test_raises_on_missing_schema(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["other"] = "value"
+        with pytest.raises(KeyError, match="_schema"):
+            dump_schema(h5path)
+
+    def test_raises_on_invalid_json(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["_schema"] = "not valid json {"
+        with pytest.raises(json.JSONDecodeError):
+            dump_schema(h5path)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def _make_valid_file(self, path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            f.attrs["name"] = "sample"
+
+    def test_valid_file_returns_empty_list(self, h5path):
+        self._make_valid_file(h5path)
+        errors = validate(h5path)
+        assert errors == []
+
+    def test_missing_required_attr_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            # 'name' is missing
+        errors = validate(h5path)
+        assert len(errors) > 0
+        messages = [e.message for e in errors]
+        assert any("name" in m for m in messages)
+
+    def test_wrong_type_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            f.attrs["name"] = "sample"
+            f.attrs["_schema_version"] = "not_an_int"
+        errors = validate(h5path)
+        assert len(errors) > 0
+
+    def test_raises_when_no_schema_embedded(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["product"] = "test/schema"
+        with pytest.raises(KeyError, match="_schema"):
+            validate(h5path)
+
+    def test_const_violation_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "wrong/type"
+            f.attrs["name"] = "sample"
+        errors = validate(h5path)
+        assert len(errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# generate_schema
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSchema:
+    def test_returns_json_schema_draft_2020_12(self):
+        result = generate_schema("test/schema")
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_returns_dict_from_registry(self):
+        result = generate_schema("test/schema")
+        assert result["type"] == "object"
+        assert "properties" in result
+
+    def test_unknown_product_raises_valueerror(self):
+        with pytest.raises(ValueError, match="no-such-type"):
+            generate_schema("no-such-type")


### PR DESCRIPTION
## Summary

- Implement `fd5.schema` module with embed_schema, validate_file, generate_schema, dump_schema
- 16 tests, 100% coverage

Closes #15

## Test plan

- [x] embed_schema writes _schema attr
- [x] validate_file checks against embedded schema
- [x] generate_schema creates JSON Schema from product schema
- [x] dump_schema outputs schema


Made with [Cursor](https://cursor.com)