### PR TITLE
feat(cli): implement validate, info, schema-dump, manifest commands

### DIFF
--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -1,9 +1,130 @@
 """fd5 command-line interface."""
 
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
 import click
+import h5py
+
+from fd5.hash import verify
+from fd5.manifest import write_manifest
+from fd5.schema import dump_schema, validate
 
 
 @click.group()
 @click.version_option(package_name="fd5")
 def cli() -> None:
     """fd5 – Fusion Data Format 5 toolkit."""
+
+
+@cli.command()
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+def validate_cmd(file: str) -> None:
+    """Validate an fd5 file against its embedded schema and content_hash."""
+    path = Path(file)
+    errors: list[str] = []
+
+    try:
+        schema_errors = validate(path)
+    except KeyError:
+        click.echo("Error: file has no embedded _schema attribute.", err=True)
+        sys.exit(1)
+
+    for err in schema_errors:
+        errors.append(f"Schema: {err.message}")
+
+    if not verify(path):
+        errors.append("Integrity: content_hash mismatch or missing.")
+
+    if errors:
+        for msg in errors:
+            click.echo(msg, err=True)
+        sys.exit(1)
+
+    click.echo("OK – schema valid, content_hash verified.")
+
+
+# click registers the command name from the function; override with the decorator
+validate_cmd.name = "validate"
+
+
+@cli.command()
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+def info(file: str) -> None:
+    """Print file metadata: root attrs and dataset shapes."""
+    path = Path(file)
+
+    with h5py.File(path, "r") as f:
+        click.echo(f"File: {path.name}")
+
+        for key in sorted(f.attrs.keys()):
+            click.echo(f"  {key}: {_format_attr(f.attrs[key])}")
+
+        datasets = _collect_datasets(f)
+        if datasets:
+            click.echo("Datasets:")
+            for ds_path, shape, dtype in datasets:
+                click.echo(f"  {ds_path}: shape={shape}, dtype={dtype}")
+
+
+@cli.command("schema-dump")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+def schema_dump(file: str) -> None:
+    """Extract and pretty-print the embedded JSON Schema."""
+    path = Path(file)
+    try:
+        schema_dict = dump_schema(path)
+    except KeyError:
+        click.echo("Error: file has no embedded _schema attribute.", err=True)
+        sys.exit(1)
+
+    click.echo(json.dumps(schema_dict, indent=2))
+
+
+@cli.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output path for manifest.toml (default: <directory>/manifest.toml).",
+)
+def manifest(directory: str, output: str | None) -> None:
+    """Generate manifest.toml from fd5 files in a directory."""
+    dir_path = Path(directory)
+    out_path = Path(output) if output else dir_path / "manifest.toml"
+    write_manifest(dir_path, out_path)
+    click.echo(f"Wrote {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_attr(value: object) -> str:
+    import numpy as np
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if isinstance(value, np.generic):
+        return str(value.item())
+    return str(value)
+
+
+def _collect_datasets(
+    group: h5py.Group, prefix: str = ""
+) -> list[tuple[str, tuple[int, ...], str]]:
+    results: list[tuple[str, tuple[int, ...], str]] = []
+    for key in sorted(group.keys()):
+        item = group[key]
+        full_path = f"{prefix}/{key}" if prefix else key
+        if isinstance(item, h5py.Dataset):
+            results.append((full_path, item.shape, str(item.dtype)))
+        elif isinstance(item, h5py.Group):
+            results.extend(_collect_datasets(item, full_path))
+    return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,310 @@
+"""Tests for fd5.cli — validate, info, schema-dump, manifest commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from fd5.cli import cli
+from fd5.hash import compute_content_hash
+from fd5.h5io import dict_to_h5
+from fd5.schema import embed_schema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def valid_h5(tmp_path: Path) -> Path:
+    """Create a valid fd5 file with embedded schema and correct content_hash."""
+    path = tmp_path / "valid.h5"
+    schema_dict = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "_schema_version": {"type": "integer"},
+            "product": {"type": "string"},
+        },
+        "required": ["_schema_version", "product"],
+    }
+    with h5py.File(path, "w") as f:
+        embed_schema(f, schema_dict)
+        f.attrs["product"] = "test/recon"
+        f.attrs["id"] = "sha256:abc123"
+        f.attrs["timestamp"] = "2026-01-15T10:00:00Z"
+        f.create_dataset("volume", data=np.zeros((4, 4), dtype=np.float32))
+        f.attrs["content_hash"] = compute_content_hash(f)
+    return path
+
+
+@pytest.fixture()
+def invalid_schema_h5(tmp_path: Path) -> Path:
+    """Create an fd5 file that fails schema validation (missing required attr)."""
+    path = tmp_path / "invalid_schema.h5"
+    schema_dict = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "product": {"type": "string"},
+        },
+        "required": ["product"],
+    }
+    with h5py.File(path, "w") as f:
+        embed_schema(f, schema_dict)
+        # 'product' missing — validation should fail
+        f.attrs["content_hash"] = compute_content_hash(f)
+    return path
+
+
+@pytest.fixture()
+def bad_hash_h5(tmp_path: Path) -> Path:
+    """Create an fd5 file with valid schema but wrong content_hash."""
+    path = tmp_path / "bad_hash.h5"
+    schema_dict = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "product": {"type": "string"},
+        },
+        "required": ["product"],
+    }
+    with h5py.File(path, "w") as f:
+        embed_schema(f, schema_dict)
+        f.attrs["product"] = "test/recon"
+        f.attrs["content_hash"] = (
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        )
+    return path
+
+
+@pytest.fixture()
+def no_schema_h5(tmp_path: Path) -> Path:
+    """Create an HDF5 file without an embedded schema."""
+    path = tmp_path / "no_schema.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["product"] = "test/recon"
+    return path
+
+
+@pytest.fixture()
+def data_dir(tmp_path: Path) -> Path:
+    """Create a directory with sample .h5 files for manifest generation."""
+    _create_h5(
+        tmp_path / "recon-aabb.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "recon",
+            "id": "sha256:aabb",
+            "id_inputs": "timestamp + scanner_uuid",
+            "name": "PET recon",
+            "description": "PET reconstruction",
+            "content_hash": "sha256:deadbeef",
+            "timestamp": "2026-01-15T10:00:00Z",
+        },
+    )
+    _create_h5(
+        tmp_path / "roi-ccdd.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "roi",
+            "id": "sha256:ccdd",
+            "id_inputs": "reference + method",
+            "name": "Tumor ROI",
+            "description": "Manual contours",
+            "content_hash": "sha256:cafebabe",
+            "timestamp": "2026-01-16T11:00:00Z",
+        },
+    )
+    return tmp_path
+
+
+def _create_h5(path: Path, root_attrs: dict) -> None:
+    with h5py.File(path, "w") as f:
+        dict_to_h5(f, root_attrs)
+
+
+# ---------------------------------------------------------------------------
+# fd5 validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCommand:
+    def test_valid_file_exits_zero(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["validate", str(valid_h5)])
+        assert result.exit_code == 0
+
+    def test_valid_file_shows_ok(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["validate", str(valid_h5)])
+        assert "ok" in result.output.lower() or "valid" in result.output.lower()
+
+    def test_schema_errors_exit_one(self, runner: CliRunner, invalid_schema_h5: Path):
+        result = runner.invoke(cli, ["validate", str(invalid_schema_h5)])
+        assert result.exit_code == 1
+
+    def test_schema_errors_show_details(
+        self, runner: CliRunner, invalid_schema_h5: Path
+    ):
+        result = runner.invoke(cli, ["validate", str(invalid_schema_h5)])
+        assert "product" in result.output.lower()
+
+    def test_bad_hash_exits_one(self, runner: CliRunner, bad_hash_h5: Path):
+        result = runner.invoke(cli, ["validate", str(bad_hash_h5)])
+        assert result.exit_code == 1
+
+    def test_bad_hash_mentions_hash(self, runner: CliRunner, bad_hash_h5: Path):
+        result = runner.invoke(cli, ["validate", str(bad_hash_h5)])
+        assert (
+            "content_hash" in result.output.lower() or "hash" in result.output.lower()
+        )
+
+    def test_no_schema_exits_one(self, runner: CliRunner, no_schema_h5: Path):
+        result = runner.invoke(cli, ["validate", str(no_schema_h5)])
+        assert result.exit_code == 1
+
+    def test_nonexistent_file_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["validate", str(tmp_path / "ghost.h5")])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# fd5 info
+# ---------------------------------------------------------------------------
+
+
+class TestInfoCommand:
+    def test_exits_zero(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert result.exit_code == 0
+
+    def test_shows_product(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert "test/recon" in result.output
+
+    def test_shows_id(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert "sha256:abc123" in result.output
+
+    def test_shows_timestamp(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert "2026-01-15" in result.output
+
+    def test_shows_content_hash(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert "content_hash" in result.output.lower() or "sha256:" in result.output
+
+    def test_shows_dataset_shapes(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["info", str(valid_h5)])
+        assert (
+            "(4, 4)" in result.output
+            or "4 x 4" in result.output
+            or "4, 4" in result.output
+        )
+
+    def test_nonexistent_file_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["info", str(tmp_path / "ghost.h5")])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# fd5 schema-dump
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDumpCommand:
+    def test_exits_zero(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["schema-dump", str(valid_h5)])
+        assert result.exit_code == 0
+
+    def test_outputs_valid_json(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["schema-dump", str(valid_h5)])
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, dict)
+
+    def test_schema_has_expected_fields(self, runner: CliRunner, valid_h5: Path):
+        result = runner.invoke(cli, ["schema-dump", str(valid_h5)])
+        parsed = json.loads(result.output)
+        assert "$schema" in parsed
+        assert parsed["type"] == "object"
+
+    def test_no_schema_exits_one(self, runner: CliRunner, no_schema_h5: Path):
+        result = runner.invoke(cli, ["schema-dump", str(no_schema_h5)])
+        assert result.exit_code == 1
+
+    def test_nonexistent_file_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["schema-dump", str(tmp_path / "ghost.h5")])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# fd5 manifest
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCommand:
+    def test_exits_zero(self, runner: CliRunner, data_dir: Path):
+        result = runner.invoke(cli, ["manifest", str(data_dir)])
+        assert result.exit_code == 0
+
+    def test_creates_manifest_file(self, runner: CliRunner, data_dir: Path):
+        runner.invoke(cli, ["manifest", str(data_dir)])
+        assert (data_dir / "manifest.toml").exists()
+
+    def test_manifest_is_valid_toml(self, runner: CliRunner, data_dir: Path):
+        import tomllib
+
+        runner.invoke(cli, ["manifest", str(data_dir)])
+        content = (data_dir / "manifest.toml").read_text()
+        parsed = tomllib.loads(content)
+        assert isinstance(parsed, dict)
+
+    def test_manifest_has_data_entries(self, runner: CliRunner, data_dir: Path):
+        import tomllib
+
+        runner.invoke(cli, ["manifest", str(data_dir)])
+        parsed = tomllib.loads((data_dir / "manifest.toml").read_text())
+        assert len(parsed["data"]) == 2
+
+    def test_custom_output_path(
+        self, runner: CliRunner, data_dir: Path, tmp_path: Path
+    ):
+        out = tmp_path / "custom" / "out.toml"
+        result = runner.invoke(cli, ["manifest", str(data_dir), "--output", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+
+    def test_nonexistent_dir_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["manifest", str(tmp_path / "nope")])
+        assert result.exit_code != 0
+
+    def test_empty_dir(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["manifest", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (tmp_path / "manifest.toml").exists()
+
+
+# ---------------------------------------------------------------------------
+# fd5 --help
+# ---------------------------------------------------------------------------
+
+
+class TestHelp:
+    def test_help_exits_zero(self, runner: CliRunner):
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+
+    def test_help_lists_commands(self, runner: CliRunner):
+        result = runner.invoke(cli, ["--help"])
+        for cmd in ("validate", "info", "schema-dump", "manifest"):
+            assert cmd in result.output


### PR DESCRIPTION
## Summary
- Implement 4 CLI commands using click: validate, info, schema-dump, manifest
- Uses existing fd5.schema, fd5.h5io, fd5.manifest modules

Closes #23

Made with [Cursor](https://cursor.com)