### PR TITLE
feat(recon): implement recon product schema (fd5-imaging)

### DIFF
--- a/.cursor/skills/pr_create/SKILL.md
+++ b/.cursor/skills/pr_create/SKILL.md
@@ -17,6 +17,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 - Run `git status` and `git fetch origin`. If the current branch has a remote tracking branch, run `git pull --rebase origin <current-branch>` (or `git pull` if the user prefers merge) so the branch is up to date with the remote.
 - If there are uncommitted changes, list them and ask the user to commit or stash before submitting the PR. Do not prepare the PR until the working tree is clean (or the user explicitly says to proceed with uncommitted changes).
+- **Merge the base branch:** Once the base branch is confirmed (step 2), run `git merge origin/<base_branch>` to integrate the latest base before creating the PR. **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them manually before proceeding.
 
 ### 2. Verify target branch
 

--- a/.cursor/skills/pr_solve/SKILL.md
+++ b/.cursor/skills/pr_solve/SKILL.md
@@ -108,6 +108,7 @@ Show the user a structured summary before any fixes:
 
 ### 5. Execute fixes
 
+- **Merge the base branch** before the first push: run `git fetch origin` and `git merge origin/<base_branch>` (use `baseRefName` from step 1's PR metadata). **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them before proceeding.
 - Work through approved tasks one at a time.
 - Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
 - Commit each fix via [git_commit](../git_commit/SKILL.md).

--- a/.devcontainer/justfile.base
+++ b/.devcontainer/justfile.base
@@ -73,7 +73,7 @@ clean-artifacts:
 [group('info')]
 check *args:
     #!/usr/bin/env bash
-    SCRIPT_DIR="$(cd "$(dirname "{{justfile_directory()}}")/.devcontainer/scripts" && pwd)" || {
+    SCRIPT_DIR="$(cd "{{source_directory()}}/scripts" && pwd)" || {
         echo "Error: Could not locate .devcontainer/scripts directory"
         exit 1
     }

--- a/.devcontainer/justfile.base
+++ b/.devcontainer/justfile.base
@@ -373,10 +373,10 @@ sidecar name *args:
 # -------------------------------------------------------------------------------
 
 # Start a devcontainer on a remote host and open Cursor/VS Code
-# Usage: just devc-remote <ssh-host>[:<remote-path>]
-# Example: just devc-remote myserver
-#          just devc-remote user@host:/opt/projects/myrepo
-#          just devc-remote myserver:/home/user/repo
+# Auto-clones the repo and runs init-workspace if needed
+# Usage: just devc-remote myserver
+#        just devc-remote myserver:/home/user/repo
+#        just devc-remote --repo git@github.com:org/repo.git myserver
 [group('devcontainer')]
-devc-remote host_path:
-    bash scripts/devc-remote.sh {{host_path}}
+devc-remote *args:
+    bash scripts/devc-remote.sh {{args}}

--- a/.devcontainer/justfile.gh
+++ b/.devcontainer/justfile.gh
@@ -7,4 +7,4 @@ _gh_scripts := source_directory() / "scripts"
 # List open issues and PRs grouped by milestone
 [group('github')]
 gh-issues:
-    python3 {{ _gh_scripts }}/gh_issues.py
+    uv run python {{ _gh_scripts }}/gh_issues.py

--- a/.devcontainer/justfile.worktree
+++ b/.devcontainer/justfile.worktree
@@ -11,6 +11,9 @@
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
+# Scripts path: resolves to scripts/ in devcontainer repo, .devcontainer/scripts/ in workspace
+_scripts := source_directory() / "scripts"
+
 # -------------------------------------------------------------------------------
 # START
 # -------------------------------------------------------------------------------
@@ -114,10 +117,11 @@ worktree-start issue prompt="" reviewer="":
             echo "    tmux session '$SESSION' is running. Use: just worktree-attach $ISSUE"
         else
             echo "    No tmux session found. Starting one..."
+            AGENT_MODEL=$(_read_model "autonomous")
             if [ -n "$PROMPT" ]; then
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --yolo --approve-mcps \"$PROMPT\""
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --yolo --approve-mcps \"$PROMPT\""
             else
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
             fi
             sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
             echo "[OK] tmux session '$SESSION' started. Use: just worktree-attach $ISSUE"
@@ -126,7 +130,7 @@ worktree-start issue prompt="" reviewer="":
     fi
 
     # Resolve the issue's linked branch (may already exist from issue:claim)
-    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
 
     if [ -z "$BRANCH" ]; then
         echo "[*] No linked branch for issue #${ISSUE}. Creating one..."
@@ -144,11 +148,16 @@ worktree-start issue prompt="" reviewer="":
         fi
 
         # Use agent ONLY for the intelligent part: deriving the short summary
+        # Try lightweight first; on failure retry with standard model (#183)
         NAMING_RULE="$(pwd)/.cursor/rules/branch-naming.mdc"
-        SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" 2>/dev/null) || true
+        SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
 
         if [ -z "$SUMMARY" ]; then
-            "$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" >/dev/null || true
+            echo "[!] Lightweight model failed. Retrying with standard model..."
+            SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
+        fi
+
+        if [ -z "$SUMMARY" ]; then
             echo "        Create one manually: gh issue develop ${ISSUE} --base dev --name ${TYPE}/${ISSUE}-<summary>"
             exit 1
         fi
@@ -157,7 +166,7 @@ worktree-start issue prompt="" reviewer="":
         OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
         PARENT=$(gh api "repos/${OWNER_REPO}/issues/${ISSUE}/parent" --jq '.number' 2>/dev/null || true)
         if [ -n "$PARENT" ]; then
-            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
             BASE="${BASE:-dev}"
         else
             BASE="dev"
@@ -213,10 +222,11 @@ worktree-start issue prompt="" reviewer="":
 
     # Start tmux session
     # --yolo: auto-approve all shell commands (autonomous agent, no human at the terminal)
+    AGENT_MODEL=$(_read_model "autonomous")
     if [ -n "$PROMPT" ]; then
-        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --yolo --approve-mcps \"$PROMPT\""
+        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --yolo --approve-mcps \"$PROMPT\""
     else
-        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+        tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
     fi
     sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
 
@@ -299,6 +309,12 @@ worktree-attach issue:
         fi
     }
 
+    _read_model() {
+        local tier="$1"
+        local cfg="$(git rev-parse --show-toplevel)/.cursor/agent-models.toml"
+        grep "^${tier}" "$cfg" | sed 's/.*= *"//' | sed 's/".*//'
+    }
+
     ISSUE="{{ issue }}"
     SESSION="wt-${ISSUE}"
     WT_DIR="{{ _wt_base }}/${ISSUE}"
@@ -307,11 +323,12 @@ worktree-attach issue:
         if [ -d "$WT_DIR" ]; then
             echo "[!] tmux session '$SESSION' stopped. Restarting..."
             _wt_ensure_trust "$WT_DIR"
-            REVIEWER=$(gh api user --jq '.login' 2>/dev/null || echo "")
             if [ -n "${WORKTREE_ATTACH_RESTART_CMD:-}" ]; then
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "$WORKTREE_ATTACH_RESTART_CMD"
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" "$WORKTREE_ATTACH_RESTART_CMD"
             else
-                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --approve-mcps"
+                REVIEWER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+                AGENT_MODEL=$(_read_model "autonomous")
+                tmux new-session -d -s "$SESSION" -c "$WT_DIR" -e "PR_REVIEWER=$REVIEWER" "agent chat --model $AGENT_MODEL --approve-mcps"
             fi
             sleep 2 && tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
             echo "[OK] tmux session '$SESSION' restarted"

--- a/.devcontainer/scripts/check-skill-names.sh
+++ b/.devcontainer/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/.devcontainer/scripts/derive-branch-summary.sh
+++ b/.devcontainer/scripts/derive-branch-summary.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Derive a kebab-case branch summary from an issue title.
+# Used by worktree-start when no linked branch exists.
+#
+# Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]
+#   TITLE: issue title
+#   NAMING_RULE: path to branch-naming.mdc (default: .cursor/rules/branch-naming.mdc)
+#   MODEL_TIER: agent-models.toml tier (default: lightweight). Use standard for retry.
+#
+# Env: BRANCH_SUMMARY_CMD — override for tests (e.g. "echo test-summary")
+#      When set, runs instead of agent. Must output summary to stdout.
+#      BRANCH_SUMMARY_MODEL — override model tier (e.g. "standard"). Ignored if BRANCH_SUMMARY_CMD set.
+#      DERIVE_BRANCH_TIMEOUT — timeout in seconds (default: 30). Use 2 for tests.
+set -euo pipefail
+
+TITLE="${1:?Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NAMING_RULE="${2:-${REPO_ROOT}/.cursor/rules/branch-naming.mdc}"
+MODEL_TIER="${3:-${BRANCH_SUMMARY_MODEL:-lightweight}}"
+TIMEOUT="${DERIVE_BRANCH_TIMEOUT:-30}"
+
+if [ -n "${BRANCH_SUMMARY_CMD:-}" ]; then
+    SUMMARY=$(timeout "$TIMEOUT" sh -c "$BRANCH_SUMMARY_CMD" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+else
+    MODEL=$(grep "^${MODEL_TIER}" "${REPO_ROOT}/.cursor/agent-models.toml" | sed 's/.*= *"//' | sed 's/".*//')
+    SUMMARY=$(timeout "$TIMEOUT" agent --print --yolo --trust --model "$MODEL" \
+        "Read the branch naming rules in ${NAMING_RULE}. " \
+        "The issue title is: ${TITLE} " \
+        "Output ONLY a kebab-case short summary suitable for a branch name (a few words). " \
+        "Omit prefixes like FEATURE, BUG, Add, Implement, Support. " \
+        "Example: 'Standardize and Enforce Commit Message Format' -> 'standardize-commit-messages'. " \
+        "No explanation. No quotes. Just the summary." 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+fi
+
+if [ -z "$SUMMARY" ]; then
+    echo "[ERROR] Failed to derive branch summary from title: ${TITLE}" >&2
+    echo "        Create one manually: gh issue develop <ISSUE> --base dev --name <type>/<issue>-<summary>" >&2
+    exit 1
+fi
+
+echo "$SUMMARY"

--- a/.devcontainer/scripts/gh_issues.py
+++ b/.devcontainer/scripts/gh_issues.py
@@ -374,13 +374,34 @@ def _infer_review(pr: dict) -> tuple[str, str]:
     return ("", "—")
 
 
+def _dedupe_status_checks(rollup: list[dict]) -> list[dict]:
+    """Deduplicate statusCheckRollup by check name, keeping latest by completedAt.
+
+    GitHub includes re-runs of the same check; we keep only the latest result
+    per check name so the CI column matches what GitHub shows on the PR page.
+    Ref: #176
+    """
+    by_name: dict[str, dict] = {}
+    for check in rollup:
+        name = check.get("name") or "?"
+        completed = check.get("completedAt") or ""
+        existing = by_name.get(name)
+        if existing is None:
+            by_name[name] = check
+        else:
+            existing_completed = existing.get("completedAt") or ""
+            if completed >= existing_completed:
+                by_name[name] = check
+    return list(by_name.values())
+
+
 def _format_ci_status(pr: dict, owner_repo: str) -> str:
     """Return Rich markup for CI status cell: pass/fail/pending summary with link.
 
     Uses statusCheckRollup from gh pr list. Links to PR checks tab.
     Ref: #143
     """
-    rollup = pr.get("statusCheckRollup") or []
+    rollup = _dedupe_status_checks(pr.get("statusCheckRollup") or [])
     if not rollup:
         return _styled("—", "dim")
 
@@ -485,7 +506,9 @@ def _build_pr_table(
 
         linked = pr_to_issues.get(pr["number"], [])
         issues_cell = (
-            " ".join(_styled(f"#{n}", "cyan") for n in sorted(linked)) if linked else ""
+            " ".join(_gh_link(owner_repo, n, "issues") for n in sorted(linked))
+            if linked
+            else ""
         )
 
         ci_cell = _format_ci_status(pr, owner_repo)

--- a/.devcontainer/scripts/resolve-branch.sh
+++ b/.devcontainer/scripts/resolve-branch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Extract the branch name from `gh issue develop --list` output.
+# Input:  tab-separated lines on stdin (branch<TAB>URL)
+# Output: first branch name (first field of first line)
+head -1 | cut -f1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,7 +123,7 @@ repos:
     hooks:
       - id: check-skill-names
         name: check-skill-names (enforce naming convention)
-        entry: scripts/check-skill-names.sh .cursor/skills
+        entry: .devcontainer/scripts/check-skill-names.sh .cursor/skills
         language: script
         files: ^\.cursor/skills/
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TOML manifest generation and parsing** ([#20](https://github.com/vig-os/fd5/issues/20))
+  - `build_manifest(directory)` scans `.h5` files and extracts root attrs
+  - `write_manifest(directory, output_path)` writes `manifest.toml`
+  - `read_manifest(path)` parses an existing `manifest.toml`
+
 ### Changed
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,5 @@ packages = ["src/fd5"]
 [dependency-groups]
 dev = [
     "hatchling>=1.25",
+    "rich>=13.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/fd5"]
 
+[project.entry-points."fd5.schemas"]
+recon = "fd5.imaging.recon:ReconSchema"
+
 [dependency-groups]
 dev = [
     "hatchling>=1.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,16 @@ name = "fd5"
 version = "0.1.0"
 description = "fd5 project"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "h5py>=3.10",
+    "numpy>=2.0",
+    "jsonschema>=4.20",
+    "tomli-w>=1.0",
+    "click>=8.0",
+]
+
+[project.scripts]
+fd5 = "fd5.cli:cli"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/check-skill-names.sh
+++ b/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -210,8 +210,11 @@ remote_compose_up() {
     else
         log_info "Starting devcontainer on $SSH_HOST..."
         # shellcheck disable=SC2029
-        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
-        # Health poll (simplified: assume success for now)
+        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+            log_error "Failed to start devcontainer on $SSH_HOST."
+            log_error "Debug with: ssh $SSH_HOST 'cd $REMOTE_PATH && $COMPOSE_CMD logs'"
+            exit 1
+        fi
         sleep 2
     fi
 }

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -243,11 +243,23 @@ open_editor() {
 
 main() {
     parse_args "$@"
+
+    log_info "Detecting local editor CLI..."
     detect_editor_cli
+    log_success "Using $EDITOR_CLI"
+
+    log_info "Checking SSH connectivity to $SSH_HOST..."
     check_ssh
+    log_success "SSH connection OK"
+
+    log_info "Running pre-flight checks on $SSH_HOST..."
     remote_preflight
+    log_success "Pre-flight OK (runtime: $RUNTIME)"
+
     remote_compose_up
     open_editor
+
+    log_success "Done — opened $EDITOR_CLI for $SSH_HOST:$REMOTE_PATH"
 }
 
 main "$@"

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+###############################################################################
+# devc-remote.sh - Remote devcontainer orchestrator
+#
+# Starts a devcontainer on a remote host via SSH and opens Cursor/VS Code.
+# Handles SSH connectivity, pre-flight checks, container state detection,
+# and compose lifecycle. URI construction delegated to Python helper.
+#
+# USAGE:
+#   ./scripts/devc-remote.sh <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh --help
+#
+# Examples:
+#   ./scripts/devc-remote.sh myserver
+#   ./scripts/devc-remote.sh user@host:/opt/projects/myrepo
+#   ./scripts/devc-remote.sh myserver:/home/user/repo
+#
+# Part of #70. See issue #152 for design.
+###############################################################################
+
+set -euo pipefail
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LOGGING (matches init.sh patterns)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+log_info() {
+    echo -e "${BLUE}ℹ${NC}  $1"
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC}  $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠${NC}  $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${NC}  $1"
+}
+
+show_help() {
+    sed -n '/^###############################################################################$/,/^###############################################################################$/p' "$0" | sed '1d;$d'
+    exit 0
+}
+
+parse_args() {
+    SSH_HOST=""
+    REMOTE_PATH="~"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help|-h)
+                show_help
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                echo "Use --help for usage information"
+                exit 1
+                ;;
+            *)
+                if [[ -n "$SSH_HOST" ]]; then
+                    log_error "Unexpected argument: $1"
+                    exit 1
+                fi
+                # Parse SSH-style format: user@host:path or host:path
+                if [[ "$1" =~ ^([^:]+):(.+)$ ]]; then
+                    SSH_HOST="${BASH_REMATCH[1]}"
+                    REMOTE_PATH="${BASH_REMATCH[2]}"
+                else
+                    SSH_HOST="$1"
+                    # Default to ~ (expanded by remote shell) if no path specified
+                    REMOTE_PATH="~"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$SSH_HOST" ]]; then
+        log_error "Missing required argument: <ssh-host>[:<remote-path>]"
+        echo "Use --help for usage information"
+        exit 1
+    fi
+}
+
+detect_editor_cli() {
+    if command -v cursor &>/dev/null; then
+        # shellcheck disable=SC2034
+        EDITOR_CLI="cursor"
+    elif command -v code &>/dev/null; then
+        # shellcheck disable=SC2034
+        EDITOR_CLI="code"
+    else
+        log_error "Neither cursor nor code CLI found. Install Cursor or VS Code and enable the shell command."
+        exit 1
+    fi
+}
+
+check_ssh() {
+    if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$SSH_HOST" true 2>/dev/null; then
+        log_error "Cannot connect to $SSH_HOST. Check your SSH config and network."
+        exit 1
+    fi
+}
+
+remote_preflight() {
+    local preflight_output
+    # shellcheck disable=SC2029
+    preflight_output=$(ssh "$SSH_HOST" "bash -s" "$REMOTE_PATH" << 'REMOTEEOF'
+REPO_PATH="${1:-$HOME}"
+if command -v podman &>/dev/null; then
+    echo "RUNTIME=podman"
+elif command -v docker &>/dev/null; then
+    echo "RUNTIME=docker"
+else
+    echo "RUNTIME="
+fi
+if (command -v podman &>/dev/null && podman compose version &>/dev/null) || \
+   (command -v docker &>/dev/null && docker compose version &>/dev/null); then
+    echo "COMPOSE_AVAILABLE=1"
+else
+    echo "COMPOSE_AVAILABLE=0"
+fi
+if [ -d "$REPO_PATH" ]; then
+    echo "REPO_PATH_EXISTS=1"
+else
+    echo "REPO_PATH_EXISTS=0"
+fi
+if [ -d "$REPO_PATH/.devcontainer" ]; then
+    echo "DEVCONTAINER_EXISTS=1"
+else
+    echo "DEVCONTAINER_EXISTS=0"
+fi
+AVAIL_GB=$(df -BG "$REPO_PATH" 2>/dev/null | awk 'NR==2 {gsub(/G/,""); print $4}')
+echo "DISK_AVAILABLE_GB=${AVAIL_GB:-0}"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "OS_TYPE=macos"
+else
+    echo "OS_TYPE=linux"
+fi
+REMOTEEOF
+    )
+
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            RUNTIME) RUNTIME="${BASH_REMATCH[2]}" ;;
+            COMPOSE_AVAILABLE) COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            REPO_PATH_EXISTS) REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_EXISTS) DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
+            DISK_AVAILABLE_GB) DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
+            OS_TYPE) OS_TYPE="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$preflight_output"
+
+    if [[ -z "${RUNTIME:-}" ]]; then
+        log_error "No container runtime found on $SSH_HOST. Install podman or docker."
+        exit 1
+    fi
+    if [[ "$RUNTIME" == "podman" ]]; then
+        COMPOSE_CMD="podman compose"
+    else
+        COMPOSE_CMD="docker compose"
+    fi
+    if [[ "${COMPOSE_AVAILABLE:-0}" != "1" ]]; then
+        log_error "Compose not available on $SSH_HOST. Install docker-compose or podman-compose."
+        exit 1
+    fi
+    if [[ "${REPO_PATH_EXISTS:-0}" != "1" ]]; then
+        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST."
+        exit 1
+    fi
+    if [[ "${DEVCONTAINER_EXISTS:-0}" != "1" ]]; then
+        log_error "No .devcontainer/ found in $REMOTE_PATH. Is this a devcontainer-enabled project?"
+        exit 1
+    fi
+    if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
+        log_warning "Low disk space on $SSH_HOST (${DISK_AVAILABLE_GB:-0}GB). At least 2GB recommended."
+    fi
+    if [[ "${OS_TYPE:-}" == "macos" ]]; then
+        log_warning "Remote host is macOS. Devcontainer support may be limited."
+    fi
+}
+
+remote_compose_up() {
+    local ps_output state health
+    # shellcheck disable=SC2029
+    ps_output=$(ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD ps --format json 2>/dev/null" || true)
+    state=$(echo "$ps_output" | grep -o '"State":"[^"]*"' | head -1 | cut -d'"' -f4)
+    health=$(echo "$ps_output" | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+    if [[ "$state" == "running" && "${health:-}" == "healthy" ]]; then
+        log_success "Devcontainer already running on $SSH_HOST. Opening..."
+    else
+        log_info "Starting devcontainer on $SSH_HOST..."
+        # shellcheck disable=SC2029
+        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
+        # Health poll (simplified: assume success for now)
+        sleep 2
+    fi
+}
+
+open_editor() {
+    local container_workspace uri
+    # Read workspaceFolder from devcontainer.json on remote host
+    # shellcheck disable=SC2029
+    container_workspace=$(ssh "$SSH_HOST" \
+        "grep -o '\"workspaceFolder\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' \
+         ${REMOTE_PATH}/.devcontainer/devcontainer.json 2>/dev/null" \
+        | sed 's/.*: *"//;s/"//' || echo "/workspace")
+
+    # Default to /workspace if workspaceFolder not found
+    container_workspace="${container_workspace:-/workspace}"
+
+    # Build URI using Python helper
+    uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
+        "$REMOTE_PATH" \
+        "$SSH_HOST" \
+        "$container_workspace")
+
+    "$EDITOR_CLI" --folder-uri "$uri"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════════════════════
+
+main() {
+    parse_args "$@"
+    detect_editor_cli
+    check_ssh
+    remote_preflight
+    remote_compose_up
+    open_editor
+}
+
+main "$@"

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -6,14 +6,19 @@
 # Handles SSH connectivity, pre-flight checks, container state detection,
 # and compose lifecycle. URI construction delegated to Python helper.
 #
+# When no :<path> is given, derives the remote path from the local repo name
+# (~/repo-name). If the repo doesn't exist on the remote, clones it. If
+# .devcontainer/ is missing, runs init-workspace via the container image.
+#
 # USAGE:
-#   ./scripts/devc-remote.sh <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh [--repo <url>] <ssh-host>[:<remote-path>]
 #   ./scripts/devc-remote.sh --help
 #
 # Examples:
 #   ./scripts/devc-remote.sh myserver
 #   ./scripts/devc-remote.sh user@host:/opt/projects/myrepo
 #   ./scripts/devc-remote.sh myserver:/home/user/repo
+#   ./scripts/devc-remote.sh --repo git@github.com:org/repo.git myserver
 #
 # Part of #70. See issue #152 for design.
 ###############################################################################
@@ -61,12 +66,22 @@ show_help() {
 
 parse_args() {
     SSH_HOST=""
-    REMOTE_PATH="~"
+    REMOTE_PATH=""
+    REPO_URL=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --help|-h)
                 show_help
+                ;;
+            --repo)
+                shift
+                REPO_URL="${1:-}"
+                if [[ -z "$REPO_URL" ]]; then
+                    log_error "--repo requires a URL argument"
+                    exit 1
+                fi
+                shift
                 ;;
             -*)
                 log_error "Unknown option: $1"
@@ -84,8 +99,6 @@ parse_args() {
                     REMOTE_PATH="${BASH_REMATCH[2]}"
                 else
                     SSH_HOST="$1"
-                    # Default to ~ (expanded by remote shell) if no path specified
-                    REMOTE_PATH="~"
                 fi
                 shift
                 ;;
@@ -96,6 +109,25 @@ parse_args() {
         log_error "Missing required argument: <ssh-host>[:<remote-path>]"
         echo "Use --help for usage information"
         exit 1
+    fi
+
+    # Auto-derive REMOTE_PATH from local repo name when not explicitly given
+    if [[ -z "$REMOTE_PATH" ]]; then
+        local local_repo_name
+        local_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
+        if [[ -n "$local_repo_name" ]]; then
+            # Tilde is intentional; expanded by the remote shell
+            # shellcheck disable=SC2088
+            REMOTE_PATH="~/${local_repo_name}"
+        else
+            log_error "No remote path given and not inside a git repository."
+            exit 1
+        fi
+    fi
+
+    # Auto-derive REPO_URL from local git remote when not explicitly given
+    if [[ -z "$REPO_URL" ]]; then
+        REPO_URL=$(git remote get-url origin 2>/dev/null || echo "")
     fi
 }
 
@@ -137,6 +169,11 @@ if (command -v podman &>/dev/null && podman compose version &>/dev/null) || \
 else
     echo "COMPOSE_AVAILABLE=0"
 fi
+if command -v git &>/dev/null; then
+    echo "GIT_AVAILABLE=1"
+else
+    echo "GIT_AVAILABLE=0"
+fi
 if [ -d "$REPO_PATH" ]; then
     echo "REPO_PATH_EXISTS=1"
 else
@@ -162,6 +199,7 @@ REMOTEEOF
         case "${BASH_REMATCH[1]}" in
             RUNTIME) RUNTIME="${BASH_REMATCH[2]}" ;;
             COMPOSE_AVAILABLE) COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            GIT_AVAILABLE) GIT_AVAILABLE="${BASH_REMATCH[2]}" ;;
             REPO_PATH_EXISTS) REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
             DEVCONTAINER_EXISTS) DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
             DISK_AVAILABLE_GB) DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
@@ -169,6 +207,7 @@ REMOTEEOF
         esac
     done <<< "$preflight_output"
 
+    # Hard errors: runtime and compose are always required
     if [[ -z "${RUNTIME:-}" ]]; then
         log_error "No container runtime found on $SSH_HOST. Install podman or docker."
         exit 1
@@ -182,20 +221,58 @@ REMOTEEOF
         log_error "Compose not available on $SSH_HOST. Install docker-compose or podman-compose."
         exit 1
     fi
-    if [[ "${REPO_PATH_EXISTS:-0}" != "1" ]]; then
-        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST."
-        exit 1
-    fi
-    if [[ "${DEVCONTAINER_EXISTS:-0}" != "1" ]]; then
-        log_error "No .devcontainer/ found in $REMOTE_PATH. Is this a devcontainer-enabled project?"
-        exit 1
-    fi
+
+    # Soft checks: repo and devcontainer are handled by clone/init steps
     if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
         log_warning "Low disk space on $SSH_HOST (${DISK_AVAILABLE_GB:-0}GB). At least 2GB recommended."
     fi
     if [[ "${OS_TYPE:-}" == "macos" ]]; then
         log_warning "Remote host is macOS. Devcontainer support may be limited."
     fi
+}
+
+remote_clone_if_needed() {
+    [[ "${REPO_PATH_EXISTS:-0}" == "1" ]] && return 0
+
+    if [[ -z "$REPO_URL" ]]; then
+        log_error "Repository not found at $REMOTE_PATH on $SSH_HOST and no repo URL available."
+        log_error "Provide a path (host:path) or use --repo <url>."
+        exit 1
+    fi
+    if [[ "${GIT_AVAILABLE:-0}" != "1" ]]; then
+        log_error "git not found on $SSH_HOST. Install git to enable auto-clone."
+        exit 1
+    fi
+
+    log_info "Cloning $REPO_URL to $REMOTE_PATH on $SSH_HOST..."
+    # shellcheck disable=SC2029
+    if ! ssh "$SSH_HOST" "git clone '$REPO_URL' '$REMOTE_PATH'"; then
+        log_error "git clone failed on $SSH_HOST."
+        exit 1
+    fi
+    log_success "Repository cloned to $REMOTE_PATH"
+    REPO_PATH_EXISTS=1
+}
+
+remote_init_if_needed() {
+    [[ "${DEVCONTAINER_EXISTS:-0}" == "1" ]] && return 0
+
+    local project_name
+    project_name=$(basename "$REMOTE_PATH" | tr '[:upper:]' '[:lower:]' | sed 's/[ -]/_/g; s/[^a-z0-9_]/_/g')
+
+    log_info "No .devcontainer/ found. Running init-workspace for '$project_name'..."
+    # shellcheck disable=SC2029
+    if ! ssh "$SSH_HOST" "$RUNTIME run --rm \
+        -e SHORT_NAME='$project_name' \
+        -e ORG_NAME='vigOS' \
+        -v '$REMOTE_PATH:/workspace' \
+        ghcr.io/vig-os/devcontainer:latest \
+        /root/assets/init-workspace.sh --no-prompts --force"; then
+        log_error "init-workspace failed on $SSH_HOST."
+        exit 1
+    fi
+    log_success "Workspace initialized"
+    DEVCONTAINER_EXISTS=1
 }
 
 remote_compose_up() {
@@ -210,8 +287,11 @@ remote_compose_up() {
     else
         log_info "Starting devcontainer on $SSH_HOST..."
         # shellcheck disable=SC2029
-        ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d" >/dev/null 2>&1
-        # Health poll (simplified: assume success for now)
+        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+            log_error "Failed to start devcontainer on $SSH_HOST."
+            log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH && $COMPOSE_CMD logs\"' for details."
+            exit 1
+        fi
         sleep 2
     fi
 }
@@ -229,12 +309,18 @@ open_editor() {
     container_workspace="${container_workspace:-/workspace}"
 
     # Build URI using Python helper
-    uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
+    if ! uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
         "$REMOTE_PATH" \
         "$SSH_HOST" \
-        "$container_workspace")
+        "$container_workspace"); then
+        log_error "Failed to build editor URI. Is devc_remote_uri.py present in $SCRIPT_DIR?"
+        exit 1
+    fi
 
-    "$EDITOR_CLI" --folder-uri "$uri"
+    if ! "$EDITOR_CLI" --folder-uri "$uri"; then
+        log_error "Failed to open $EDITOR_CLI. URI: $uri"
+        exit 1
+    fi
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -246,6 +332,8 @@ main() {
     detect_editor_cli
     check_ssh
     remote_preflight
+    remote_clone_if_needed
+    remote_init_if_needed
     remote_compose_up
     open_editor
 }

--- a/scripts/devc_remote_uri.py
+++ b/scripts/devc_remote_uri.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build Cursor/VS Code nested authority URI for remote devcontainers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def hex_encode(s: str) -> str:
+    """Hex-encode a string (UTF-8)."""
+    return s.encode().hex()
+
+
+def build_uri(
+    workspace_path: str,
+    devcontainer_path: str,
+    ssh_host: str,
+    container_workspace: str,
+) -> str:
+    """Build vscode-remote URI for dev-container over SSH.
+
+    Format: vscode-remote://dev-container+{DC_HEX}@ssh-remote+{SSH_SPEC}/{container_workspace}
+    """
+    if not workspace_path:
+        raise ValueError("workspace_path cannot be empty")
+    if not devcontainer_path:
+        raise ValueError("devcontainer_path cannot be empty")
+    if not ssh_host:
+        raise ValueError("ssh_host cannot be empty")
+    if not container_workspace:
+        raise ValueError("container_workspace cannot be empty")
+    spec = {
+        "settingType": "config",
+        "workspacePath": workspace_path,
+        "devcontainerPath": devcontainer_path,
+    }
+    dc_hex = hex_encode(json.dumps(spec, separators=(",", ":")))
+    path = "/" + container_workspace.lstrip("/")
+    return f"vscode-remote://dev-container+{dc_hex}@ssh-remote+{ssh_host}{path}"
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Build Cursor/VS Code URI for remote devcontainers"
+    )
+    parser.add_argument("workspace_path", help="Workspace path on the remote host")
+    parser.add_argument("ssh_host", help="SSH host from ~/.ssh/config")
+    parser.add_argument("container_workspace", help="Container workspace path")
+    parser.add_argument(
+        "--devcontainer-path",
+        help="Path to devcontainer.json (default: {workspace_path}/.devcontainer/devcontainer.json)",
+    )
+    args = parser.parse_args()
+
+    devcontainer_path = args.devcontainer_path or (
+        f"{args.workspace_path.rstrip('/')}/.devcontainer/devcontainer.json"
+    )
+    uri = build_uri(
+        workspace_path=args.workspace_path,
+        devcontainer_path=devcontainer_path,
+        ssh_host=args.ssh_host,
+        container_workspace=args.container_workspace,
+    )
+    print(uri)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+###############################################################################
+# setup-labels.sh — Provision GitHub labels from label-taxonomy.toml
+#
+# Reads the canonical label definitions from .github/label-taxonomy.toml and
+# creates or updates them on the target repository.  Idempotent: safe to run
+# repeatedly.
+#
+# USAGE:
+#   ./scripts/setup-labels.sh                  # current repo
+#   ./scripts/setup-labels.sh --repo owner/repo
+#   ./scripts/setup-labels.sh --prune          # also delete unlisted labels
+#   ./scripts/setup-labels.sh --dry-run        # show what would happen
+#
+# REQUIRES: gh (GitHub CLI), authenticated
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAXONOMY_FILE="${SCRIPT_DIR}/../.github/label-taxonomy.toml"
+
+REPO_ARGS=()
+PRUNE=false
+DRY_RUN=false
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            REPO_ARGS=(--repo "$2")
+            shift 2
+            ;;
+        --prune)
+            PRUNE=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '/^###############################################################################$/,/^###############################################################################$/p' "$0" | sed '1d;$d'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$TAXONOMY_FILE" ]]; then
+    echo "Error: taxonomy file not found: $TAXONOMY_FILE" >&2
+    exit 1
+fi
+
+# ── Parse TOML ───────────────────────────────────────────────────────────────
+# Minimal parser: extracts name/description/color from [[labels]] blocks.
+
+NAMES=()
+DESCRIPTIONS=()
+COLORS=()
+
+current_name=""
+current_desc=""
+current_color=""
+
+flush_label() {
+    if [[ -n "$current_name" ]]; then
+        NAMES+=("$current_name")
+        DESCRIPTIONS+=("$current_desc")
+        COLORS+=("$current_color")
+    fi
+    current_name=""
+    current_desc=""
+    current_color=""
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+
+    if [[ "$line" =~ ^\[\[labels\]\] ]]; then
+        flush_label
+        continue
+    fi
+
+    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_name="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^description[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_desc="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ ^color[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+        current_color="${BASH_REMATCH[1]}"
+    fi
+done < "$TAXONOMY_FILE"
+flush_label
+
+echo "Taxonomy: ${#NAMES[@]} labels defined in $(basename "$TAXONOMY_FILE")"
+
+# ── Fetch existing labels ────────────────────────────────────────────────────
+
+mapfile -t EXISTING < <(gh label list "${REPO_ARGS[@]}" --limit 100 --json name --jq '.[].name')
+
+echo "Remote:   ${#EXISTING[@]} labels on repo"
+echo ""
+
+# ── Create / update ──────────────────────────────────────────────────────────
+
+for i in "${!NAMES[@]}"; do
+    name="${NAMES[$i]}"
+    desc="${DESCRIPTIONS[$i]}"
+    color="${COLORS[$i]}"
+
+    found=false
+    for existing in "${EXISTING[@]}"; do
+        if [[ "$existing" == "$name" ]]; then
+            found=true
+            break
+        fi
+    done
+
+    if $found; then
+        if $DRY_RUN; then
+            echo "[DRY-RUN]  update  $name"
+        else
+            gh label edit "$name" --description "$desc" --color "$color" "${REPO_ARGS[@]}"
+            echo "[UPDATED]  $name"
+        fi
+    else
+        if $DRY_RUN; then
+            echo "[DRY-RUN]  create  $name"
+        else
+            gh label create "$name" --description "$desc" --color "$color" "${REPO_ARGS[@]}"
+            echo "[CREATED]  $name"
+        fi
+    fi
+done
+
+# ── Prune ────────────────────────────────────────────────────────────────────
+
+if $PRUNE; then
+    for existing in "${EXISTING[@]}"; do
+        is_canonical=false
+        for name in "${NAMES[@]}"; do
+            if [[ "$existing" == "$name" ]]; then
+                is_canonical=true
+                break
+            fi
+        done
+
+        if ! $is_canonical; then
+            if $DRY_RUN; then
+                echo "[DRY-RUN]  delete  $existing"
+            else
+                gh label delete "$existing" --yes "${REPO_ARGS[@]}"
+                echo "[DELETED]  $existing"
+            fi
+        fi
+    done
+fi
+
+echo ""
+echo "Done."

--- a/scripts/spike_chunk_hash.py
+++ b/scripts/spike_chunk_hash.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Spike #24 — Inline SHA-256 hashing during h5py chunked writes.
+
+Tests two approaches:
+  1. write_direct_chunk(): write pre-serialised chunks with known boundaries.
+  2. Standard chunked writes with pre-hash of each chunk slice.
+
+Measures SHA-256 overhead on a realistic chunk size (1 slice of 512×512 float32 ≈ 1 MB).
+
+Usage:
+    python scripts/spike_chunk_hash.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+ROWS = 512
+COLS = 512
+NUM_SLICES = 64
+DTYPE = np.float32
+CHUNK_SHAPE = (1, ROWS, COLS)  # 1 slice per chunk ≈ 1 MiB
+DATASET_SHAPE = (NUM_SLICES, ROWS, COLS)
+
+
+@dataclass
+class BenchResult:
+    label: str
+    write_s: float = 0.0
+    hash_s: float = 0.0
+    total_s: float = 0.0
+    chunk_hashes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Approach 1: write_direct_chunk() with inline SHA-256
+# ---------------------------------------------------------------------------
+def approach_write_direct_chunk(path: Path) -> BenchResult:
+    """Write raw (uncompressed) chunks via write_direct_chunk and hash each."""
+    result = BenchResult(label="write_direct_chunk")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+            raw = chunk.tobytes()
+
+            t_h0 = time.perf_counter()
+            digest = hashlib.sha256(raw).hexdigest()
+            t_h1 = time.perf_counter()
+            result.hash_s += t_h1 - t_h0
+            result.chunk_hashes.append(digest)
+
+            t_w0 = time.perf_counter()
+            ds.id.write_direct_chunk((i, 0, 0), raw)
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Approach 2: standard chunked write with pre-hash of each slice
+# ---------------------------------------------------------------------------
+def approach_standard_chunked(path: Path) -> BenchResult:
+    """Write via normal slice assignment, hashing each slice before write."""
+    result = BenchResult(label="standard_chunked (pre-hash)")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+
+            t_h0 = time.perf_counter()
+            digest = hashlib.sha256(chunk.tobytes()).hexdigest()
+            t_h1 = time.perf_counter()
+            result.hash_s += t_h1 - t_h0
+            result.chunk_hashes.append(digest)
+
+            t_w0 = time.perf_counter()
+            ds[i : i + 1, :, :] = chunk
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Baseline: standard chunked write, NO hashing
+# ---------------------------------------------------------------------------
+def baseline_no_hash(path: Path) -> BenchResult:
+    """Write via normal slice assignment, no hashing (baseline)."""
+    result = BenchResult(label="standard_chunked (no hash)")
+    rng = np.random.default_rng(42)
+
+    t0 = time.perf_counter()
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset(
+            "data",
+            shape=DATASET_SHAPE,
+            dtype=DTYPE,
+            chunks=CHUNK_SHAPE,
+            compression=None,
+        )
+
+        for i in range(NUM_SLICES):
+            chunk = rng.standard_normal(CHUNK_SHAPE, dtype=DTYPE)
+
+            t_w0 = time.perf_counter()
+            ds[i : i + 1, :, :] = chunk
+            t_w1 = time.perf_counter()
+            result.write_s += t_w1 - t_w0
+
+    result.total_s = time.perf_counter() - t0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Verification: read back and re-hash to confirm data integrity
+# ---------------------------------------------------------------------------
+def verify_hashes(path: Path, expected: list[str]) -> bool:
+    """Re-read each chunk and verify SHA-256 matches."""
+    with h5py.File(path, "r") as f:
+        ds = f["data"]
+        for i, expected_hash in enumerate(expected):
+            raw = ds[i : i + 1, :, :].tobytes()
+            actual = hashlib.sha256(raw).hexdigest()
+            if actual != expected_hash:
+                print(f"  MISMATCH at slice {i}: {actual} != {expected_hash}")
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+def print_report(results: list[BenchResult]) -> None:
+    chunk_bytes = int(np.prod(CHUNK_SHAPE)) * np.dtype(DTYPE).itemsize
+    total_bytes = chunk_bytes * NUM_SLICES
+    total_mib = total_bytes / (1024 * 1024)
+
+    print("=" * 72)
+    print("Spike #24 — Inline SHA-256 hashing during h5py chunked writes")
+    print(f"  Shape: {DATASET_SHAPE}  dtype={DTYPE.__name__}")
+    print(f"  Chunk: {CHUNK_SHAPE}  ({chunk_bytes / 1024:.0f} KiB per chunk)")
+    print(f"  Total: {NUM_SLICES} chunks, {total_mib:.1f} MiB")
+    print("=" * 72)
+
+    for r in results:
+        hash_pct = (r.hash_s / r.total_s * 100) if r.total_s > 0 else 0
+        throughput = total_mib / r.total_s if r.total_s > 0 else 0
+        print(f"\n  {r.label}")
+        print(f"    write:      {r.write_s * 1000:8.1f} ms")
+        print(f"    SHA-256:    {r.hash_s * 1000:8.1f} ms  ({hash_pct:.1f}% of total)")
+        print(f"    total:      {r.total_s * 1000:8.1f} ms")
+        print(f"    throughput: {throughput:8.1f} MiB/s")
+
+    print("\n" + "=" * 72)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> None:
+    results: list[BenchResult] = []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        # Approach 1: write_direct_chunk
+        p1 = tmp / "direct_chunk.h5"
+        r1 = approach_write_direct_chunk(p1)
+        results.append(r1)
+
+        # Approach 2: standard chunked with pre-hash
+        p2 = tmp / "standard_chunked.h5"
+        r2 = approach_standard_chunked(p2)
+        results.append(r2)
+
+        # Baseline: no hash
+        p3 = tmp / "baseline.h5"
+        r3 = baseline_no_hash(p3)
+        results.append(r3)
+
+        print_report(results)
+
+        # Verify data integrity for hashed approaches
+        print("\nVerification (read-back SHA-256 check):")
+        # write_direct_chunk writes raw bytes; read-back via h5py slice
+        # should yield identical bytes for uncompressed data.
+        ok1 = verify_hashes(p1, r1.chunk_hashes)
+        print(f"  write_direct_chunk:       {'PASS' if ok1 else 'FAIL'}")
+
+        ok2 = verify_hashes(p2, r2.chunk_hashes)
+        print(f"  standard_chunked:         {'PASS' if ok2 else 'FAIL'}")
+
+        # Both approaches used same RNG seed — hashes must match
+        hashes_match = r1.chunk_hashes == r2.chunk_hashes
+        print(f"  cross-approach hash match: {'PASS' if hashes_match else 'FAIL'}")
+
+    print("\nConclusion:")
+    hash_overhead_pct = (r2.hash_s / r3.total_s * 100) if r3.total_s > 0 else 0
+    print(f"  SHA-256 adds ~{hash_overhead_pct:.1f}% overhead vs no-hash baseline.")
+    print("  write_direct_chunk gives explicit control over chunk boundaries.")
+    print("  Standard chunked write + pre-hash is simpler and equally correct")
+    print("  for uncompressed data when chunk shape == slice shape.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -1,0 +1,9 @@
+"""fd5 command-line interface."""
+
+import click
+
+
+@click.group()
+@click.version_option(package_name="fd5")
+def cli() -> None:
+    """fd5 – Fusion Data Format 5 toolkit."""

--- a/src/fd5/h5io.py
+++ b/src/fd5/h5io.py
@@ -1,0 +1,105 @@
+"""fd5.h5io — lossless round-trip between Python dicts and HDF5 groups/attrs.
+
+Type mapping follows white-paper.md § Implementation Notes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+def dict_to_h5(group: h5py.Group, d: dict[str, Any]) -> None:
+    """Write a Python dict as HDF5 attributes and sub-groups.
+
+    Keys are written in sorted order for deterministic layout.
+    ``None`` values are skipped (absence encodes None).
+    """
+    for key in sorted(d.keys()):
+        value = d[key]
+        if value is None:
+            continue
+        _write_value(group, key, value)
+
+
+def h5_to_dict(group: h5py.Group) -> dict[str, Any]:
+    """Read HDF5 attrs and sub-groups back to a Python dict.
+
+    Datasets are never read — only attributes and groups.
+    """
+    result: dict[str, Any] = {}
+    for key in sorted(group.attrs.keys()):
+        result[key] = _read_attr(group.attrs[key])
+    for key in sorted(group.keys()):
+        item = group[key]
+        if isinstance(item, h5py.Group):
+            result[key] = h5_to_dict(item)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_value(group: h5py.Group, key: str, value: Any) -> None:
+    if isinstance(value, dict):
+        sub = group.create_group(key)
+        dict_to_h5(sub, value)
+    elif isinstance(value, bool):
+        group.attrs[key] = np.bool_(value)
+    elif isinstance(value, int):
+        group.attrs[key] = np.int64(value)
+    elif isinstance(value, float):
+        group.attrs[key] = np.float64(value)
+    elif isinstance(value, str):
+        group.attrs[key] = value
+    elif isinstance(value, list):
+        _write_list(group, key, value)
+    else:
+        raise TypeError(f"Unsupported type {type(value).__name__!r} for key {key!r}")
+
+
+def _write_list(group: h5py.Group, key: str, lst: list[Any]) -> None:
+    if len(lst) == 0:
+        group.attrs.create(key, data=np.array([], dtype=np.float64))
+        return
+
+    first = lst[0]
+    if isinstance(first, bool):
+        group.attrs[key] = np.array(lst, dtype=np.bool_)
+    elif isinstance(first, (int, float)):
+        group.attrs[key] = np.array(lst)
+    elif isinstance(first, str):
+        dt = h5py.special_dtype(vlen=str)
+        group.attrs.create(key, data=lst, dtype=dt)
+    else:
+        raise TypeError(
+            f"Unsupported type {type(first).__name__!r} in list for key {key!r}"
+        )
+
+
+def _read_attr(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, np.ndarray):
+        return _read_array(value)
+    return value
+
+
+def _read_array(arr: np.ndarray) -> list[Any]:
+    if arr.dtype.kind in ("U", "S", "O"):
+        return [str(v) for v in arr]
+    if arr.dtype == np.bool_:
+        return [bool(v) for v in arr]
+    return arr.tolist()

--- a/src/fd5/hash.py
+++ b/src/fd5/hash.py
@@ -1,0 +1,173 @@
+"""fd5.hash — id computation, Merkle tree hashing, and integrity verification.
+
+Implements the content_hash computation described in white-paper.md
+§ content_hash computation — Merkle tree with per-chunk hashing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Union
+
+import h5py
+import numpy as np
+
+_CHUNK_HASHES_SUFFIX = "_chunk_hashes"
+_EXCLUDED_ATTRS = frozenset({"content_hash"})
+
+
+# ---------------------------------------------------------------------------
+# id computation
+# ---------------------------------------------------------------------------
+
+
+def compute_id(inputs: dict[str, str], id_inputs_desc: str) -> str:
+    """Compute ``sha256:...`` identity hash from *inputs* joined with ``\\0``.
+
+    Keys are sorted for determinism.  *id_inputs_desc* is the human-readable
+    description stored alongside the hash (not used in the hash itself).
+    """
+    payload = "\0".join(inputs[k] for k in sorted(inputs))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# ChunkHasher — per-chunk SHA-256 accumulator
+# ---------------------------------------------------------------------------
+
+
+class ChunkHasher:
+    """Accumulates per-chunk SHA-256 hashes during streaming writes."""
+
+    def __init__(self) -> None:
+        self._digests: list[str] = []
+
+    def update(self, chunk: np.ndarray) -> None:
+        """Hash *chunk* (row-major ``tobytes()``) and store the digest."""
+        self._digests.append(hashlib.sha256(chunk.tobytes()).hexdigest())
+
+    def digests(self) -> list[str]:
+        """Return the list of per-chunk hex digests accumulated so far."""
+        return list(self._digests)
+
+    def dataset_hash(self) -> str:
+        """Compute the dataset-level hash from accumulated chunk hashes.
+
+        ``sha256(chunk_hash_0 + chunk_hash_1 + ...)``
+        """
+        if not self._digests:
+            raise ValueError("Cannot compute dataset_hash: no chunks recorded")
+        concatenated = "".join(self._digests)
+        return hashlib.sha256(concatenated.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# MerkleTree — bottom-up hash of an HDF5 file
+# ---------------------------------------------------------------------------
+
+
+def _is_chunk_hashes_dataset(name: str) -> bool:
+    return name.endswith(_CHUNK_HASHES_SUFFIX)
+
+
+def _serialize_attr(value: object) -> bytes:
+    """Deterministic byte serialisation of a single HDF5 attribute value."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    if isinstance(value, np.ndarray):
+        return value.tobytes()
+    if isinstance(value, (np.generic,)):
+        return np.array(value).tobytes()
+    return str(value).encode("utf-8")
+
+
+def _sorted_attrs_hash(obj: h5py.Group | h5py.Dataset) -> str:
+    """``sha256(sha256(key + serialize(val)) for key in sorted(attrs))``."""
+    h = hashlib.sha256()
+    for key in sorted(obj.attrs.keys()):
+        if key in _EXCLUDED_ATTRS:
+            continue
+        inner = hashlib.sha256(
+            key.encode("utf-8") + _serialize_attr(obj.attrs[key])
+        ).hexdigest()
+        h.update(inner.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _dataset_hash(ds: h5py.Dataset) -> str:
+    """Hash a dataset: read all data as contiguous row-major bytes.
+
+    For chunked datasets the result is identical to hashing the whole
+    array because ``ds[...].tobytes()`` always returns row-major bytes
+    regardless of on-disk chunk layout.  Dataset attributes are hashed
+    separately via the group-level Merkle node.
+    """
+    data_hash = hashlib.sha256(ds[...].tobytes()).hexdigest()
+    attrs_h = _sorted_attrs_hash(ds)
+    return hashlib.sha256((attrs_h + data_hash).encode("utf-8")).hexdigest()
+
+
+def _group_hash(group: h5py.Group) -> str:
+    """Recursively compute the Merkle hash of *group*.
+
+    ``sha256(sorted_attrs_hash + child_hashes)`` where children are
+    processed in sorted key order, ``_chunk_hashes`` datasets are excluded.
+    """
+    h = hashlib.sha256()
+    h.update(_sorted_attrs_hash(group).encode("utf-8"))
+
+    for key in sorted(group.keys()):
+        if _is_chunk_hashes_dataset(key):
+            continue
+        child = group[key]
+        if isinstance(child, h5py.Group):
+            h.update(_group_hash(child).encode("utf-8"))
+        elif isinstance(child, h5py.Dataset):
+            h.update(_dataset_hash(child).encode("utf-8"))
+
+    return h.hexdigest()
+
+
+class MerkleTree:
+    """Computes the Merkle root hash of an HDF5 file/group.
+
+    Follows the algorithm in white-paper.md § File-level Merkle tree:
+    ``content_hash = sha256(root_group_hash)``.
+    """
+
+    def __init__(self, root: h5py.File | h5py.Group) -> None:
+        self._root = root
+
+    def root_hash(self) -> str:
+        """Return the 64-char hex Merkle root."""
+        return hashlib.sha256(_group_hash(self._root).encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_content_hash(root: h5py.File | h5py.Group) -> str:
+    """Return the algorithm-prefixed content hash: ``sha256:<hex>``."""
+    return f"sha256:{MerkleTree(root).root_hash()}"
+
+
+def verify(path: Union[str, Path]) -> bool:
+    """Recompute the Merkle tree and compare with the stored ``content_hash``.
+
+    Returns ``True`` if the hashes match, ``False`` otherwise (including
+    when ``content_hash`` is missing).
+    """
+    path = Path(path)
+    with h5py.File(path, "r") as f:
+        stored = f.attrs.get("content_hash")
+        if stored is None:
+            return False
+        if isinstance(stored, bytes):
+            stored = stored.decode("utf-8")
+        return compute_content_hash(f) == stored

--- a/src/fd5/imaging/__init__.py
+++ b/src/fd5/imaging/__init__.py
@@ -1,0 +1,1 @@
+"""fd5.imaging — medical imaging domain schemas for fd5."""

--- a/src/fd5/imaging/recon.py
+++ b/src/fd5/imaging/recon.py
@@ -1,0 +1,238 @@
+"""fd5.imaging.recon — Recon product schema for reconstructed image volumes.
+
+Implements the ``recon`` product schema per white-paper.md § recon.
+Handles 3D/4D/5D float32 volumes with multiscale pyramids, MIP projections,
+dynamic frames, affine transforms, and chunked gzip compression.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+_SCHEMA_VERSION = "1.0.0"
+
+_GZIP_LEVEL = 4
+
+_ID_INPUTS = ["timestamp", "scanner", "vendor_series_id"]
+
+
+class ReconSchema:
+    """Product schema for reconstructed image volumes (``recon``)."""
+
+    product_type: str = "recon"
+    schema_version: str = _SCHEMA_VERSION
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "recon"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "domain": {"type": "string"},
+                "volume": {
+                    "type": "object",
+                    "description": "Root-level volume dataset (represented as attrs in h5_to_dict)",
+                },
+            },
+            "required": ["_schema_version", "product", "name", "description"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {
+            "product": "recon",
+            "domain": "medical_imaging",
+        }
+
+    def id_inputs(self) -> list[str]:
+        return list(_ID_INPUTS)
+
+    def write(self, target: h5py.File | h5py.Group, data: dict[str, Any]) -> None:
+        """Write recon data to *target*.
+
+        *data* must contain:
+        - ``volume``: numpy float32 array (3D, 4D, or 5D)
+        - ``affine``: float64 (4, 4) spatial affine matrix
+        - ``dimension_order``: str (e.g. ``"ZYX"``, ``"TZYX"``)
+        - ``reference_frame``: str (e.g. ``"LPS"``)
+        - ``description``: str describing the volume
+
+        Optional keys:
+        - ``frames``: dict with frame timing for 4D+ data
+        - ``pyramid``: dict with ``scale_factors`` and ``method``
+        """
+        volume = data["volume"]
+        self._write_volume(target, volume, data)
+
+        spatial_vol = _spatial_volume(volume, data["dimension_order"])
+
+        if "frames" in data:
+            self._write_frames(target, data["frames"])
+
+        if "pyramid" in data:
+            self._write_pyramid(target, spatial_vol, data)
+
+        self._write_mips(target, spatial_vol)
+
+    # ------------------------------------------------------------------
+    # Volume
+    # ------------------------------------------------------------------
+
+    def _write_volume(
+        self,
+        target: h5py.File | h5py.Group,
+        volume: np.ndarray,
+        data: dict[str, Any],
+    ) -> None:
+        ndim = volume.ndim
+        chunks = (1,) * (ndim - 2) + volume.shape[-2:]
+        ds = target.create_dataset(
+            "volume",
+            data=volume,
+            chunks=chunks,
+            compression="gzip",
+            compression_opts=_GZIP_LEVEL,
+        )
+        ds.attrs["affine"] = data["affine"]
+        ds.attrs["dimension_order"] = data["dimension_order"]
+        ds.attrs["reference_frame"] = data["reference_frame"]
+        ds.attrs["description"] = data["description"]
+
+    # ------------------------------------------------------------------
+    # Frames (4D+ data)
+    # ------------------------------------------------------------------
+
+    def _write_frames(
+        self,
+        target: h5py.File | h5py.Group,
+        frames: dict[str, Any],
+    ) -> None:
+        grp = target.create_group("frames")
+        grp.attrs["n_frames"] = np.int64(frames["n_frames"])
+        grp.attrs["frame_type"] = frames["frame_type"]
+        grp.attrs["description"] = frames["description"]
+
+        grp.create_dataset(
+            "frame_start",
+            data=np.asarray(frames["frame_start"], dtype=np.float64),
+        )
+        grp["frame_start"].attrs["units"] = "s"
+        grp["frame_start"].attrs["unitSI"] = np.float64(1.0)
+        grp["frame_start"].attrs["description"] = (
+            "Start time of each frame relative to reference"
+        )
+
+        grp.create_dataset(
+            "frame_duration",
+            data=np.asarray(frames["frame_duration"], dtype=np.float64),
+        )
+        grp["frame_duration"].attrs["units"] = "s"
+        grp["frame_duration"].attrs["unitSI"] = np.float64(1.0)
+        grp["frame_duration"].attrs["description"] = (
+            "Duration of each frame (non-uniform allowed)"
+        )
+
+        if "frame_label" in frames:
+            labels = frames["frame_label"]
+            dt = h5py.special_dtype(vlen=str)
+            grp.create_dataset("frame_label", data=labels, dtype=dt)
+            grp["frame_label"].attrs["description"] = "Human-readable label per frame"
+
+    # ------------------------------------------------------------------
+    # Pyramid
+    # ------------------------------------------------------------------
+
+    def _write_pyramid(
+        self,
+        target: h5py.File | h5py.Group,
+        spatial_vol: np.ndarray,
+        data: dict[str, Any],
+    ) -> None:
+        pyramid_cfg = data["pyramid"]
+        scale_factors = pyramid_cfg["scale_factors"]
+        method = pyramid_cfg["method"]
+
+        grp = target.create_group("pyramid")
+        grp.attrs["n_levels"] = np.int64(len(scale_factors))
+        grp.attrs["scale_factors"] = np.array(scale_factors, dtype=np.int64)
+        grp.attrs["method"] = method
+        grp.attrs["description"] = (
+            "Multiscale pyramid for progressive-resolution access"
+        )
+
+        affine = data["affine"]
+
+        for i, factor in enumerate(scale_factors, start=1):
+            level_vol = _downsample(spatial_vol, factor)
+            level_affine = _scale_affine(affine, factor)
+
+            level_grp = grp.create_group(f"level_{i}")
+            chunks = (1,) + level_vol.shape[1:]
+            ds = level_grp.create_dataset(
+                "volume",
+                data=level_vol,
+                chunks=chunks,
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            ds.attrs["affine"] = level_affine
+            ds.attrs["scale_factor"] = np.int64(factor)
+            ds.attrs["description"] = f"{factor}x downsampled volume"
+
+    # ------------------------------------------------------------------
+    # MIP projections
+    # ------------------------------------------------------------------
+
+    def _write_mips(
+        self,
+        target: h5py.File | h5py.Group,
+        spatial_vol: np.ndarray,
+    ) -> None:
+        # Coronal: project along Y (axis=1) → shape (Z, X)
+        mip_cor = spatial_vol.max(axis=1).astype(np.float32)
+        ds_cor = target.create_dataset("mip_coronal", data=mip_cor)
+        ds_cor.attrs["projection_type"] = "mip"
+        ds_cor.attrs["axis"] = np.int64(1)
+        ds_cor.attrs["description"] = "Coronal MIP (summed over all frames if dynamic)"
+
+        # Sagittal: project along X (axis=2) → shape (Z, Y)
+        mip_sag = spatial_vol.max(axis=2).astype(np.float32)
+        ds_sag = target.create_dataset("mip_sagittal", data=mip_sag)
+        ds_sag.attrs["projection_type"] = "mip"
+        ds_sag.attrs["axis"] = np.int64(2)
+        ds_sag.attrs["description"] = "Sagittal MIP (summed over all frames if dynamic)"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spatial_volume(volume: np.ndarray, dimension_order: str) -> np.ndarray:
+    """Extract or derive the 3D spatial volume for MIP / pyramid computation.
+
+    For 4D+ data, sum over all leading (non-spatial) dimensions.
+    """
+    n_spatial = 3  # Z, Y, X
+    n_leading = volume.ndim - n_spatial
+    result = volume
+    for _ in range(n_leading):
+        result = result.sum(axis=0)
+    return result.astype(np.float32)
+
+
+def _downsample(vol: np.ndarray, factor: int) -> np.ndarray:
+    """Downsample a 3D volume by *factor* using stride-based subsampling."""
+    return vol[::factor, ::factor, ::factor].copy()
+
+
+def _scale_affine(affine: np.ndarray, factor: int) -> np.ndarray:
+    """Scale the spatial part of an affine matrix by *factor*."""
+    scaled = affine.copy()
+    scaled[:3, :3] *= factor
+    return scaled

--- a/src/fd5/manifest.py
+++ b/src/fd5/manifest.py
@@ -1,0 +1,89 @@
+"""fd5.manifest — TOML manifest generation and parsing.
+
+Scans a directory of fd5 HDF5 files, extracts root attributes,
+and writes/reads a ``manifest.toml`` index.  See white-paper.md § manifest.toml.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import h5py
+import tomli_w
+
+from fd5.h5io import h5_to_dict
+
+_MANIFEST_SCHEMA_VERSION = 1
+
+_EXCLUDED_DATA_ATTRS = frozenset(
+    {
+        "_schema",
+        "_schema_version",
+        "content_hash",
+        "id_inputs",
+        "name",
+        "description",
+    }
+)
+
+
+def build_manifest(directory: Path) -> dict[str, Any]:
+    """Scan ``.h5`` files in *directory* and build a manifest dict.
+
+    Files are iterated lazily via ``Path.glob``.  Dataset-level metadata
+    (``study``, ``subject``) is taken from the first file that contains them.
+    """
+    manifest: dict[str, Any] = {
+        "_schema_version": _MANIFEST_SCHEMA_VERSION,
+        "dataset_name": directory.name,
+    }
+    data_entries: list[dict[str, Any]] = []
+
+    for h5_path in sorted(directory.glob("*.h5")):
+        with h5py.File(h5_path, "r") as f:
+            root_attrs = h5_to_dict(f)
+
+            _extract_dataset_metadata(manifest, f)
+
+            entry = _build_data_entry(root_attrs, h5_path.name)
+            data_entries.append(entry)
+
+    manifest["data"] = data_entries
+    return manifest
+
+
+def write_manifest(directory: Path, output_path: Path) -> None:
+    """Build a manifest from *directory* and write it as TOML to *output_path*."""
+    manifest = build_manifest(directory)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(tomli_w.dumps(manifest).encode())
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    """Parse an existing ``manifest.toml`` and return the dict."""
+    return tomllib.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_dataset_metadata(manifest: dict[str, Any], f: h5py.File) -> None:
+    """Extract study/subject groups from the HDF5 file into the manifest (once)."""
+    if "study" not in manifest and "study" in f:
+        manifest["study"] = h5_to_dict(f["study"])
+    if "subject" not in manifest and "subject" in f:
+        manifest["subject"] = h5_to_dict(f["subject"])
+
+
+def _build_data_entry(root_attrs: dict[str, Any], filename: str) -> dict[str, Any]:
+    """Build a single ``[[data]]`` entry from root attributes."""
+    entry: dict[str, Any] = {}
+    for key, value in root_attrs.items():
+        if key not in _EXCLUDED_DATA_ATTRS and not isinstance(value, dict):
+            entry[key] = value
+    entry["file"] = filename
+    return entry

--- a/src/fd5/naming.py
+++ b/src/fd5/naming.py
@@ -1,0 +1,44 @@
+"""Filename generation following the fd5 naming convention.
+
+See white-paper.md § File Naming Convention.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+_SHA256_PREFIX = "sha256:"
+_ID_HEX_LENGTH = 8
+_EXTENSION = ".h5"
+_TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
+
+def generate_filename(
+    product: str,
+    id_hash: str,
+    timestamp: datetime | None,
+    descriptors: list[str],
+) -> str:
+    """Generate an fd5-compliant filename.
+
+    Format: ``YYYY-MM-DD_HH-MM-SS_<product>-<id>_<descriptors>.h5``
+
+    When *timestamp* is ``None`` the datetime prefix is omitted.
+    The *id_hash* is truncated to the first 8 hex characters; a
+    ``sha256:`` prefix is stripped automatically if present.
+    """
+    short_id = _truncate_id(id_hash)
+    parts: list[str] = []
+
+    if timestamp is not None:
+        parts.append(timestamp.strftime(_TIMESTAMP_FORMAT))
+
+    parts.append(f"{product}-{short_id}")
+    parts.extend(descriptors)
+
+    return "_".join(parts) + _EXTENSION
+
+
+def _truncate_id(id_hash: str) -> str:
+    raw = id_hash.removeprefix(_SHA256_PREFIX)
+    return raw[:_ID_HEX_LENGTH]

--- a/src/fd5/provenance.py
+++ b/src/fd5/provenance.py
@@ -1,0 +1,120 @@
+"""fd5.provenance — writers for sources/ and provenance/ groups.
+
+Implements the provenance DAG (sources/ with HDF5 external links) and
+original-file tracking (provenance/original_files compound dataset,
+provenance/ingest/ attrs) per white-paper.md §§ sources/ group, provenance/ group.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+from fd5.h5io import dict_to_h5
+
+_SOURCES_DESCRIPTION = "Data products this file was derived from"
+_PROVENANCE_DESCRIPTION = (
+    "Provenance of the original source files ingested into this product"
+)
+_INGEST_DESCRIPTION = "Ingest pipeline that created this file"
+
+_SOURCE_ATTR_KEYS = ("id", "product", "file", "content_hash", "role", "description")
+
+
+def write_sources(
+    file: h5py.File,
+    sources: list[dict[str, Any]],
+) -> None:
+    """Create ``sources/`` group with per-source sub-groups, attrs, and external links.
+
+    Each dict in *sources* must contain ``name`` (used as the sub-group key)
+    plus ``id``, ``product``, ``file``, ``content_hash``, ``role``, and
+    ``description``.  The ``file`` value is used as a relative-path HDF5
+    external link targeting ``"/"``.
+    """
+    if "sources" in file:
+        raise ValueError("sources/ group already exists")
+
+    grp = file.create_group("sources")
+    grp.attrs["description"] = _SOURCES_DESCRIPTION
+
+    for src in sources:
+        name = src["name"]
+        attrs = {k: src[k] for k in _SOURCE_ATTR_KEYS}
+        sub = grp.create_group(name)
+        dict_to_h5(sub, attrs)
+        sub["link"] = h5py.ExternalLink(src["file"], "/")
+
+
+def write_original_files(
+    file: h5py.File,
+    records: list[dict[str, Any]],
+) -> None:
+    """Create ``provenance/original_files`` compound dataset.
+
+    Each dict in *records* must contain ``path`` (str), ``sha256`` (str),
+    and ``size_bytes`` (int).
+    """
+    prov = _ensure_provenance(file)
+
+    if "original_files" in prov:
+        raise ValueError("provenance/original_files already exists")
+
+    dt = np.dtype(
+        [
+            ("path", h5py.string_dtype()),
+            ("sha256", h5py.string_dtype()),
+            ("size_bytes", np.int64),
+        ]
+    )
+
+    if len(records) == 0:
+        prov.create_dataset("original_files", shape=(0,), dtype=dt)
+        return
+
+    data = np.array(
+        [(r["path"], r["sha256"], r["size_bytes"]) for r in records],
+        dtype=dt,
+    )
+    prov.create_dataset("original_files", data=data)
+
+
+def write_ingest(
+    file: h5py.File,
+    *,
+    tool: str,
+    version: str,
+    timestamp: str,
+) -> None:
+    """Create ``provenance/ingest/`` group with tool, version, timestamp attrs."""
+    prov = _ensure_provenance(file)
+
+    if "ingest" in prov:
+        raise ValueError("provenance/ingest/ already exists")
+
+    ingest = prov.create_group("ingest")
+    dict_to_h5(
+        ingest,
+        {
+            "description": _INGEST_DESCRIPTION,
+            "timestamp": timestamp,
+            "tool": tool,
+            "tool_version": version,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_provenance(file: h5py.File) -> h5py.Group:
+    """Return the ``provenance/`` group, creating it if absent."""
+    if "provenance" not in file:
+        grp = file.create_group("provenance")
+        grp.attrs["description"] = _PROVENANCE_DESCRIPTION
+        return grp
+    return file["provenance"]

--- a/src/fd5/registry.py
+++ b/src/fd5/registry.py
@@ -1,0 +1,83 @@
+"""Product schema registry with entry-point discovery.
+
+Discovers product schemas from ``importlib.metadata`` entry points
+(group ``fd5.schemas``), allows lookup by product-type string, and
+provides a ``register_schema`` escape-hatch for testing.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ProductSchema(Protocol):
+    """Structural interface every product schema must satisfy."""
+
+    product_type: str
+    schema_version: str
+
+    def json_schema(self) -> dict[str, Any]: ...
+    def required_root_attrs(self) -> dict[str, Any]: ...
+    def write(self, target: Any, data: Any) -> None: ...
+    def id_inputs(self) -> list[str]: ...
+
+
+_registry: dict[str, ProductSchema] = {}
+_ep_loaded: bool = False
+
+_EP_GROUP = "fd5.schemas"
+
+
+def _load_entry_points() -> dict[str, ProductSchema]:
+    """Load all entry points in the ``fd5.schemas`` group.
+
+    Each entry point must be a callable returning a ``ProductSchema``
+    instance.  The entry-point *name* is used as the product-type key.
+    """
+    schemas: dict[str, ProductSchema] = {}
+    for ep in importlib.metadata.entry_points(group=_EP_GROUP):
+        factory = ep.load()
+        schemas[ep.name] = factory()
+    return schemas
+
+
+def _load_and_merge() -> None:
+    """Merge entry-point schemas into the registry (once)."""
+    global _ep_loaded  # noqa: PLW0603
+    ep_schemas = _load_entry_points()
+    for name, schema in ep_schemas.items():
+        _registry.setdefault(name, schema)
+    _ep_loaded = True
+
+
+def _ensure_loaded() -> None:
+    if not _ep_loaded:
+        _load_and_merge()
+
+
+def register_schema(product_type: str, schema: ProductSchema) -> None:
+    """Register *schema* under *product_type* (overwrites existing)."""
+    _registry[product_type] = schema
+
+
+def get_schema(product_type: str) -> ProductSchema:
+    """Return the schema registered for *product_type*.
+
+    Raises:
+        ValueError: If no schema is registered for *product_type*.
+    """
+    _ensure_loaded()
+    try:
+        return _registry[product_type]
+    except KeyError:
+        raise ValueError(
+            f"No schema registered for product type {product_type!r}"
+        ) from None
+
+
+def list_schemas() -> list[str]:
+    """Return all registered product-type strings."""
+    _ensure_loaded()
+    return list(_registry)

--- a/src/fd5/schema.py
+++ b/src/fd5/schema.py
@@ -1,0 +1,19 @@
+"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files."""
+
+from __future__ import annotations
+
+
+def embed_schema(file, schema_dict, *, schema_version=1):
+    raise NotImplementedError
+
+
+def dump_schema(path):
+    raise NotImplementedError
+
+
+def validate(path):
+    raise NotImplementedError
+
+
+def generate_schema(product_type):
+    raise NotImplementedError

--- a/src/fd5/schema.py
+++ b/src/fd5/schema.py
@@ -1,19 +1,70 @@
-"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files."""
+"""fd5.schema — embed, validate, dump, and generate JSON Schema for fd5 files.
+
+Stores ``_schema`` as a JSON string attribute at file root for single-read
+self-description (see white-paper.md § 9).
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
 
-def embed_schema(file, schema_dict, *, schema_version=1):
-    raise NotImplementedError
+import h5py
+import jsonschema
+import numpy as np
+
+from fd5.h5io import h5_to_dict
+from fd5.registry import get_schema
 
 
-def dump_schema(path):
-    raise NotImplementedError
+def embed_schema(
+    file: h5py.File,
+    schema_dict: dict[str, Any],
+    *,
+    schema_version: int = 1,
+) -> None:
+    """Write ``_schema`` (JSON string) and ``_schema_version`` (int) to *file* root."""
+    file.attrs["_schema"] = json.dumps(schema_dict, separators=(",", ":"))
+    file.attrs["_schema_version"] = np.int64(schema_version)
 
 
-def validate(path):
-    raise NotImplementedError
+def dump_schema(path: str | Path) -> dict[str, Any]:
+    """Extract and parse the ``_schema`` attribute from an fd5 file.
+
+    Raises:
+        KeyError: If the file has no ``_schema`` attribute.
+        json.JSONDecodeError: If the stored string is not valid JSON.
+    """
+    with h5py.File(path, "r") as f:
+        raw = f.attrs["_schema"]
+    return json.loads(raw)
 
 
-def generate_schema(product_type):
-    raise NotImplementedError
+def validate(path: str | Path) -> list[jsonschema.ValidationError]:
+    """Validate file structure against its embedded JSON Schema.
+
+    Returns a list of :class:`jsonschema.ValidationError` — empty when valid.
+
+    Raises:
+        KeyError: If the file has no ``_schema`` attribute.
+    """
+    with h5py.File(path, "r") as f:
+        raw = f.attrs["_schema"]
+        schema_dict = json.loads(raw)
+        instance = h5_to_dict(f)
+
+    validator = jsonschema.Draft202012Validator(schema_dict)
+    return list(validator.iter_errors(instance))
+
+
+def generate_schema(product_type: str) -> dict[str, Any]:
+    """Produce a JSON Schema Draft 2020-12 document for *product_type*.
+
+    Delegates to the product schema registry.
+
+    Raises:
+        ValueError: If *product_type* is not registered.
+    """
+    product_schema = get_schema(product_type)
+    return product_schema.json_schema()

--- a/src/fd5/template_project/__init__.py
+++ b/src/fd5/template_project/__init__.py
@@ -1,3 +1,0 @@
-"""fd5 - A new Python project."""
-
-__version__ = "0.1.0"

--- a/src/fd5/units.py
+++ b/src/fd5/units.py
@@ -1,0 +1,62 @@
+"""Physical units convention helpers.
+
+Implements the value/units/unitSI sub-group pattern for attributes and
+the units/unitSI attribute pattern for datasets as defined in the fd5
+white paper (see white-paper.md § Units convention).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import h5py
+    import numpy as np
+
+type Scalar = int | float
+type QuantityValue = Scalar | list[Scalar] | np.ndarray
+
+
+def write_quantity(
+    group: h5py.Group,
+    name: str,
+    value: QuantityValue,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Create a sub-group with ``value``, ``units``, and ``unitSI`` attrs.
+
+    If a sub-group with *name* already exists it is replaced.
+    """
+    if name in group:
+        del group[name]
+    sub = group.create_group(name)
+    sub.attrs["value"] = value
+    sub.attrs["units"] = units
+    sub.attrs["unitSI"] = unit_si
+
+
+def read_quantity(
+    group: h5py.Group,
+    name: str,
+) -> tuple[QuantityValue, str, float]:
+    """Read a physical quantity sub-group.
+
+    Returns:
+        ``(value, units, unit_si)`` tuple.
+
+    Raises:
+        KeyError: If *name* does not exist in *group*.
+    """
+    sub = group[name]
+    return sub.attrs["value"], sub.attrs["units"], sub.attrs["unitSI"]
+
+
+def set_dataset_units(
+    dataset: h5py.Dataset,
+    units: str,
+    unit_si: float,
+) -> None:
+    """Set ``units`` and ``unitSI`` attributes on a dataset."""
+    dataset.attrs["units"] = units
+    dataset.attrs["unitSI"] = unit_si

--- a/tests/test_h5io.py
+++ b/tests/test_h5io.py
@@ -1,0 +1,294 @@
+"""Tests for fd5.h5io — dict_to_h5 and h5_to_dict round-trip helpers."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.h5io import dict_to_h5, h5_to_dict
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def h5group(tmp_path):
+    """Yield a writable HDF5 group, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — scalar types
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Scalars:
+    def test_str(self, h5group):
+        dict_to_h5(h5group, {"name": "Alice"})
+        assert h5group.attrs["name"] == "Alice"
+
+    def test_int(self, h5group):
+        dict_to_h5(h5group, {"count": 42})
+        assert h5group.attrs["count"] == 42
+
+    def test_float(self, h5group):
+        dict_to_h5(h5group, {"ratio": 3.14})
+        assert h5group.attrs["ratio"] == pytest.approx(3.14)
+
+    def test_bool_true(self, h5group):
+        dict_to_h5(h5group, {"flag": True})
+        assert h5group.attrs["flag"] is np.True_
+
+    def test_bool_false(self, h5group):
+        dict_to_h5(h5group, {"flag": False})
+        assert h5group.attrs["flag"] is np.False_
+
+    def test_none_skipped(self, h5group):
+        dict_to_h5(h5group, {"missing": None})
+        assert "missing" not in h5group.attrs
+
+    def test_none_mixed_with_values(self, h5group):
+        dict_to_h5(h5group, {"a": 1, "b": None, "c": "hello"})
+        assert "a" in h5group.attrs
+        assert "b" not in h5group.attrs
+        assert "c" in h5group.attrs
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — nested dicts (sub-groups)
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Nested:
+    def test_nested_dict_creates_subgroup(self, h5group):
+        dict_to_h5(h5group, {"sub": {"x": 1}})
+        assert "sub" in h5group
+        assert h5group["sub"].attrs["x"] == 1
+
+    def test_deeply_nested(self, h5group):
+        dict_to_h5(h5group, {"a": {"b": {"c": 99}}})
+        assert h5group["a"]["b"].attrs["c"] == 99
+
+    def test_empty_dict_creates_empty_group(self, h5group):
+        dict_to_h5(h5group, {"empty": {}})
+        assert "empty" in h5group
+        assert len(h5group["empty"].attrs) == 0
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — sorted keys
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5SortedKeys:
+    def test_keys_written_in_sorted_order(self, h5group):
+        dict_to_h5(h5group, {"z": 1, "a": 2, "m": 3})
+        assert list(h5group.attrs.keys()) == ["a", "m", "z"]
+
+
+# ---------------------------------------------------------------------------
+# dict_to_h5 — list types
+# ---------------------------------------------------------------------------
+
+
+class TestDictToH5Lists:
+    def test_list_int(self, h5group):
+        dict_to_h5(h5group, {"vals": [1, 2, 3]})
+        result = h5group.attrs["vals"]
+        np.testing.assert_array_equal(result, [1, 2, 3])
+
+    def test_list_float(self, h5group):
+        dict_to_h5(h5group, {"vals": [1.1, 2.2, 3.3]})
+        result = h5group.attrs["vals"]
+        np.testing.assert_array_almost_equal(result, [1.1, 2.2, 3.3])
+
+    def test_list_str(self, h5group):
+        dict_to_h5(h5group, {"tags": ["a", "b", "c"]})
+        result = list(h5group.attrs["tags"])
+        assert result == ["a", "b", "c"]
+
+    def test_list_bool(self, h5group):
+        dict_to_h5(h5group, {"flags": [True, False, True]})
+        result = h5group.attrs["flags"]
+        np.testing.assert_array_equal(result, [True, False, True])
+        assert result.dtype == np.bool_
+
+    def test_empty_list(self, h5group):
+        dict_to_h5(h5group, {"empty": []})
+        result = h5group.attrs["empty"]
+        assert len(result) == 0
+
+    def test_list_mixed_numeric(self, h5group):
+        dict_to_h5(h5group, {"mixed": [1, 2.5, 3]})
+        result = h5group.attrs["mixed"]
+        np.testing.assert_array_almost_equal(result, [1, 2.5, 3])
+
+
+# ---------------------------------------------------------------------------
+# h5_to_dict — reading attrs
+# ---------------------------------------------------------------------------
+
+
+class TestH5ToDict:
+    def test_read_str(self, h5group):
+        h5group.attrs["name"] = "Alice"
+        result = h5_to_dict(h5group)
+        assert result == {"name": "Alice"}
+        assert isinstance(result["name"], str)
+
+    def test_read_int(self, h5group):
+        h5group.attrs["count"] = np.int64(42)
+        result = h5_to_dict(h5group)
+        assert result == {"count": 42}
+        assert isinstance(result["count"], int)
+
+    def test_read_float(self, h5group):
+        h5group.attrs["ratio"] = np.float64(3.14)
+        result = h5_to_dict(h5group)
+        assert result["ratio"] == pytest.approx(3.14)
+        assert isinstance(result["ratio"], float)
+
+    def test_read_bool(self, h5group):
+        h5group.attrs["flag"] = np.bool_(True)
+        result = h5_to_dict(h5group)
+        assert result == {"flag": True}
+        assert isinstance(result["flag"], bool)
+
+    def test_read_subgroup(self, h5group):
+        sub = h5group.create_group("sub")
+        sub.attrs["x"] = np.int64(1)
+        result = h5_to_dict(h5group)
+        assert result == {"sub": {"x": 1}}
+
+    def test_empty_group(self, h5group):
+        result = h5_to_dict(h5group)
+        assert result == {}
+
+    def test_read_numeric_array(self, h5group):
+        h5group.attrs["vals"] = np.array([1, 2, 3], dtype=np.int64)
+        result = h5_to_dict(h5group)
+        assert result["vals"] == [1, 2, 3]
+        assert isinstance(result["vals"], list)
+
+    def test_read_float_array(self, h5group):
+        h5group.attrs["vals"] = np.array([1.1, 2.2], dtype=np.float64)
+        result = h5_to_dict(h5group)
+        assert result["vals"] == pytest.approx([1.1, 2.2])
+
+    def test_read_string_array(self, h5group):
+        dt = h5py.special_dtype(vlen=str)
+        h5group.attrs.create("tags", data=["a", "b"], dtype=dt)
+        result = h5_to_dict(h5group)
+        assert result["tags"] == ["a", "b"]
+
+    def test_read_bool_array(self, h5group):
+        h5group.attrs["flags"] = np.array([True, False], dtype=np.bool_)
+        result = h5_to_dict(h5group)
+        assert result["flags"] == [True, False]
+        assert all(isinstance(v, bool) for v in result["flags"])
+
+    def test_datasets_skipped(self, h5group):
+        h5group.attrs["meta"] = "value"
+        h5group.create_dataset("volume", data=np.zeros((10, 10)))
+        result = h5_to_dict(h5group)
+        assert "volume" not in result
+        assert result == {"meta": "value"}
+
+    def test_datasets_in_subgroup_skipped(self, h5group):
+        sub = h5group.create_group("sub")
+        sub.attrs["x"] = np.int64(1)
+        sub.create_dataset("data", data=np.zeros(5))
+        result = h5_to_dict(h5group)
+        assert "data" not in result["sub"]
+        assert result == {"sub": {"x": 1}}
+
+    def test_absent_attr_means_missing_key(self, h5group):
+        h5group.attrs["present"] = "yes"
+        result = h5_to_dict(h5group)
+        assert "present" in result
+        assert "absent" not in result
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_complex_nested(self, h5group):
+        original = {
+            "acquisition": {
+                "date": "2026-01-15",
+                "duration_s": 300.5,
+                "num_frames": 100,
+                "is_gated": True,
+            },
+            "instrument": {
+                "model": "Scanner-X",
+                "calibration": {
+                    "date": "2025-12-01",
+                    "version": 3,
+                },
+            },
+            "processing": {
+                "algorithm": "osem",
+                "iterations": 4,
+                "subsets": 21,
+                "use_tof": False,
+                "voxel_size": [2.0, 2.0, 2.0],
+            },
+            "tags": ["clinical", "brain"],
+        }
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == original
+
+    def test_round_trip_empty_dict(self, h5group):
+        dict_to_h5(h5group, {})
+        assert h5_to_dict(h5group) == {}
+
+    def test_round_trip_scalars(self, h5group):
+        original = {"a": 1, "b": 2.0, "c": "three", "d": True}
+        dict_to_h5(h5group, original)
+        assert h5_to_dict(h5group) == original
+
+    def test_round_trip_with_none_values(self, h5group):
+        original = {"present": "yes", "absent": None}
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == {"present": "yes"}
+
+    def test_round_trip_list_types(self, h5group):
+        original = {
+            "bools": [True, False, True],
+            "floats": [1.1, 2.2],
+            "ints": [10, 20, 30],
+            "strings": ["x", "y"],
+        }
+        dict_to_h5(h5group, original)
+        result = h5_to_dict(h5group)
+        assert result == original
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_unsupported_type_raises_typeerror(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"bad": object()})
+
+    def test_unsupported_type_in_nested(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"sub": {"bad": set()}})
+
+    def test_unsupported_list_element_type(self, h5group):
+        with pytest.raises(TypeError, match="Unsupported type"):
+            dict_to_h5(h5group, {"bad": [object()]})

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,448 @@
+"""Tests for fd5.hash — id computation, Merkle tree hashing, and integrity verification."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.hash import (
+    ChunkHasher,
+    MerkleTree,
+    compute_content_hash,
+    compute_id,
+    verify,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def h5file(tmp_path: Path):
+    """Yield a writable HDF5 file, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path: Path) -> Path:
+    """Return a path for creating HDF5 files."""
+    return tmp_path / "test.h5"
+
+
+# ---------------------------------------------------------------------------
+# compute_id
+# ---------------------------------------------------------------------------
+
+
+class TestComputeId:
+    def test_basic(self):
+        result = compute_id(
+            {"product": "recon", "timestamp": "2026-01-15T10:00:00Z"},
+            "product + timestamp",
+        )
+        expected_payload = "recon\0" + "2026-01-15T10:00:00Z"
+        expected = (
+            "sha256:" + hashlib.sha256(expected_payload.encode("utf-8")).hexdigest()
+        )
+        assert result == expected
+
+    def test_prefix_format(self):
+        result = compute_id({"a": "1"}, "a")
+        assert result.startswith("sha256:")
+        hex_part = result[len("sha256:") :]
+        assert len(hex_part) == 64
+
+    def test_deterministic(self):
+        inputs = {"x": "hello", "y": "world"}
+        desc = "x + y"
+        assert compute_id(inputs, desc) == compute_id(inputs, desc)
+
+    def test_sorted_keys(self):
+        r1 = compute_id({"b": "2", "a": "1"}, "a + b")
+        r2 = compute_id({"a": "1", "b": "2"}, "a + b")
+        assert r1 == r2
+
+    def test_different_values_differ(self):
+        r1 = compute_id({"a": "1"}, "a")
+        r2 = compute_id({"a": "2"}, "a")
+        assert r1 != r2
+
+    def test_null_separator_prevents_collision(self):
+        r1 = compute_id({"a": "12", "b": "3"}, "a + b")
+        r2 = compute_id({"a": "1", "b": "23"}, "a + b")
+        assert r1 != r2
+
+    def test_single_input(self):
+        result = compute_id({"key": "value"}, "key")
+        expected = "sha256:" + hashlib.sha256(b"value").hexdigest()
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# ChunkHasher
+# ---------------------------------------------------------------------------
+
+
+class TestChunkHasher:
+    def test_single_chunk(self):
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        hasher = ChunkHasher()
+        hasher.update(data)
+        hashes = hasher.digests()
+        assert len(hashes) == 1
+        expected = hashlib.sha256(data.tobytes()).hexdigest()
+        assert hashes[0] == expected
+
+    def test_multiple_chunks(self):
+        hasher = ChunkHasher()
+        chunks = [
+            np.array([1.0, 2.0], dtype=np.float32),
+            np.array([3.0, 4.0], dtype=np.float32),
+        ]
+        for c in chunks:
+            hasher.update(c)
+
+        hashes = hasher.digests()
+        assert len(hashes) == 2
+        for i, c in enumerate(chunks):
+            assert hashes[i] == hashlib.sha256(c.tobytes()).hexdigest()
+
+    def test_dataset_hash(self):
+        hasher = ChunkHasher()
+        c1 = np.array([1.0], dtype=np.float64)
+        c2 = np.array([2.0], dtype=np.float64)
+        hasher.update(c1)
+        hasher.update(c2)
+
+        h1 = hashlib.sha256(c1.tobytes()).hexdigest()
+        h2 = hashlib.sha256(c2.tobytes()).hexdigest()
+        expected = hashlib.sha256((h1 + h2).encode("utf-8")).hexdigest()
+        assert hasher.dataset_hash() == expected
+
+    def test_empty_raises(self):
+        hasher = ChunkHasher()
+        with pytest.raises(ValueError, match="no chunks"):
+            hasher.dataset_hash()
+
+    def test_row_major_bytes(self):
+        data = np.array([[1, 2], [3, 4]], dtype=np.int32)
+        hasher = ChunkHasher()
+        hasher.update(data)
+        expected = hashlib.sha256(data.tobytes()).hexdigest()
+        assert hasher.digests()[0] == expected
+
+
+# ---------------------------------------------------------------------------
+# MerkleTree
+# ---------------------------------------------------------------------------
+
+
+class TestMerkleTree:
+    def test_attrs_only(self, h5file: h5py.File):
+        h5file.attrs["name"] = "test"
+        h5file.attrs["count"] = np.int64(42)
+        tree = MerkleTree(h5file)
+        root = tree.root_hash()
+        assert isinstance(root, str)
+        assert len(root) == 64
+
+    def test_excludes_content_hash_attr(self, h5file: h5py.File):
+        h5file.attrs["name"] = "test"
+        tree1 = MerkleTree(h5file)
+        hash1 = tree1.root_hash()
+
+        h5file.attrs["content_hash"] = "sha256:deadbeef"
+        tree2 = MerkleTree(h5file)
+        hash2 = tree2.root_hash()
+
+        assert hash1 == hash2
+
+    def test_excludes_chunk_hashes_datasets(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("volume", data=np.zeros((4, 4), dtype=np.float32))
+            f.attrs["name"] = "test"
+
+        with h5py.File(h5path, "r") as f:
+            tree1 = MerkleTree(f)
+            hash1 = tree1.root_hash()
+
+        with h5py.File(h5path, "a") as f:
+            dt = h5py.special_dtype(vlen=str)
+            f.create_dataset(
+                "volume_chunk_hashes",
+                data=np.array(["abc123"], dtype=object),
+                dtype=dt,
+            )
+
+        with h5py.File(h5path, "r") as f:
+            tree2 = MerkleTree(f)
+            hash2 = tree2.root_hash()
+
+        assert hash1 == hash2
+
+    def test_sorted_keys_deterministic(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["z_attr"] = "last"
+            f.attrs["a_attr"] = "first"
+            f.create_dataset("z_data", data=np.array([1.0]))
+            f.create_dataset("a_data", data=np.array([2.0]))
+
+        with h5py.File(h5path, "r") as f:
+            hash1 = MerkleTree(f).root_hash()
+
+        with h5py.File(h5path, "r") as f:
+            hash2 = MerkleTree(f).root_hash()
+
+        assert hash1 == hash2
+
+    def test_different_data_different_hash(self, tmp_path: Path):
+        p1 = tmp_path / "a.h5"
+        p2 = tmp_path / "b.h5"
+
+        with h5py.File(p1, "w") as f:
+            f.create_dataset("d", data=np.array([1.0]))
+        with h5py.File(p2, "w") as f:
+            f.create_dataset("d", data=np.array([2.0]))
+
+        with h5py.File(p1, "r") as f1, h5py.File(p2, "r") as f2:
+            assert MerkleTree(f1).root_hash() != MerkleTree(f2).root_hash()
+
+    def test_different_attrs_different_hash(self, tmp_path: Path):
+        p1 = tmp_path / "a.h5"
+        p2 = tmp_path / "b.h5"
+
+        with h5py.File(p1, "w") as f:
+            f.attrs["val"] = "hello"
+        with h5py.File(p2, "w") as f:
+            f.attrs["val"] = "world"
+
+        with h5py.File(p1, "r") as f1, h5py.File(p2, "r") as f2:
+            assert MerkleTree(f1).root_hash() != MerkleTree(f2).root_hash()
+
+    def test_nested_groups(self, h5file: h5py.File):
+        g = h5file.create_group("metadata")
+        g.attrs["version"] = np.int64(1)
+        g.create_dataset("data", data=np.array([1, 2, 3]))
+
+        tree = MerkleTree(h5file)
+        root = tree.root_hash()
+        assert isinstance(root, str)
+        assert len(root) == 64
+
+    def test_dataset_with_chunks(self, h5file: h5py.File):
+        h5file.create_dataset(
+            "volume",
+            data=np.zeros((10, 4), dtype=np.float32),
+            chunks=(2, 4),
+        )
+        tree = MerkleTree(h5file)
+        root = tree.root_hash()
+        assert isinstance(root, str)
+        assert len(root) == 64
+
+    def test_non_chunked_dataset(self, h5file: h5py.File):
+        h5file.create_dataset("scalar", data=np.float64(3.14))
+        tree = MerkleTree(h5file)
+        root = tree.root_hash()
+        assert isinstance(root, str)
+
+    def test_empty_file(self, h5file: h5py.File):
+        tree = MerkleTree(h5file)
+        root = tree.root_hash()
+        assert isinstance(root, str)
+        assert len(root) == 64
+
+
+# ---------------------------------------------------------------------------
+# compute_content_hash
+# ---------------------------------------------------------------------------
+
+
+class TestComputeContentHash:
+    def test_returns_prefixed_hash(self, h5file: h5py.File):
+        h5file.create_dataset("data", data=np.array([1.0, 2.0, 3.0]))
+        result = compute_content_hash(h5file)
+        assert result.startswith("sha256:")
+        assert len(result) == len("sha256:") + 64
+
+    def test_deterministic(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("d", data=np.array([1, 2, 3]))
+            f.attrs["name"] = "test"
+
+        with h5py.File(h5path, "r") as f:
+            h1 = compute_content_hash(f)
+        with h5py.File(h5path, "r") as f:
+            h2 = compute_content_hash(f)
+
+        assert h1 == h2
+
+    def test_ignores_content_hash_attr(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("d", data=np.array([1.0]))
+            h1 = compute_content_hash(f)
+            f.attrs["content_hash"] = h1
+
+        with h5py.File(h5path, "r") as f:
+            h2 = compute_content_hash(f)
+
+        assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    def test_valid_file(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0, 2.0, 3.0]))
+            f.attrs["name"] = "test"
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        assert verify(h5path) is True
+
+    def test_corrupted_attr(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0, 2.0, 3.0]))
+            f.attrs["name"] = "test"
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        with h5py.File(h5path, "a") as f:
+            f.attrs["name"] = "tampered"
+
+        assert verify(h5path) is False
+
+    def test_corrupted_data(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0, 2.0, 3.0]))
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        with h5py.File(h5path, "a") as f:
+            f["data"][0] = 999.0
+
+        assert verify(h5path) is False
+
+    def test_missing_content_hash(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0]))
+
+        assert verify(h5path) is False
+
+    def test_accepts_path_string(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        assert verify(str(h5path)) is True
+
+    def test_complex_file(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["product"] = "recon"
+            f.attrs["version"] = np.int64(1)
+            g = f.create_group("metadata")
+            g.attrs["algorithm"] = "osem"
+            g.attrs["iterations"] = np.int64(4)
+            f.create_dataset(
+                "volume",
+                data=np.random.default_rng(42).standard_normal(
+                    (8, 8, 8), dtype=np.float32
+                ),
+                chunks=(2, 8, 8),
+            )
+            f.create_dataset("scalar", data=np.float64(1.5))
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        assert verify(h5path) is True
+
+    def test_idempotent(self, h5path: Path):
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0]))
+            f.attrs["content_hash"] = compute_content_hash(f)
+
+        assert verify(h5path) is True
+        assert verify(h5path) is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and integration
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_chunk_hash_edge_chunk(self):
+        """Edge chunks (partial) should hash actual data only."""
+        data = np.arange(5, dtype=np.float32)
+        hasher = ChunkHasher()
+        hasher.update(data)
+        expected = hashlib.sha256(data.tobytes()).hexdigest()
+        assert hasher.digests()[0] == expected
+
+    def test_same_data_same_hash_different_layout(self, tmp_path: Path):
+        """Same data + attrs = same hash regardless of HDF5 layout."""
+        p1 = tmp_path / "a.h5"
+        p2 = tmp_path / "b.h5"
+
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+
+        with h5py.File(p1, "w") as f:
+            f.create_dataset("d", data=data, chunks=(2, 4))
+            f.attrs["name"] = "test"
+
+        with h5py.File(p2, "w") as f:
+            f.create_dataset("d", data=data, chunks=(3, 4))
+            f.attrs["name"] = "test"
+
+        with h5py.File(p1, "r") as f1, h5py.File(p2, "r") as f2:
+            assert MerkleTree(f1).root_hash() == MerkleTree(f2).root_hash()
+
+    def test_dataset_attrs_included_in_hash(self, tmp_path: Path):
+        """Attributes on datasets should be included in the Merkle tree."""
+        p1 = tmp_path / "a.h5"
+        p2 = tmp_path / "b.h5"
+
+        data = np.array([1.0, 2.0])
+
+        with h5py.File(p1, "w") as f:
+            ds = f.create_dataset("d", data=data)
+            ds.attrs["units"] = "mm"
+
+        with h5py.File(p2, "w") as f:
+            ds = f.create_dataset("d", data=data)
+            ds.attrs["units"] = "cm"
+
+        with h5py.File(p1, "r") as f1, h5py.File(p2, "r") as f2:
+            assert MerkleTree(f1).root_hash() != MerkleTree(f2).root_hash()
+
+    def test_merkle_tree_with_chunk_hashes_present(self, h5path: Path):
+        """Merkle hash should be the same whether _chunk_hashes are present or not."""
+        data = np.zeros((4, 4), dtype=np.float32)
+
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("volume", data=data, chunks=(2, 4))
+            f.attrs["name"] = "test"
+
+        with h5py.File(h5path, "r") as f:
+            hash_without = MerkleTree(f).root_hash()
+
+        with h5py.File(h5path, "a") as f:
+            dt = h5py.special_dtype(vlen=str)
+            f.create_dataset(
+                "volume_chunk_hashes",
+                data=np.array(["aaa", "bbb"], dtype=object),
+                dtype=dt,
+            )
+            f["volume_chunk_hashes"].attrs["algorithm"] = "sha256"
+
+        with h5py.File(h5path, "r") as f:
+            hash_with = MerkleTree(f).root_hash()
+
+        assert hash_without == hash_with

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,259 @@
+"""Tests for fd5.manifest — build_manifest, write_manifest, read_manifest."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import h5py
+import pytest
+
+from fd5.h5io import dict_to_h5
+from fd5.manifest import build_manifest, read_manifest, write_manifest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def data_dir(tmp_path: Path) -> Path:
+    """Create a temporary directory with sample .h5 files."""
+    _create_h5(
+        tmp_path / "recon-aabb1122.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "recon",
+            "id": "sha256:aabb112233445566",
+            "id_inputs": "timestamp + scanner_uuid",
+            "name": "PET recon",
+            "description": "Whole-body PET reconstruction",
+            "content_hash": "sha256:deadbeef",
+            "timestamp": "2024-07-24T19:06:10+02:00",
+            "scan_type": "pet",
+            "duration_s": 367.0,
+        },
+        groups={
+            "study": {"type": "clinical"},
+            "subject": {"species": "human", "birth_date": "1959-03-15"},
+        },
+    )
+    _create_h5(
+        tmp_path / "roi-ccdd3344.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "roi",
+            "id": "sha256:ccdd334455667788",
+            "id_inputs": "reference_image_id + method_type",
+            "name": "Tumor ROI",
+            "description": "Manual tumor contours",
+            "content_hash": "sha256:cafebabe",
+            "timestamp": "2026-01-15T10:30:00+01:00",
+            "method": "manual",
+            "n_regions": 3,
+        },
+        groups={
+            "study": {"type": "clinical"},
+            "subject": {"species": "human", "birth_date": "1959-03-15"},
+        },
+    )
+    return tmp_path
+
+
+def _create_h5(
+    path: Path,
+    root_attrs: dict,
+    groups: dict | None = None,
+) -> None:
+    with h5py.File(path, "w") as f:
+        dict_to_h5(f, root_attrs)
+        if groups:
+            for name, attrs in groups.items():
+                g = f.create_group(name)
+                dict_to_h5(g, attrs)
+
+
+# ---------------------------------------------------------------------------
+# build_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestBuildManifest:
+    def test_returns_dict(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert isinstance(result, dict)
+
+    def test_schema_version(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert result["_schema_version"] == 1
+
+    def test_dataset_name_from_directory(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert result["dataset_name"] == data_dir.name
+
+    def test_study_extracted(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert result["study"] == {"type": "clinical"}
+
+    def test_subject_extracted(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert result["subject"] == {"species": "human", "birth_date": "1959-03-15"}
+
+    def test_data_entries_count(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        assert len(result["data"]) == 2
+
+    def test_data_entry_has_required_fields(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        for entry in result["data"]:
+            assert "product" in entry
+            assert "id" in entry
+            assert "file" in entry
+
+    def test_data_entry_product(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        products = {e["product"] for e in result["data"]}
+        assert products == {"recon", "roi"}
+
+    def test_data_entry_file_is_filename(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        for entry in result["data"]:
+            assert entry["file"].endswith(".h5")
+            assert "/" not in entry["file"]
+
+    def test_data_entry_includes_timestamp(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        for entry in result["data"]:
+            assert "timestamp" in entry
+
+    def test_data_entry_includes_product_specific_fields(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        recon = next(e for e in result["data"] if e["product"] == "recon")
+        assert recon["scan_type"] == "pet"
+        assert recon["duration_s"] == 367.0
+
+        roi = next(e for e in result["data"] if e["product"] == "roi")
+        assert roi["method"] == "manual"
+        assert roi["n_regions"] == 3
+
+    def test_data_entry_excludes_internal_attrs(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        for entry in result["data"]:
+            assert "_schema_version" not in entry
+            assert "content_hash" not in entry
+            assert "id_inputs" not in entry
+            assert "_schema" not in entry
+            assert "name" not in entry
+            assert "description" not in entry
+
+    def test_empty_directory(self, tmp_path: Path):
+        result = build_manifest(tmp_path)
+        assert result["data"] == []
+        assert result["_schema_version"] == 1
+        assert result["dataset_name"] == tmp_path.name
+
+    def test_files_sorted_by_name(self, data_dir: Path):
+        result = build_manifest(data_dir)
+        files = [e["file"] for e in result["data"]]
+        assert files == sorted(files)
+
+    def test_no_study_or_subject_when_absent(self, tmp_path: Path):
+        _create_h5(
+            tmp_path / "sim-11223344.h5",
+            root_attrs={
+                "_schema_version": 1,
+                "product": "sim",
+                "id": "sha256:1122334455667788",
+                "id_inputs": "config_hash + seed",
+                "name": "Sim run",
+                "description": "Monte Carlo simulation",
+                "content_hash": "sha256:00000000",
+            },
+            groups=None,
+        )
+        result = build_manifest(tmp_path)
+        assert "study" not in result
+        assert "subject" not in result
+
+
+# ---------------------------------------------------------------------------
+# write_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestWriteManifest:
+    def test_creates_file(self, data_dir: Path, tmp_path: Path):
+        out = tmp_path / "output" / "manifest.toml"
+        write_manifest(data_dir, out)
+        assert out.exists()
+
+    def test_output_is_valid_toml(self, data_dir: Path, tmp_path: Path):
+        out = tmp_path / "output" / "manifest.toml"
+        write_manifest(data_dir, out)
+        parsed = tomllib.loads(out.read_text())
+        assert isinstance(parsed, dict)
+
+    def test_schema_version_in_output(self, data_dir: Path, tmp_path: Path):
+        out = tmp_path / "output" / "manifest.toml"
+        write_manifest(data_dir, out)
+        parsed = tomllib.loads(out.read_text())
+        assert parsed["_schema_version"] == 1
+
+    def test_data_entries_in_output(self, data_dir: Path, tmp_path: Path):
+        out = tmp_path / "output" / "manifest.toml"
+        write_manifest(data_dir, out)
+        parsed = tomllib.loads(out.read_text())
+        assert len(parsed["data"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# read_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestReadManifest:
+    def test_round_trip(self, data_dir: Path, tmp_path: Path):
+        out = tmp_path / "output" / "manifest.toml"
+        write_manifest(data_dir, out)
+        result = read_manifest(out)
+        assert result["_schema_version"] == 1
+        assert len(result["data"]) == 2
+
+    def test_reads_hand_crafted_toml(self, tmp_path: Path):
+        toml_text = """\
+_schema_version = 1
+dataset_name = "test_dataset"
+
+[study]
+type = "clinical"
+
+[[data]]
+product = "recon"
+id = "sha256:aabb1122"
+file = "recon-aabb1122.h5"
+timestamp = "2024-07-24T19:06:10+02:00"
+"""
+        toml_file = tmp_path / "manifest.toml"
+        toml_file.write_text(toml_text)
+        result = read_manifest(toml_file)
+        assert result["dataset_name"] == "test_dataset"
+        assert result["data"][0]["product"] == "recon"
+
+    def test_returns_dict(self, tmp_path: Path):
+        toml_file = tmp_path / "manifest.toml"
+        toml_file.write_text('_schema_version = 1\ndataset_name = "x"\n')
+        result = read_manifest(toml_file)
+        assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# Lazy iteration
+# ---------------------------------------------------------------------------
+
+
+class TestLazyIteration:
+    def test_glob_returns_generator(self, data_dir: Path):
+        """Path.glob returns a generator, not a list — verifies lazy scanning."""
+        glob_result = data_dir.glob("*.h5")
+        assert hasattr(glob_result, "__next__")

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,98 @@
+"""Tests for fd5.naming module."""
+
+from datetime import datetime, timezone
+
+
+from fd5.naming import generate_filename
+
+
+class TestGenerateFilename:
+    """Tests for generate_filename."""
+
+    def test_full_filename_with_timestamp(self):
+        ts = datetime(2024, 7, 24, 18, 14, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:87f032f6abcdef1234567890",
+            timestamp=ts,
+            descriptors=["ct", "thorax", "dlir"],
+        )
+        assert result == "2024-07-24_18-14-00_recon-87f032f6_ct_thorax_dlir.h5"
+
+    def test_id_hash_truncated_to_8_hex_chars(self):
+        ts = datetime(2025, 3, 15, 9, 22, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="alignment",
+            id_hash="sha256:c4f2a1b8deadbeef",
+            timestamp=ts,
+            descriptors=["wgs", "sample01", "bwamem2"],
+        )
+        assert (
+            result == "2025-03-15_09-22-00_alignment-c4f2a1b8_wgs_sample01_bwamem2.h5"
+        )
+
+    def test_no_timestamp_omits_datetime_prefix(self):
+        result = generate_filename(
+            product="sim",
+            id_hash="sha256:xyz99999aabbccdd",
+            timestamp=None,
+            descriptors=["pet", "nema", "gate"],
+        )
+        assert result == "sim-xyz99999_pet_nema_gate.h5"
+
+    def test_single_descriptor(self):
+        ts = datetime(2024, 7, 24, 19, 6, 10, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="listmode",
+            id_hash="sha256:def67890aabb1122",
+            timestamp=ts,
+            descriptors=["coinc"],
+        )
+        assert result == "2024-07-24_19-06-10_listmode-def67890_coinc.h5"
+
+    def test_empty_descriptors(self):
+        ts = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd11223344",
+            timestamp=ts,
+            descriptors=[],
+        )
+        assert result == "2024-01-01_00-00-00_recon-aabbccdd.h5"
+
+    def test_calibration_no_timestamp(self):
+        result = generate_filename(
+            product="calibration",
+            id_hash="sha256:11223344aabbccdd",
+            timestamp=None,
+            descriptors=["detector", "energy", "hpge"],
+        )
+        assert result == "calibration-11223344_detector_energy_hpge.h5"
+
+    def test_id_hash_without_prefix(self):
+        ts = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = generate_filename(
+            product="features",
+            id_hash="a1b2c3d4e5f6a7b8",
+            timestamp=ts,
+            descriptors=["satellite", "band4", "ndvi"],
+        )
+        assert result == "2025-06-01_12-00-00_features-a1b2c3d4_satellite_band4_ndvi.h5"
+
+    def test_return_type_is_str(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=None,
+            descriptors=[],
+        )
+        assert isinstance(result, str)
+
+    def test_extension_is_h5(self):
+        result = generate_filename(
+            product="recon",
+            id_hash="sha256:aabbccdd",
+            timestamp=None,
+            descriptors=["x"],
+        )
+        assert result.endswith(".h5")

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -68,13 +68,13 @@ class TestWriteSources:
     def test_subgroup_has_external_link(self, h5file):
         src = self._make_source()
         write_sources(h5file, [src])
-        link = h5file["sources"].get("emission", getlink=True)
+        link = h5file["sources/emission"].get("link", getlink=True)
         assert isinstance(link, h5py.ExternalLink)
 
     def test_external_link_uses_relative_path(self, h5file):
         src = self._make_source(file="subdir/some_file.h5")
         write_sources(h5file, [src])
-        link = h5file["sources"].get("emission", getlink=True)
+        link = h5file["sources/emission"].get("link", getlink=True)
         assert link.filename == "subdir/some_file.h5"
         assert link.path == "/"
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,276 @@
+"""Tests for fd5.provenance — write_sources, write_original_files, write_ingest."""
+
+from __future__ import annotations
+
+import h5py
+import pytest
+
+from fd5.provenance import write_ingest, write_original_files, write_sources
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    """Yield a writable HDF5 file, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+# ---------------------------------------------------------------------------
+# write_sources
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSources:
+    """write_sources creates sources/ group with sub-groups, attrs, and external links."""
+
+    def _make_source(self, **overrides):
+        defaults = {
+            "name": "emission",
+            "id": "sha256:def67890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12",
+            "product": "listmode",
+            "file": "2024-07-24_19-06-10_listmode-def67890_pet_coinc.h5",
+            "content_hash": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "role": "emission_data",
+            "description": "PET listmode coincidence data used for reconstruction",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_creates_sources_group(self, h5file):
+        write_sources(h5file, [self._make_source()])
+        assert "sources" in h5file
+
+    def test_sources_group_has_description(self, h5file):
+        write_sources(h5file, [self._make_source()])
+        assert "description" in h5file["sources"].attrs
+
+    def test_creates_named_subgroup(self, h5file):
+        write_sources(h5file, [self._make_source(name="emission")])
+        assert "emission" in h5file["sources"]
+
+    def test_subgroup_has_required_attrs(self, h5file):
+        src = self._make_source()
+        write_sources(h5file, [src])
+        grp = h5file["sources/emission"]
+        assert grp.attrs["id"] == src["id"]
+        assert grp.attrs["product"] == src["product"]
+        assert grp.attrs["file"] == src["file"]
+        assert grp.attrs["content_hash"] == src["content_hash"]
+        assert grp.attrs["role"] == src["role"]
+        assert grp.attrs["description"] == src["description"]
+
+    def test_subgroup_has_external_link(self, h5file):
+        src = self._make_source()
+        write_sources(h5file, [src])
+        link = h5file["sources"].get("emission", getlink=True)
+        assert isinstance(link, h5py.ExternalLink)
+
+    def test_external_link_uses_relative_path(self, h5file):
+        src = self._make_source(file="subdir/some_file.h5")
+        write_sources(h5file, [src])
+        link = h5file["sources"].get("emission", getlink=True)
+        assert link.filename == "subdir/some_file.h5"
+        assert link.path == "/"
+
+    def test_multiple_sources(self, h5file):
+        sources = [
+            self._make_source(name="emission"),
+            self._make_source(
+                name="attenuation",
+                product="recon",
+                file="2024-07-24_18-25-00_recon-21d255e7_ct_ctac.h5",
+                role="mu_map",
+                description="CT reconstruction for attenuation correction",
+            ),
+        ]
+        write_sources(h5file, sources)
+        assert "emission" in h5file["sources"]
+        assert "attenuation" in h5file["sources"]
+
+    def test_empty_sources_list(self, h5file):
+        write_sources(h5file, [])
+        assert "sources" in h5file
+        assert len(h5file["sources"]) == 0
+
+    def test_name_key_not_stored_as_attr(self, h5file):
+        write_sources(h5file, [self._make_source()])
+        grp = h5file["sources/emission"]
+        assert "name" not in grp.attrs
+
+
+# ---------------------------------------------------------------------------
+# write_original_files
+# ---------------------------------------------------------------------------
+
+
+class TestWriteOriginalFiles:
+    """write_original_files creates provenance/original_files compound dataset."""
+
+    def _make_record(self, **overrides):
+        defaults = {
+            "path": "/data/raw/scan_001.dcm",
+            "sha256": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            "size_bytes": 1048576,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_creates_provenance_group(self, h5file):
+        write_original_files(h5file, [self._make_record()])
+        assert "provenance" in h5file
+
+    def test_provenance_group_has_description(self, h5file):
+        write_original_files(h5file, [self._make_record()])
+        assert "description" in h5file["provenance"].attrs
+
+    def test_creates_original_files_dataset(self, h5file):
+        write_original_files(h5file, [self._make_record()])
+        assert "original_files" in h5file["provenance"]
+
+    def test_dataset_is_compound_type(self, h5file):
+        write_original_files(h5file, [self._make_record()])
+        ds = h5file["provenance/original_files"]
+        assert ds.dtype.names is not None
+        assert "path" in ds.dtype.names
+        assert "sha256" in ds.dtype.names
+        assert "size_bytes" in ds.dtype.names
+
+    def test_single_record_values(self, h5file):
+        rec = self._make_record()
+        write_original_files(h5file, [rec])
+        ds = h5file["provenance/original_files"]
+        assert len(ds) == 1
+        row = ds[0]
+        assert row["path"].decode("utf-8") == rec["path"]
+        assert row["sha256"].decode("utf-8") == rec["sha256"]
+        assert int(row["size_bytes"]) == rec["size_bytes"]
+
+    def test_multiple_records(self, h5file):
+        records = [
+            self._make_record(path="/data/raw/scan_001.dcm", size_bytes=100),
+            self._make_record(path="/data/raw/scan_002.dcm", size_bytes=200),
+        ]
+        write_original_files(h5file, records)
+        ds = h5file["provenance/original_files"]
+        assert len(ds) == 2
+
+    def test_empty_records(self, h5file):
+        write_original_files(h5file, [])
+        ds = h5file["provenance/original_files"]
+        assert len(ds) == 0
+
+    def test_preserves_existing_provenance_group(self, h5file):
+        h5file.create_group("provenance")
+        h5file["provenance"].attrs["existing"] = "keep"
+        write_original_files(h5file, [self._make_record()])
+        assert h5file["provenance"].attrs["existing"] == "keep"
+
+
+# ---------------------------------------------------------------------------
+# write_ingest
+# ---------------------------------------------------------------------------
+
+
+class TestWriteIngest:
+    """write_ingest writes provenance/ingest/ group attrs."""
+
+    def test_creates_provenance_ingest_group(self, h5file):
+        write_ingest(
+            h5file,
+            tool="duplet_ingest",
+            version="0.3.1",
+            timestamp="2026-02-11T15:00:00+01:00",
+        )
+        assert "provenance" in h5file
+        assert "ingest" in h5file["provenance"]
+
+    def test_ingest_attrs(self, h5file):
+        write_ingest(
+            h5file,
+            tool="duplet_ingest",
+            version="0.3.1",
+            timestamp="2026-02-11T15:00:00+01:00",
+        )
+        grp = h5file["provenance/ingest"]
+        assert grp.attrs["tool"] == "duplet_ingest"
+        assert grp.attrs["tool_version"] == "0.3.1"
+        assert grp.attrs["timestamp"] == "2026-02-11T15:00:00+01:00"
+
+    def test_ingest_has_description(self, h5file):
+        write_ingest(
+            h5file,
+            tool="duplet_ingest",
+            version="0.3.1",
+            timestamp="2026-02-11T15:00:00+01:00",
+        )
+        grp = h5file["provenance/ingest"]
+        assert "description" in grp.attrs
+
+    def test_preserves_existing_provenance_group(self, h5file):
+        h5file.create_group("provenance")
+        h5file["provenance"].attrs["existing"] = "keep"
+        write_ingest(
+            h5file, tool="test", version="1.0", timestamp="2026-01-01T00:00:00Z"
+        )
+        assert h5file["provenance"].attrs["existing"] == "keep"
+
+    def test_coexists_with_original_files(self, h5file):
+        write_original_files(
+            h5file,
+            [
+                {
+                    "path": "/data/file.dcm",
+                    "sha256": "sha256:abc123",
+                    "size_bytes": 42,
+                }
+            ],
+        )
+        write_ingest(
+            h5file, tool="test", version="1.0", timestamp="2026-01-01T00:00:00Z"
+        )
+        assert "original_files" in h5file["provenance"]
+        assert "ingest" in h5file["provenance"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    """Calling writers twice should raise or produce consistent state."""
+
+    def test_write_sources_twice_raises(self, h5file):
+        src = [
+            {
+                "name": "emission",
+                "id": "sha256:abc",
+                "product": "listmode",
+                "file": "file.h5",
+                "content_hash": "sha256:def",
+                "role": "emission_data",
+                "description": "test",
+            }
+        ]
+        write_sources(h5file, src)
+        with pytest.raises((ValueError, RuntimeError)):
+            write_sources(h5file, src)
+
+    def test_write_original_files_twice_raises(self, h5file):
+        rec = [{"path": "/f.dcm", "sha256": "sha256:abc", "size_bytes": 1}]
+        write_original_files(h5file, rec)
+        with pytest.raises((ValueError, RuntimeError)):
+            write_original_files(h5file, rec)
+
+    def test_write_ingest_twice_raises(self, h5file):
+        write_ingest(h5file, tool="t", version="1", timestamp="2026-01-01T00:00:00Z")
+        with pytest.raises((ValueError, RuntimeError)):
+            write_ingest(
+                h5file, tool="t", version="1", timestamp="2026-01-01T00:00:00Z"
+            )

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -1,0 +1,478 @@
+"""Tests for fd5.imaging.recon — ReconSchema product schema."""
+
+from __future__ import annotations
+
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.registry import ProductSchema, register_schema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def schema():
+    from fd5.imaging.recon import ReconSchema
+
+    return ReconSchema()
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    path = tmp_path / "recon.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path):
+    return tmp_path / "recon.h5"
+
+
+def _make_volume_3d(shape=(64, 128, 128)):
+    return np.random.default_rng(42).random(shape, dtype=np.float32)
+
+
+def _make_volume_4d(shape=(4, 32, 64, 64)):
+    return np.random.default_rng(42).random(shape, dtype=np.float32)
+
+
+def _make_affine():
+    aff = np.eye(4, dtype=np.float64)
+    aff[0, 0] = 2.0  # 2mm voxel spacing Z
+    aff[1, 1] = 1.0
+    aff[2, 2] = 1.0
+    return aff
+
+
+def _minimal_3d_data():
+    vol = _make_volume_3d((16, 32, 32))
+    return {
+        "volume": vol,
+        "affine": _make_affine(),
+        "dimension_order": "ZYX",
+        "reference_frame": "LPS",
+        "description": "Test static CT reconstruction volume",
+    }
+
+
+def _minimal_4d_data():
+    vol = _make_volume_4d((3, 8, 16, 16))
+    return {
+        "volume": vol,
+        "affine": _make_affine(),
+        "dimension_order": "TZYX",
+        "reference_frame": "LPS",
+        "description": "Test dynamic PET reconstruction volume",
+        "frames": {
+            "n_frames": 3,
+            "frame_type": "time",
+            "description": "Dynamic time frames for PET reconstruction",
+            "frame_start": np.array([0.0, 60.0, 120.0]),
+            "frame_duration": np.array([60.0, 60.0, 60.0]),
+            "frame_label": ["frame_0", "frame_1", "frame_2"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_satisfies_product_schema_protocol(self, schema):
+        assert isinstance(schema, ProductSchema)
+
+    def test_product_type_is_recon(self, schema):
+        assert schema.product_type == "recon"
+
+    def test_schema_version_is_string(self, schema):
+        assert isinstance(schema.schema_version, str)
+
+    def test_has_required_methods(self, schema):
+        assert callable(schema.json_schema)
+        assert callable(schema.required_root_attrs)
+        assert callable(schema.write)
+        assert callable(schema.id_inputs)
+
+
+# ---------------------------------------------------------------------------
+# json_schema()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchema:
+    def test_returns_dict(self, schema):
+        result = schema.json_schema()
+        assert isinstance(result, dict)
+
+    def test_has_draft_2020_12_meta(self, schema):
+        result = schema.json_schema()
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_product_const_is_recon(self, schema):
+        result = schema.json_schema()
+        assert result["properties"]["product"]["const"] == "recon"
+
+    def test_requires_volume(self, schema):
+        result = schema.json_schema()
+        assert "volume" in result.get("required", []) or "volume" in result.get(
+            "properties", {}
+        )
+
+    def test_valid_json_schema(self, schema):
+        import jsonschema
+
+        result = schema.json_schema()
+        jsonschema.Draft202012Validator.check_schema(result)
+
+
+# ---------------------------------------------------------------------------
+# required_root_attrs()
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredRootAttrs:
+    def test_returns_dict(self, schema):
+        result = schema.required_root_attrs()
+        assert isinstance(result, dict)
+
+    def test_contains_product_recon(self, schema):
+        result = schema.required_root_attrs()
+        assert result["product"] == "recon"
+
+    def test_contains_domain(self, schema):
+        result = schema.required_root_attrs()
+        assert result["domain"] == "medical_imaging"
+
+
+# ---------------------------------------------------------------------------
+# id_inputs()
+# ---------------------------------------------------------------------------
+
+
+class TestIdInputs:
+    def test_returns_list_of_strings(self, schema):
+        result = schema.id_inputs()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_follows_medical_imaging_convention(self, schema):
+        result = schema.id_inputs()
+        assert "timestamp" in result
+        assert "scanner" in result
+        assert "vendor_series_id" in result
+
+
+# ---------------------------------------------------------------------------
+# write() — 3D static volume
+# ---------------------------------------------------------------------------
+
+
+class TestWrite3D:
+    def test_writes_volume_dataset(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "volume" in h5file
+        assert h5file["volume"].dtype == np.float32
+
+    def test_volume_shape_matches(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["volume"].shape == (16, 32, 32)
+
+    def test_volume_has_affine_attr(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        aff = h5file["volume"].attrs["affine"]
+        assert aff.shape == (4, 4)
+        assert aff.dtype == np.float64
+
+    def test_volume_has_dimension_order(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["volume"].attrs["dimension_order"] == "ZYX"
+
+    def test_volume_has_reference_frame(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["volume"].attrs["reference_frame"] == "LPS"
+
+    def test_volume_has_description(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "description" in h5file["volume"].attrs
+
+    def test_3d_chunking_strategy(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        chunks = h5file["volume"].chunks
+        assert chunks == (1, 32, 32)
+
+    def test_gzip_compression_level_4(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["volume"].compression == "gzip"
+        assert h5file["volume"].compression_opts == 4
+
+    def test_no_frames_group_for_3d(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "frames" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# write() — 4D dynamic volume
+# ---------------------------------------------------------------------------
+
+
+class TestWrite4D:
+    def test_writes_volume_dataset(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "volume" in h5file
+        assert h5file["volume"].shape == (3, 8, 16, 16)
+
+    def test_4d_chunking_strategy(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        chunks = h5file["volume"].chunks
+        assert chunks == (1, 1, 16, 16)
+
+    def test_4d_dimension_order(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert h5file["volume"].attrs["dimension_order"] == "TZYX"
+
+    def test_frames_group_exists(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "frames" in h5file
+        assert isinstance(h5file["frames"], h5py.Group)
+
+    def test_frames_attrs(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        grp = h5file["frames"]
+        assert grp.attrs["n_frames"] == 3
+        assert grp.attrs["frame_type"] == "time"
+        assert "description" in grp.attrs
+
+    def test_frame_start_dataset(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/frame_start"]
+        np.testing.assert_array_almost_equal(ds[:], [0.0, 60.0, 120.0])
+
+    def test_frame_duration_dataset(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/frame_duration"]
+        np.testing.assert_array_almost_equal(ds[:], [60.0, 60.0, 60.0])
+
+    def test_frame_label_dataset(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/frame_label"]
+        labels = [v.decode() if isinstance(v, bytes) else str(v) for v in ds[:]]
+        assert labels == ["frame_0", "frame_1", "frame_2"]
+
+
+# ---------------------------------------------------------------------------
+# write() — pyramid
+# ---------------------------------------------------------------------------
+
+
+class TestWritePyramid:
+    def test_pyramid_group_created(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2, 4],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        assert "pyramid" in h5file
+
+    def test_pyramid_attrs(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2, 4],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        grp = h5file["pyramid"]
+        assert grp.attrs["n_levels"] == 2
+        np.testing.assert_array_equal(grp.attrs["scale_factors"], [2, 4])
+        assert grp.attrs["method"] == "local_mean"
+
+    def test_pyramid_levels_created(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2, 4],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        assert "pyramid/level_1" in h5file
+        assert "pyramid/level_1/volume" in h5file
+        assert "pyramid/level_2" in h5file
+        assert "pyramid/level_2/volume" in h5file
+
+    def test_pyramid_level_has_scale_factor_attr(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        ds = h5file["pyramid/level_1/volume"]
+        assert ds.attrs["scale_factor"] == 2
+
+    def test_pyramid_level_has_affine(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        ds = h5file["pyramid/level_1/volume"]
+        assert "affine" in ds.attrs
+        assert ds.attrs["affine"].shape == (4, 4)
+
+    def test_pyramid_level_shape_downsampled(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        ds = h5file["pyramid/level_1/volume"]
+        assert ds.shape == (8, 16, 16)
+
+    def test_pyramid_level_compression(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["pyramid"] = {
+            "scale_factors": [2],
+            "method": "local_mean",
+        }
+        schema.write(h5file, data)
+        ds = h5file["pyramid/level_1/volume"]
+        assert ds.compression == "gzip"
+        assert ds.compression_opts == 4
+
+
+# ---------------------------------------------------------------------------
+# write() — MIP projections
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMIP:
+    def test_mip_coronal_created(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "mip_coronal" in h5file
+
+    def test_mip_sagittal_created(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "mip_sagittal" in h5file
+
+    def test_mip_coronal_shape(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        ds = h5file["mip_coronal"]
+        assert ds.shape == (16, 32)
+
+    def test_mip_sagittal_shape(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        ds = h5file["mip_sagittal"]
+        assert ds.shape == (16, 32)
+
+    def test_mip_coronal_attrs(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        ds = h5file["mip_coronal"]
+        assert ds.attrs["projection_type"] == "mip"
+        assert ds.attrs["axis"] == 1
+        assert "description" in ds.attrs
+
+    def test_mip_sagittal_attrs(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        ds = h5file["mip_sagittal"]
+        assert ds.attrs["projection_type"] == "mip"
+        assert ds.attrs["axis"] == 2
+        assert "description" in ds.attrs
+
+    def test_mip_dtype_float32(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["mip_coronal"].dtype == np.float32
+        assert h5file["mip_sagittal"].dtype == np.float32
+
+    def test_mip_4d_uses_summed_volume(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        vol = data["volume"]
+        summed = vol.sum(axis=0)
+        expected_coronal = summed.max(axis=1)
+        np.testing.assert_array_almost_equal(h5file["mip_coronal"][:], expected_coronal)
+
+
+# ---------------------------------------------------------------------------
+# Entry point registration
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointRegistration:
+    def test_factory_returns_recon_schema(self):
+        from fd5.imaging.recon import ReconSchema
+
+        instance = ReconSchema()
+        assert instance.product_type == "recon"
+
+    def test_entry_point_name_is_recon(self):
+        """The entry point must register under name 'recon'."""
+        import importlib.metadata
+
+        eps = importlib.metadata.entry_points(group="fd5.schemas")
+        names = [ep.name for ep in eps]
+        assert "recon" in names
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_create_validate_roundtrip(self, schema, h5path):
+        from fd5.schema import embed_schema, validate
+
+        data = _minimal_3d_data()
+        with h5py.File(h5path, "w") as f:
+            root_attrs = schema.required_root_attrs()
+            for k, v in root_attrs.items():
+                f.attrs[k] = v
+            f.attrs["name"] = "integration-test-recon"
+            f.attrs["description"] = "Integration test recon file"
+            schema_dict = schema.json_schema()
+            embed_schema(f, schema_dict)
+            schema.write(f, data)
+
+        errors = validate(h5path)
+        assert errors == [], [e.message for e in errors]
+
+    def test_generate_schema_for_recon(self, schema):
+        register_schema("recon", schema)
+        from fd5.schema import generate_schema
+
+        result = generate_schema("recon")
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert result["properties"]["product"]["const"] == "recon"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,136 @@
+"""Tests for fd5.registry module."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fd5.registry import ProductSchema, get_schema, list_schemas, register_schema
+
+
+class _StubSchema:
+    """Minimal implementation satisfying the ProductSchema protocol."""
+
+    product_type: str = "pet/static"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {"type": "object"}
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product_type": "pet/static"}
+
+    def write(self, target: Any, data: Any) -> None:
+        pass
+
+    def id_inputs(self) -> list[str]:
+        return ["/scan/start_time"]
+
+
+def _assert_satisfies_protocol(obj: object) -> None:
+    """Verify *obj* is structurally compatible with ProductSchema."""
+    schema: ProductSchema = obj  # type: ignore[assignment]
+    assert hasattr(schema, "product_type")
+    assert hasattr(schema, "schema_version")
+    assert callable(schema.json_schema)
+    assert callable(schema.required_root_attrs)
+    assert callable(schema.write)
+    assert callable(schema.id_inputs)
+
+
+class TestProductSchemaProtocol:
+    """ProductSchema is a typing.Protocol — verify structural subtyping."""
+
+    def test_stub_satisfies_protocol(self):
+        _assert_satisfies_protocol(_StubSchema())
+
+    def test_protocol_has_required_members(self):
+        import inspect
+
+        methods = {
+            name
+            for name, _ in inspect.getmembers(ProductSchema)
+            if not name.startswith("_")
+        }
+        annotations = set(ProductSchema.__protocol_attrs__)
+        all_members = methods | annotations
+        assert all_members >= {
+            "product_type",
+            "schema_version",
+            "json_schema",
+            "required_root_attrs",
+            "write",
+            "id_inputs",
+        }
+
+
+class TestRegisterSchema:
+    """Tests for register_schema."""
+
+    def test_registers_and_retrieves(self):
+        stub = _StubSchema()
+        register_schema("test/register", stub)
+        assert get_schema("test/register") is stub
+
+    def test_overwrites_existing(self):
+        stub_a = _StubSchema()
+        stub_b = _StubSchema()
+        register_schema("test/overwrite", stub_a)
+        register_schema("test/overwrite", stub_b)
+        assert get_schema("test/overwrite") is stub_b
+
+    def test_appears_in_list(self):
+        stub = _StubSchema()
+        register_schema("test/listed", stub)
+        assert "test/listed" in list_schemas()
+
+
+class TestGetSchema:
+    """Tests for get_schema."""
+
+    def test_returns_registered_schema(self):
+        stub = _StubSchema()
+        register_schema("test/get", stub)
+        assert get_schema("test/get") is stub
+
+    def test_unknown_product_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="no-such-product"):
+            get_schema("no-such-product")
+
+
+class TestListSchemas:
+    """Tests for list_schemas."""
+
+    def test_returns_list_of_strings(self):
+        result = list_schemas()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_contains_registered_types(self):
+        register_schema("test/list-a", _StubSchema())
+        register_schema("test/list-b", _StubSchema())
+        result = list_schemas()
+        assert "test/list-a" in result
+        assert "test/list-b" in result
+
+
+class TestEntryPointDiscovery:
+    """Entry point loading uses importlib.metadata group 'fd5.schemas'."""
+
+    def test_loads_entry_points_on_first_access(self, monkeypatch):
+        """Schemas from entry points are available via get_schema."""
+        import fd5.registry as reg
+
+        stub = _StubSchema()
+        stub.product_type = "ep/test"
+
+        monkeypatch.setattr(
+            reg,
+            "_load_entry_points",
+            lambda: {"ep/test": stub},
+        )
+        reg._registry.clear()
+        reg._load_and_merge()
+
+        assert get_schema("ep/test") is stub

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,204 @@
+"""Tests for fd5.schema — embed, validate, dump, and generate JSON Schema."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import h5py
+import pytest
+
+from fd5.registry import register_schema
+from fd5.schema import dump_schema, embed_schema, generate_schema, validate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubSchema:
+    """Minimal ProductSchema for testing."""
+
+    product_type: str = "test/schema"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "test/schema"},
+                "name": {"type": "string"},
+            },
+            "required": ["_schema_version", "product", "name"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product": "test/schema"}
+
+    def write(self, target: Any, data: Any) -> None:
+        pass
+
+    def id_inputs(self) -> list[str]:
+        return ["/name"]
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    """Yield a writable HDF5 file, auto-closed after test."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path):
+    """Return a path for an HDF5 file (closed between write and read)."""
+    return tmp_path / "test.h5"
+
+
+@pytest.fixture(autouse=True)
+def _register_stub():
+    """Register the stub schema for every test."""
+    register_schema("test/schema", _StubSchema())
+
+
+# ---------------------------------------------------------------------------
+# embed_schema
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedSchema:
+    def test_writes_schema_attr_as_json_string(self, h5file):
+        schema_dict = {"type": "object", "properties": {}}
+        embed_schema(h5file, schema_dict)
+        raw = h5file.attrs["_schema"]
+        assert isinstance(raw, str)
+        assert json.loads(raw) == schema_dict
+
+    def test_writes_schema_version_as_int(self, h5file):
+        embed_schema(h5file, {"type": "object"}, schema_version=2)
+        assert h5file.attrs["_schema_version"] == 2
+
+    def test_default_schema_version_is_one(self, h5file):
+        embed_schema(h5file, {"type": "object"})
+        assert h5file.attrs["_schema_version"] == 1
+
+    def test_schema_readable_by_h5_tools(self, h5path):
+        """Schema stored as plain JSON string is human-readable via h5dump."""
+        schema_dict = {"type": "object", "description": "test"}
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+        with h5py.File(h5path, "r") as f:
+            raw = f.attrs["_schema"]
+            parsed = json.loads(raw)
+            assert parsed == schema_dict
+
+    def test_idempotent_overwrites(self, h5file):
+        embed_schema(h5file, {"v": 1})
+        embed_schema(h5file, {"v": 2}, schema_version=3)
+        assert json.loads(h5file.attrs["_schema"]) == {"v": 2}
+        assert h5file.attrs["_schema_version"] == 3
+
+
+# ---------------------------------------------------------------------------
+# dump_schema
+# ---------------------------------------------------------------------------
+
+
+class TestDumpSchema:
+    def test_extracts_embedded_schema(self, h5path):
+        schema_dict = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+        result = dump_schema(h5path)
+        assert result == schema_dict
+
+    def test_raises_on_missing_schema(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["other"] = "value"
+        with pytest.raises(KeyError, match="_schema"):
+            dump_schema(h5path)
+
+    def test_raises_on_invalid_json(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["_schema"] = "not valid json {"
+        with pytest.raises(json.JSONDecodeError):
+            dump_schema(h5path)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def _make_valid_file(self, path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            f.attrs["name"] = "sample"
+
+    def test_valid_file_returns_empty_list(self, h5path):
+        self._make_valid_file(h5path)
+        errors = validate(h5path)
+        assert errors == []
+
+    def test_missing_required_attr_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            # 'name' is missing
+        errors = validate(h5path)
+        assert len(errors) > 0
+        messages = [e.message for e in errors]
+        assert any("name" in m for m in messages)
+
+    def test_wrong_type_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "test/schema"
+            f.attrs["name"] = "sample"
+            f.attrs["_schema_version"] = "not_an_int"
+        errors = validate(h5path)
+        assert len(errors) > 0
+
+    def test_raises_when_no_schema_embedded(self, h5path):
+        with h5py.File(h5path, "w") as f:
+            f.attrs["product"] = "test/schema"
+        with pytest.raises(KeyError, match="_schema"):
+            validate(h5path)
+
+    def test_const_violation_returns_errors(self, h5path):
+        schema_dict = _StubSchema().json_schema()
+        with h5py.File(h5path, "w") as f:
+            embed_schema(f, schema_dict)
+            f.attrs["product"] = "wrong/type"
+            f.attrs["name"] = "sample"
+        errors = validate(h5path)
+        assert len(errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# generate_schema
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSchema:
+    def test_returns_json_schema_draft_2020_12(self):
+        result = generate_schema("test/schema")
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_returns_dict_from_registry(self):
+        result = generate_schema("test/schema")
+        assert result["type"] == "object"
+        assert "properties" in result
+
+    def test_unknown_product_raises_valueerror(self):
+        with pytest.raises(ValueError, match="no-such-type"):
+            generate_schema("no-such-type")

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,126 @@
+"""Tests for fd5.units module."""
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.units import read_quantity, set_dataset_units, write_quantity
+
+
+@pytest.fixture()
+def h5_group(tmp_path):
+    """Yield an open HDF5 group backed by a temp file."""
+    path = tmp_path / "test.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+class TestWriteQuantity:
+    """Tests for write_quantity."""
+
+    def test_creates_subgroup_with_attrs(self, h5_group):
+        write_quantity(h5_group, "z_min", -450.2, "mm", 0.001)
+
+        grp = h5_group["z_min"]
+        assert grp.attrs["value"] == pytest.approx(-450.2)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_integer_value(self, h5_group):
+        write_quantity(h5_group, "kvp", 120, "kV", 1000.0)
+
+        grp = h5_group["kvp"]
+        assert grp.attrs["value"] == 120
+        assert grp.attrs["units"] == "kV"
+        assert grp.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_list_value(self, h5_group):
+        write_quantity(h5_group, "grid_spacing", [4.0, 4.0, 4.0], "mm", 0.001)
+
+        grp = h5_group["grid_spacing"]
+        np.testing.assert_array_equal(grp.attrs["value"], [4.0, 4.0, 4.0])
+        assert grp.attrs["units"] == "mm"
+
+    def test_numpy_array_value(self, h5_group):
+        arr = np.array([1.0, 2.0, 3.0])
+        write_quantity(h5_group, "offsets", arr, "mm", 0.001)
+
+        grp = h5_group["offsets"]
+        np.testing.assert_array_equal(grp.attrs["value"], arr)
+
+    def test_overwrites_existing_quantity(self, h5_group):
+        write_quantity(h5_group, "duration", 100.0, "s", 1.0)
+        write_quantity(h5_group, "duration", 200.0, "s", 1.0)
+
+        assert h5_group["duration"].attrs["value"] == pytest.approx(200.0)
+
+
+class TestReadQuantity:
+    """Tests for read_quantity."""
+
+    def test_reads_back_scalar(self, h5_group):
+        write_quantity(h5_group, "duration", 367.0, "s", 1.0)
+
+        value, units, unit_si = read_quantity(h5_group, "duration")
+        assert value == pytest.approx(367.0)
+        assert units == "s"
+        assert unit_si == pytest.approx(1.0)
+
+    def test_reads_back_array(self, h5_group):
+        write_quantity(h5_group, "frame_durations", [120.0, 120.0], "s", 1.0)
+
+        value, units, unit_si = read_quantity(h5_group, "frame_durations")
+        np.testing.assert_array_equal(value, [120.0, 120.0])
+        assert units == "s"
+
+    def test_missing_quantity_raises_keyerror(self, h5_group):
+        with pytest.raises(KeyError):
+            read_quantity(h5_group, "nonexistent")
+
+
+class TestSetDatasetUnits:
+    """Tests for set_dataset_units."""
+
+    def test_sets_units_and_unitsi_attrs(self, h5_group):
+        ds = h5_group.create_dataset("volume", data=np.zeros((2, 2, 2)))
+        set_dataset_units(ds, "Bq/mL", 1000.0)
+
+        assert ds.attrs["units"] == "Bq/mL"
+        assert ds.attrs["unitSI"] == pytest.approx(1000.0)
+
+    def test_overwrites_existing_units(self, h5_group):
+        ds = h5_group.create_dataset("signal", data=np.zeros(10))
+        set_dataset_units(ds, "mV", 0.001)
+        set_dataset_units(ds, "V", 1.0)
+
+        assert ds.attrs["units"] == "V"
+        assert ds.attrs["unitSI"] == pytest.approx(1.0)
+
+
+class TestRoundTrip:
+    """Round-trip: write then read returns identical values."""
+
+    def test_scalar_round_trip(self, h5_group):
+        write_quantity(h5_group, "activity", 350.0, "MBq", 1e6)
+        value, units, unit_si = read_quantity(h5_group, "activity")
+
+        assert value == pytest.approx(350.0)
+        assert units == "MBq"
+        assert unit_si == pytest.approx(1e6)
+
+    def test_array_round_trip(self, h5_group):
+        original = [4.0, 4.0, 4.0]
+        write_quantity(h5_group, "grid_spacing", original, "mm", 0.001)
+        value, units, unit_si = read_quantity(h5_group, "grid_spacing")
+
+        np.testing.assert_array_equal(value, original)
+        assert units == "mm"
+        assert unit_si == pytest.approx(0.001)
+
+    def test_negative_value_round_trip(self, h5_group):
+        write_quantity(h5_group, "z_min", -850.0, "mm", 0.001)
+        value, units, unit_si = read_quantity(h5_group, "z_min")
+
+        assert value == pytest.approx(-850.0)
+        assert units == "mm"
+        assert unit_si == pytest.approx(0.001)

--- a/uv.lock
+++ b/uv.lock
@@ -543,6 +543,7 @@ science = [
 [package.dev-dependencies]
 dev = [
     { name = "hatchling" },
+    { name = "rich" },
 ]
 
 [package.metadata]
@@ -560,7 +561,10 @@ requires-dist = [
 provides-extras = ["dev", "science", "all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "hatchling", specifier = ">=1.25" }]
+dev = [
+    { name = "hatchling", specifier = ">=1.25" },
+    { name = "rich", specifier = ">=13.0.0" },
+]
 
 [[package]]
 name = "fonttools"
@@ -1129,6 +1133,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1255,6 +1271,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1918,6 +1943,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -278,6 +278,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +527,13 @@ wheels = [
 name = "fd5"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "h5py" },
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "tomli-w" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -548,15 +567,20 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "fd5", extras = ["dev", "science"], marker = "extra == 'all'" },
+    { name = "h5py", specifier = ">=3.10" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "jsonschema", specifier = ">=4.20" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.9" },
+    { name = "numpy", specifier = ">=2.0" },
     { name = "numpy", marker = "extra == 'science'", specifier = ">=2.0" },
     { name = "pandas", marker = "extra == 'science'", specifier = ">=2.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = ">=1.14" },
+    { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["dev", "science", "all"]
 
@@ -623,6 +647,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/b8/c0d9aa013ecfa8b7057946c080c0c07f6fa41e231d2e9bd306a2f8110bdc/h5py-3.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:316dd0f119734f324ca7ed10b5627a2de4ea42cc4dfbcedbee026aaa361c238c", size = 3399089, upload-time = "2025-10-16T10:34:12.135Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5e/3c6f6e0430813c7aefe784d00c6711166f46225f5d229546eb53032c3707/h5py-3.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b51469890e58e85d5242e43aab29f5e9c7e526b951caab354f3ded4ac88e7b76", size = 2847803, upload-time = "2025-10-16T10:34:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/ba36273b888a4a48d78f9268d2aee05787e4438557450a8442946ab8f3ec/h5py-3.15.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a33bfd5dfcea037196f7778534b1ff7e36a7f40a89e648c8f2967292eb6898e", size = 4914884, upload-time = "2025-10-16T10:34:18.452Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/30/d1c94066343a98bb2cea40120873193a4fed68c4ad7f8935c11caf74c681/h5py-3.15.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25c8843fec43b2cc368aa15afa1cdf83fc5e17b1c4e10cd3771ef6c39b72e5ce", size = 5109965, upload-time = "2025-10-16T10:34:21.853Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3d/d28172116eafc3bc9f5991b3cb3fd2c8a95f5984f50880adfdf991de9087/h5py-3.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a308fd8681a864c04423c0324527237a0484e2611e3441f8089fd00ed56a8171", size = 4561870, upload-time = "2025-10-16T10:34:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/393a7226024238b0f51965a7156004eaae1fcf84aa4bfecf7e582676271b/h5py-3.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4a016df3f4a8a14d573b496e4d1964deb380e26031fc85fb40e417e9131888a", size = 5037161, upload-time = "2025-10-16T10:34:30.383Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/329e7436bf87ca6b0fe06dd0a3795c34bebe4ed8d6c44450a20565d57832/h5py-3.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:59b25cf02411bf12e14f803fef0b80886444c7fe21a5ad17c6a28d3f08098a1e", size = 2874165, upload-time = "2025-10-16T10:34:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/2d02b10a66747c54446e932171dd89b8b4126c0111b440e6bc05a7c852ec/h5py-3.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:61d5a58a9851e01ee61c932bbbb1c98fe20aba0a5674776600fb9a361c0aa652", size = 2458214, upload-time = "2025-10-16T10:34:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/40207e0192415cbff7ea1d37b9f24b33f6d38a5a2f5d18a678de78f967ae/h5py-3.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8440fd8bee9500c235ecb7aa1917a0389a2adb80c209fa1cc485bd70e0d94a5", size = 3376511, upload-time = "2025-10-16T10:34:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/31/96/ba99a003c763998035b0de4c299598125df5fc6c9ccf834f152ddd60e0fb/h5py-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab2219dbc6fcdb6932f76b548e2b16f34a1f52b7666e998157a4dfc02e2c4123", size = 2826143, upload-time = "2025-10-16T10:34:41.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c2/fc6375d07ea3962df7afad7d863fe4bde18bb88530678c20d4c90c18de1d/h5py-3.15.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8cb02c3a96255149ed3ac811eeea25b655d959c6dd5ce702c9a95ff11859eb5", size = 4908316, upload-time = "2025-10-16T10:34:44.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/4402ea66272dacc10b298cca18ed73e1c0791ff2ae9ed218d3859f9698ac/h5py-3.15.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:121b2b7a4c1915d63737483b7bff14ef253020f617c2fb2811f67a4bed9ac5e8", size = 5103710, upload-time = "2025-10-16T10:34:48.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f6/11f1e2432d57d71322c02a97a5567829a75f223a8c821764a0e71a65cde8/h5py-3.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59b0d63b318bf3cc06687def2b45afd75926bbc006f7b8cd2b1a231299fc8599", size = 4556042, upload-time = "2025-10-16T10:34:51.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/3eda3ef16bfe7a7dbc3d8d6836bbaa7986feb5ff091395e140dc13927bcc/h5py-3.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e02fe77a03f652500d8bff288cbf3675f742fc0411f5a628fa37116507dc7cc0", size = 5030639, upload-time = "2025-10-16T10:34:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ea/fbb258a98863f99befb10ed727152b4ae659f322e1d9c0576f8a62754e81/h5py-3.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dea78b092fd80a083563ed79a3171258d4a4d307492e7cf8b2313d464c82ba52", size = 2864363, upload-time = "2025-10-16T10:34:58.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c9/35021cc9cd2b2915a7da3026e3d77a05bed1144a414ff840953b33937fb9/h5py-3.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:c256254a8a81e2bddc0d376e23e2a6d2dc8a1e8a2261835ed8c1281a0744cd97", size = 2449570, upload-time = "2025-10-16T10:35:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2c/926eba1514e4d2e47d0e9eb16c784e717d8b066398ccfca9b283917b1bfb/h5py-3.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5f4fb0567eb8517c3ecd6b3c02c4f4e9da220c8932604960fd04e24ee1254763", size = 3380368, upload-time = "2025-10-16T10:35:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4b/d715ed454d3baa5f6ae1d30b7eca4c7a1c1084f6a2edead9e801a1541d62/h5py-3.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:954e480433e82d3872503104f9b285d369048c3a788b2b1a00e53d1c47c98dd2", size = 2833793, upload-time = "2025-10-16T10:35:05.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd125c131889ebbef0849f4a0e29cf363b48aba42f228d08b4079913b576bb3a", size = 4903199, upload-time = "2025-10-16T10:35:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28a20e1a4082a479b3d7db2169f3a5034af010b90842e75ebbf2e9e49eb4183e", size = 5097224, upload-time = "2025-10-16T10:35:12.808Z" },
+    { url = "https://files.pythonhosted.org/packages/30/30/5273218400bf2da01609e1292f562c94b461fcb73c7a9e27fdadd43abc0a/h5py-3.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa8df5267f545b4946df8ca0d93d23382191018e4cda2deda4c2cedf9a010e13", size = 4551207, upload-time = "2025-10-16T10:35:16.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
 ]
 
 [[package]]
@@ -2174,6 +2233,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements `ReconSchema` class in `fd5.imaging.recon` satisfying the `ProductSchema` protocol from `fd5.registry`
- Writes 3D/4D/5D float32 `volume` datasets with `affine`, `dimension_order`, `reference_frame`, `description` attrs; `frames/` group for 4D+ data with `frame_start`, `frame_duration`, `frame_label`, `frame_type`; multiscale `pyramid/` group with configurable levels; `mip_coronal` and `mip_sagittal` MIP projections
- Chunking: `(1, Y, X)` for 3D, `(1, 1, Y, X)` for 4D; gzip level 4 compression throughout
- `id_inputs` follows medical imaging convention: `timestamp + scanner + vendor_series_id`
- Registered via `fd5.schemas` entry point in `pyproject.toml` so `fd5.create(product="recon")` works
- 50 tests with 100% coverage on `fd5.imaging.recon`

## Test plan

- [x] `ReconSchema` satisfies `ProductSchema` protocol (runtime `isinstance` check)
- [x] `json_schema()` returns valid JSON Schema Draft 2020-12 with `product` const `"recon"`
- [x] `required_root_attrs()` returns `product="recon"`, `domain="medical_imaging"`
- [x] `id_inputs()` returns `["timestamp", "scanner", "vendor_series_id"]`
- [x] `write()` creates 3D volume with correct chunking `(1, Y, X)`, gzip-4, affine, dimension_order, reference_frame
- [x] `write()` creates 4D volume with `(1, 1, Y, X)` chunking and `frames/` group
- [x] `write()` creates `pyramid/` group with downsampled levels, scale_factors, affine
- [x] `write()` creates `mip_coronal` (Z, X) and `mip_sagittal` (Z, Y) projections
- [x] MIP for 4D data uses summed volume
- [x] Entry point `recon` discoverable via `importlib.metadata`
- [x] Integration: create → embed_schema → validate roundtrip passes
- [x] 100% test coverage

Closes #22

Made with [Cursor](https://cursor.com)