### PR TITLE
docs: add project README and backfill CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HDF5 dict round-trip helpers** ([#12](https://github.com/vig-os/fd5/issues/12))
+  - `dict_to_h5(group, d)` writes nested Python dicts as HDF5 attrs/sub-groups
+  - `h5_to_dict(group)` reads HDF5 attrs and sub-groups back to a Python dict
+  - Deterministic sorted-key layout; lossless type mapping for str, int, float, bool, lists, and nested dicts
+
+- **Physical units convention helpers** ([#13](https://github.com/vig-os/fd5/issues/13))
+  - `write_quantity(group, name, value, units, unit_si)` creates sub-groups with `value`, `units`, `unitSI` attrs
+  - `read_quantity(group, name)` reads them back as a `(value, units, unit_si)` tuple
+  - `set_dataset_units(dataset, units, unit_si)` sets units attrs on datasets
+
+- **Merkle tree hashing and content_hash computation** ([#14](https://github.com/vig-os/fd5/issues/14))
+  - `compute_id(inputs, desc)` computes SHA-256 identity hashes from key-value pairs
+  - `ChunkHasher` for per-chunk SHA-256 accumulation during streaming writes
+  - `MerkleTree` bottom-up hash of an HDF5 file for file-level integrity
+  - `compute_content_hash(root)` and `verify(path)` for sealing and verification
+
+- **JSON Schema embedding and validation** ([#15](https://github.com/vig-os/fd5/issues/15))
+  - `embed_schema(file, schema_dict)` writes `_schema` JSON string attr at file root
+  - `dump_schema(path)` extracts and parses the embedded schema
+  - `validate(path)` validates file structure against its embedded JSON Schema (Draft 2020-12)
+  - `generate_schema(product_type)` produces a JSON Schema document via the registry
+
+- **Provenance group writers** ([#16](https://github.com/vig-os/fd5/issues/16))
+  - `write_sources(file, sources)` creates `sources/` group with per-source sub-groups and HDF5 external links
+  - `write_original_files(file, records)` creates `provenance/original_files` compound dataset
+  - `write_ingest(file, tool, version, timestamp)` creates `provenance/ingest/` group
+
+- **Product schema registry with entry-point discovery** ([#17](https://github.com/vig-os/fd5/issues/17))
+  - `get_schema(product_type)` looks up registered schemas
+  - `register_schema(product_type, schema)` for programmatic registration
+  - `list_schemas()` returns all registered product-type strings
+  - Auto-discovers schemas from `fd5.schemas` entry-point group
+
+- **Filename generation utility** ([#18](https://github.com/vig-os/fd5/issues/18))
+  - `generate_filename(product, id_hash, timestamp, descriptors)` produces deterministic fd5 filenames
+  - Format: `YYYY-MM-DD_HH-MM-SS_<product>-<id8>.h5`
+
+- **`fd5.create()` builder / context-manager API** ([#19](https://github.com/vig-os/fd5/issues/19))
+  - Context manager that creates a sealed fd5 file with atomic rename on success
+  - `Fd5Builder` with `write_metadata`, `write_sources`, `write_provenance`, `write_study`, `write_extra`, `write_product`
+  - Auto-embeds schema, computes content hash, and validates required attrs on seal
+
 - **TOML manifest generation and parsing** ([#20](https://github.com/vig-os/fd5/issues/20))
   - `build_manifest(directory)` scans `.h5` files and extracts root attrs
   - `write_manifest(directory, output_path)` writes `manifest.toml`
   - `read_manifest(path)` parses an existing `manifest.toml`
 
+- **Project dependencies** ([#21](https://github.com/vig-os/fd5/issues/21))
+  - Core: `h5py`, `numpy`, `jsonschema`, `tomli-w`, `click`
+  - Optional `dev` and `science` extras in `pyproject.toml`
+
+- **Recon product schema** ([#22](https://github.com/vig-os/fd5/issues/22))
+  - `ReconSchema` for reconstructed image volumes (3D/4D/5D float32)
+  - Multiscale pyramid generation, MIP projections (coronal/sagittal), dynamic frame support
+  - Chunked gzip compression; affine transforms and dimension ordering
+
+- **CLI commands** ([#23](https://github.com/vig-os/fd5/issues/23))
+  - `fd5 validate` — validate schema and content_hash integrity
+  - `fd5 info` — print root attributes and dataset shapes
+  - `fd5 schema-dump` — extract and pretty-print embedded JSON Schema
+  - `fd5 manifest` — generate `manifest.toml` from a directory of fd5 files
+
+- **Streaming chunk write + inline hashing spike** ([#24](https://github.com/vig-os/fd5/issues/24))
+  - Validated h5py streaming chunk write with inline SHA-256 hashing workflow
+
+- **End-to-end integration test** ([#49](https://github.com/vig-os/fd5/issues/49))
+  - Full create → validate → info → manifest round-trip test
+
+### Fixed
+
+- **CI lint job missing tool dependencies** ([#48](https://github.com/vig-os/fd5/issues/48))
+  - Added pre-commit and linting tools to dev extras in `pyproject.toml`
+
 ### Changed
 
 ### Removed
-
-### Fixed
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,1 +1,152 @@
-# README
+# fd5 — FAIR Data on HDF5
+
+`fd5` is a self-describing, FAIR-principled data format for scientific data products built on HDF5. It defines conventions for storing N-dimensional arrays, tabular event data, time series, histograms, and arbitrary scientific measurements alongside their full metadata, provenance, and schema — all inside a single, immutable HDF5 file per data product.
+
+The format is **domain-agnostic by design**: the core conventions (schema, provenance DAG, units, hashing, metadata structure) apply to any domain that produces immutable data products. Domain-specific **product schemas** are layered on top.
+
+See [`white-paper.md`](white-paper.md) for the full specification.
+
+## Features
+
+- **Self-describing files** — embedded JSON Schema, `description` attributes on every group/dataset, units convention (`@units` / `@unitSI`) for AI and human readability
+- **Immutable, write-once** — files are sealed with a Merkle-tree content hash at creation time; integrity is verifiable at any point
+- **FAIR compliance** — persistent identifiers, structured metadata, open format, full provenance chain
+- **Context-manager API** — `fd5.create()` orchestrates file creation, schema embedding, hashing, and atomic rename in one call
+- **Product schema registry** — extensible via Python entry points (`fd5.schemas` group); ships with `recon` (reconstructed image volumes)
+- **Lossless dict ↔ HDF5 round-trip** — `dict_to_h5` / `h5_to_dict` for nested metadata
+- **Physical units helpers** — `write_quantity` / `read_quantity` and `set_dataset_units` following NeXus/OpenPMD conventions
+- **Provenance tracking** — `sources/` group with external links, `provenance/original_files` compound dataset, ingest metadata
+- **TOML manifest** — scan a directory of `.h5` files and generate a `manifest.toml` index
+- **Deterministic filenames** — `YYYY-MM-DD_HH-MM-SS_<product>-<id8>.h5`
+- **CLI toolkit** — `fd5 validate`, `fd5 info`, `fd5 schema-dump`, `fd5 manifest`
+
+## Installation
+
+```bash
+pip install fd5
+```
+
+With optional scientific extras:
+
+```bash
+pip install "fd5[science]"
+```
+
+For development:
+
+```bash
+pip install "fd5[dev]"
+```
+
+## Quickstart
+
+### Python API
+
+```python
+import numpy as np
+from fd5.create import create
+
+with create(
+    "output/",
+    product="recon",
+    name="patient-001-brain-pet",
+    description="FDG-PET brain reconstruction",
+    timestamp="2025-06-15T10:30:00+00:00",
+) as builder:
+    # Write product-specific data
+    builder.write_product({
+        "volume": np.random.rand(128, 128, 128).astype(np.float32),
+        "affine": np.eye(4),
+        "dimension_order": "ZYX",
+        "reference_frame": "LPS",
+        "description": "Reconstructed PET volume",
+    })
+
+    # Write metadata, provenance, study info
+    builder.write_metadata({"scanner": "Siemens Biograph", "tracer": "FDG"})
+    builder.write_provenance(
+        original_files=[{"path": "raw/pet.dcm", "sha256": "abc...", "size_bytes": 1024}],
+        ingest_tool="my-pipeline",
+        ingest_version="1.0.0",
+        ingest_timestamp="2025-06-15T10:30:00+00:00",
+    )
+
+# File is automatically sealed: schema embedded, content_hash computed, renamed
+```
+
+### CLI
+
+```bash
+# Validate schema + integrity
+fd5 validate output/2025-06-15_10-30-00_recon-a1b2c3d4.h5
+
+# Print root attributes and dataset shapes
+fd5 info output/2025-06-15_10-30-00_recon-a1b2c3d4.h5
+
+# Extract embedded JSON Schema
+fd5 schema-dump output/2025-06-15_10-30-00_recon-a1b2c3d4.h5
+
+# Generate manifest.toml for a directory of fd5 files
+fd5 manifest output/
+```
+
+## Architecture
+
+The architecture is defined in the [white paper](white-paper.md). Key design decisions:
+
+- **HDF5 is the single source of truth** — all other representations (TOML, YAML, JSON-LD) are derived dumps
+- **One file = one data product** — each gets its own sealed `.h5` file
+- **`_type` + `_version`** for forward-compatible extensibility
+- **Merkle-tree hashing** for file-level integrity verification
+- **Entry-point registry** for pluggable product schemas
+
+### Module layout
+
+```
+src/fd5/
+├── __init__.py          # Package root
+├── create.py            # fd5.create() builder / context manager
+├── h5io.py              # dict ↔ HDF5 round-trip helpers
+├── hash.py              # Merkle tree hashing, id computation, verify()
+├── units.py             # Physical units convention helpers
+├── schema.py            # JSON Schema embed / validate / dump / generate
+├── registry.py          # Product schema registry (entry-point discovery)
+├── provenance.py        # sources/ and provenance/ group writers
+├── manifest.py          # TOML manifest generation and parsing
+├── naming.py            # Deterministic filename generation
+├── cli.py               # Click CLI (validate, info, schema-dump, manifest)
+└── imaging/
+    ├── __init__.py      # Medical imaging domain schemas
+    └── recon.py         # Recon product schema (3D/4D/5D volumes)
+```
+
+## Development
+
+### Prerequisites
+
+- Python ≥ 3.12
+- [uv](https://docs.astral.sh/uv/) (recommended) or pip
+
+### Setup
+
+```bash
+git clone https://github.com/vig-os/fd5.git
+cd fd5
+pip install -e ".[dev]"
+```
+
+### Running tests
+
+```bash
+pytest
+```
+
+### Project dependencies
+
+Core: `h5py`, `numpy`, `jsonschema`, `tomli-w`, `click`
+
+See [`pyproject.toml`](pyproject.toml) for the full dependency specification.
+
+## License
+
+See the project repository for license details.


### PR DESCRIPTION
## Summary

- **README.md**: Added project overview (what is fd5, FAIR data format on HDF5), feature list, installation instructions, quickstart with `fd5.create()` Python API example, CLI usage examples, architecture/module layout reference, and development setup guide
- **CHANGELOG.md**: Backfilled entries for all implemented modules (#12–#24), CI lint fix (#48), and end-to-end integration test (#49) under Unreleased/Added and Unreleased/Fixed, following the changelog format rules

## Test plan

- [x] Pre-commit hooks pass (pymarkdown, typos, etc.)
- [ ] Review README quickstart example matches current `fd5.create()` API
- [ ] Review CHANGELOG entries match implemented features and correct issue numbers
- [ ] CI lint failure is a known issue (#63) — ignore

Closes #65

Made with [Cursor](https://cursor.com)