### PR TITLE
fix(ci): skip vig-utils hooks unavailable outside devcontainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           sync-dependencies: 'true'
 
       - name: Run pre-commit hooks
+        env:
+          SKIP: check-action-pins,validate-commit-msg
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   test:


### PR DESCRIPTION
## Summary

- Adds `SKIP=check-action-pins,validate-commit-msg` env var to the pre-commit step in CI, so hooks depending on the devcontainer-only `vig-utils` package are cleanly skipped instead of causing spawn failures.

## Details

The `check-action-pins` and `validate-commit-msg` pre-commit hooks call entry points from `vig-utils`, which is installed system-wide in the vigOS devcontainer but is not available in CI (not on PyPI). This caused the lint job to fail with `No such file or directory` errors.

Using pre-commit's native `SKIP` env var is the simplest fix — the hooks still run locally in the devcontainer and are only skipped in the CI environment where `vig-utils` is unavailable.

## Test plan

- [ ] CI lint job passes without `check-action-pins` spawn errors
- [ ] Other pre-commit hooks still run normally
- [ ] `check-action-pins` and `validate-commit-msg` continue to work locally in devcontainer

Closes #63

Made with [Cursor](https://cursor.com)