### PR TITLE
feat(imaging): add sinogram product schema for projection data

### DIFF
--- a/src/fd5/imaging/sinogram.py
+++ b/src/fd5/imaging/sinogram.py
@@ -1,0 +1,215 @@
+"""fd5.imaging.sinogram — Sinogram product schema for projection data.
+
+Implements the ``sinogram`` product schema per white-paper.md § sinogram.
+Handles 3D/4D float32 arrays indexed by detector coordinates
+(radial, angular, axial ring-difference, optionally TOF bin) with
+scanner geometry metadata and correction flags.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+_SCHEMA_VERSION = "1.0.0"
+
+_GZIP_LEVEL = 4
+
+_ID_INPUTS = ["timestamp", "scanner", "vendor_series_id"]
+
+
+class SinogramSchema:
+    """Product schema for projection data (``sinogram``)."""
+
+    product_type: str = "sinogram"
+    schema_version: str = _SCHEMA_VERSION
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "sinogram"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "domain": {"type": "string"},
+                "n_radial": {"type": "integer"},
+                "n_angular": {"type": "integer"},
+                "n_planes": {"type": "integer"},
+                "span": {"type": "integer"},
+                "max_ring_diff": {"type": "integer"},
+                "tof_bins": {"type": "integer"},
+            },
+            "required": [
+                "_schema_version",
+                "product",
+                "name",
+                "description",
+                "n_radial",
+                "n_angular",
+                "n_planes",
+                "span",
+                "max_ring_diff",
+                "tof_bins",
+            ],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {
+            "product": "sinogram",
+            "domain": "medical_imaging",
+        }
+
+    def id_inputs(self) -> list[str]:
+        return list(_ID_INPUTS)
+
+    def write(self, target: h5py.File | h5py.Group, data: dict[str, Any]) -> None:
+        """Write sinogram data to *target*.
+
+        *data* must contain:
+        - ``sinogram``: numpy float32 array, 3D (n_planes, n_angular, n_radial)
+          or 4D (n_planes, n_tof, n_angular, n_radial) when TOF
+        - ``n_radial``, ``n_angular``, ``n_planes``: int
+        - ``span``: int — axial compression factor
+        - ``max_ring_diff``: int
+        - ``tof_bins``: int — 0 or 1 for non-TOF
+
+        Optional keys:
+        - ``acquisition``: dict with scanner geometry
+        - ``corrections_applied``: dict with correction flags
+        - ``additive_correction``: numpy array (same shape as sinogram)
+        - ``multiplicative_correction``: numpy array (same shape as sinogram)
+        """
+        self._write_root_attrs(target, data)
+        self._write_sinogram(target, data["sinogram"])
+        self._write_metadata(target, data)
+
+        if "additive_correction" in data:
+            self._write_correction(
+                target,
+                "additive_correction",
+                data["additive_correction"],
+                "Additive correction term (scatter + randoms)",
+            )
+
+        if "multiplicative_correction" in data:
+            self._write_correction(
+                target,
+                "multiplicative_correction",
+                data["multiplicative_correction"],
+                "Multiplicative correction term (normalization * attenuation)",
+            )
+
+    # ------------------------------------------------------------------
+    # Root attrs
+    # ------------------------------------------------------------------
+
+    def _write_root_attrs(
+        self,
+        target: h5py.File | h5py.Group,
+        data: dict[str, Any],
+    ) -> None:
+        target.attrs["n_radial"] = np.int64(data["n_radial"])
+        target.attrs["n_angular"] = np.int64(data["n_angular"])
+        target.attrs["n_planes"] = np.int64(data["n_planes"])
+        target.attrs["span"] = np.int64(data["span"])
+        target.attrs["max_ring_diff"] = np.int64(data["max_ring_diff"])
+        target.attrs["tof_bins"] = np.int64(data["tof_bins"])
+
+    # ------------------------------------------------------------------
+    # Sinogram dataset
+    # ------------------------------------------------------------------
+
+    def _write_sinogram(
+        self,
+        target: h5py.File | h5py.Group,
+        sinogram: np.ndarray,
+    ) -> None:
+        ndim = sinogram.ndim
+        chunks = (1,) * (ndim - 2) + sinogram.shape[-2:]
+        ds = target.create_dataset(
+            "sinogram",
+            data=sinogram,
+            chunks=chunks,
+            compression="gzip",
+            compression_opts=_GZIP_LEVEL,
+        )
+        ds.attrs["description"] = "Projection data in sinogram format"
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def _write_metadata(
+        self,
+        target: h5py.File | h5py.Group,
+        data: dict[str, Any],
+    ) -> None:
+        meta = target.create_group("metadata")
+
+        if "acquisition" in data:
+            self._write_acquisition(meta, data["acquisition"])
+
+        if "corrections_applied" in data:
+            self._write_corrections_applied(meta, data["corrections_applied"])
+
+    def _write_acquisition(
+        self,
+        meta_grp: h5py.Group,
+        acq: dict[str, Any],
+    ) -> None:
+        grp = meta_grp.create_group("acquisition")
+        grp.attrs["n_rings"] = np.int64(acq["n_rings"])
+        grp.attrs["n_crystals_per_ring"] = np.int64(acq["n_crystals_per_ring"])
+        grp.attrs["description"] = "Scanner geometry"
+
+        rs_grp = grp.create_group("ring_spacing")
+        rs_grp.attrs["value"] = np.float64(acq["ring_spacing"])
+        rs_grp.attrs["units"] = "mm"
+        rs_grp.attrs["unitSI"] = np.float64(0.001)
+
+        cp_grp = grp.create_group("crystal_pitch")
+        cp_grp.attrs["value"] = np.float64(acq["crystal_pitch"])
+        cp_grp.attrs["units"] = "mm"
+        cp_grp.attrs["unitSI"] = np.float64(0.001)
+
+    def _write_corrections_applied(
+        self,
+        meta_grp: h5py.Group,
+        corrections: dict[str, bool],
+    ) -> None:
+        grp = meta_grp.create_group("corrections_applied")
+        grp.attrs["normalization"] = np.bool_(corrections.get("normalization", False))
+        grp.attrs["attenuation"] = np.bool_(corrections.get("attenuation", False))
+        grp.attrs["scatter"] = np.bool_(corrections.get("scatter", False))
+        grp.attrs["randoms"] = np.bool_(corrections.get("randoms", False))
+        grp.attrs["dead_time"] = np.bool_(corrections.get("dead_time", False))
+        grp.attrs["decay"] = np.bool_(corrections.get("decay", False))
+        grp.attrs["description"] = (
+            "Which corrections have been applied to this sinogram"
+        )
+
+    # ------------------------------------------------------------------
+    # Correction datasets
+    # ------------------------------------------------------------------
+
+    def _write_correction(
+        self,
+        target: h5py.File | h5py.Group,
+        name: str,
+        array: np.ndarray,
+        description: str,
+    ) -> None:
+        ndim = array.ndim
+        chunks = (1,) * (ndim - 2) + array.shape[-2:]
+        ds = target.create_dataset(
+            name,
+            data=array,
+            chunks=chunks,
+            compression="gzip",
+            compression_opts=_GZIP_LEVEL,
+        )
+        ds.attrs["description"] = description

--- a/tests/test_sinogram.py
+++ b/tests/test_sinogram.py
@@ -1,0 +1,459 @@
+"""Tests for fd5.imaging.sinogram — SinogramSchema product schema."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.registry import ProductSchema, register_schema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def schema():
+    from fd5.imaging.sinogram import SinogramSchema
+
+    return SinogramSchema()
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    path = tmp_path / "sinogram.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path):
+    return tmp_path / "sinogram.h5"
+
+
+def _make_sinogram_3d(shape=(11, 180, 128)):
+    return np.random.default_rng(42).random(shape, dtype=np.float32)
+
+
+def _make_sinogram_4d(shape=(11, 13, 180, 128)):
+    return np.random.default_rng(42).random(shape, dtype=np.float32)
+
+
+def _minimal_3d_data():
+    sino = _make_sinogram_3d((11, 180, 128))
+    return {
+        "sinogram": sino,
+        "n_radial": 128,
+        "n_angular": 180,
+        "n_planes": 11,
+        "span": 3,
+        "max_ring_diff": 5,
+        "tof_bins": 0,
+    }
+
+
+def _minimal_4d_data():
+    sino = _make_sinogram_4d((11, 13, 180, 128))
+    return {
+        "sinogram": sino,
+        "n_radial": 128,
+        "n_angular": 180,
+        "n_planes": 11,
+        "span": 3,
+        "max_ring_diff": 5,
+        "tof_bins": 13,
+    }
+
+
+def _full_data():
+    data = _minimal_3d_data()
+    data["acquisition"] = {
+        "n_rings": 64,
+        "n_crystals_per_ring": 504,
+        "ring_spacing": 4.0,
+        "crystal_pitch": 2.0,
+    }
+    data["corrections_applied"] = {
+        "normalization": True,
+        "attenuation": True,
+        "scatter": False,
+        "randoms": True,
+        "dead_time": False,
+        "decay": True,
+    }
+    data["additive_correction"] = np.zeros((11, 180, 128), dtype=np.float32)
+    data["multiplicative_correction"] = np.ones((11, 180, 128), dtype=np.float32)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_satisfies_product_schema_protocol(self, schema):
+        assert isinstance(schema, ProductSchema)
+
+    def test_product_type_is_sinogram(self, schema):
+        assert schema.product_type == "sinogram"
+
+    def test_schema_version_is_string(self, schema):
+        assert isinstance(schema.schema_version, str)
+
+    def test_has_required_methods(self, schema):
+        assert callable(schema.json_schema)
+        assert callable(schema.required_root_attrs)
+        assert callable(schema.write)
+        assert callable(schema.id_inputs)
+
+
+# ---------------------------------------------------------------------------
+# json_schema()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchema:
+    def test_returns_dict(self, schema):
+        result = schema.json_schema()
+        assert isinstance(result, dict)
+
+    def test_has_draft_2020_12_meta(self, schema):
+        result = schema.json_schema()
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_product_const_is_sinogram(self, schema):
+        result = schema.json_schema()
+        assert result["properties"]["product"]["const"] == "sinogram"
+
+    def test_requires_sinogram_fields(self, schema):
+        result = schema.json_schema()
+        required = result["required"]
+        for field in [
+            "_schema_version",
+            "product",
+            "name",
+            "description",
+            "n_radial",
+            "n_angular",
+            "n_planes",
+            "span",
+            "max_ring_diff",
+            "tof_bins",
+        ]:
+            assert field in required
+
+    def test_sinogram_geometry_properties(self, schema):
+        result = schema.json_schema()
+        props = result["properties"]
+        for field in [
+            "n_radial",
+            "n_angular",
+            "n_planes",
+            "span",
+            "max_ring_diff",
+            "tof_bins",
+        ]:
+            assert field in props
+            assert props[field]["type"] == "integer"
+
+    def test_valid_json_schema(self, schema):
+        import jsonschema
+
+        result = schema.json_schema()
+        jsonschema.Draft202012Validator.check_schema(result)
+
+
+# ---------------------------------------------------------------------------
+# required_root_attrs()
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredRootAttrs:
+    def test_returns_dict(self, schema):
+        result = schema.required_root_attrs()
+        assert isinstance(result, dict)
+
+    def test_contains_product_sinogram(self, schema):
+        result = schema.required_root_attrs()
+        assert result["product"] == "sinogram"
+
+    def test_contains_domain(self, schema):
+        result = schema.required_root_attrs()
+        assert result["domain"] == "medical_imaging"
+
+
+# ---------------------------------------------------------------------------
+# id_inputs()
+# ---------------------------------------------------------------------------
+
+
+class TestIdInputs:
+    def test_returns_list_of_strings(self, schema):
+        result = schema.id_inputs()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_follows_medical_imaging_convention(self, schema):
+        result = schema.id_inputs()
+        assert "timestamp" in result
+        assert "scanner" in result
+        assert "vendor_series_id" in result
+
+
+# ---------------------------------------------------------------------------
+# write() — 3D non-TOF sinogram
+# ---------------------------------------------------------------------------
+
+
+class TestWrite3D:
+    def test_writes_sinogram_dataset(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "sinogram" in h5file
+        assert h5file["sinogram"].dtype == np.float32
+
+    def test_sinogram_shape_matches(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["sinogram"].shape == (11, 180, 128)
+
+    def test_sinogram_has_description(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert (
+            h5file["sinogram"].attrs["description"]
+            == "Projection data in sinogram format"
+        )
+
+    def test_3d_chunking_strategy(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        chunks = h5file["sinogram"].chunks
+        assert chunks == (1, 180, 128)
+
+    def test_gzip_compression_level_4(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file["sinogram"].compression == "gzip"
+        assert h5file["sinogram"].compression_opts == 4
+
+    def test_root_attrs_written(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert h5file.attrs["n_radial"] == 128
+        assert h5file.attrs["n_angular"] == 180
+        assert h5file.attrs["n_planes"] == 11
+        assert h5file.attrs["span"] == 3
+        assert h5file.attrs["max_ring_diff"] == 5
+        assert h5file.attrs["tof_bins"] == 0
+
+    def test_metadata_group_exists(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "metadata" in h5file
+
+    def test_data_round_trip(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        np.testing.assert_array_equal(h5file["sinogram"][:], data["sinogram"])
+
+
+# ---------------------------------------------------------------------------
+# write() — 4D TOF sinogram
+# ---------------------------------------------------------------------------
+
+
+class TestWrite4D:
+    def test_writes_sinogram_dataset(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "sinogram" in h5file
+        assert h5file["sinogram"].shape == (11, 13, 180, 128)
+
+    def test_4d_chunking_strategy(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        chunks = h5file["sinogram"].chunks
+        assert chunks == (1, 1, 180, 128)
+
+    def test_tof_bins_in_root_attrs(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert h5file.attrs["tof_bins"] == 13
+
+    def test_4d_data_round_trip(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        np.testing.assert_array_equal(h5file["sinogram"][:], data["sinogram"])
+
+
+# ---------------------------------------------------------------------------
+# write() — acquisition metadata
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAcquisition:
+    def test_acquisition_group_created(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        assert "metadata/acquisition" in h5file
+
+    def test_acquisition_attrs(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/acquisition"]
+        assert grp.attrs["n_rings"] == 64
+        assert grp.attrs["n_crystals_per_ring"] == 504
+        assert grp.attrs["description"] == "Scanner geometry"
+
+    def test_ring_spacing(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/acquisition/ring_spacing"]
+        assert float(grp.attrs["value"]) == 4.0
+        assert grp.attrs["units"] == "mm"
+        assert float(grp.attrs["unitSI"]) == 0.001
+
+    def test_crystal_pitch(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/acquisition/crystal_pitch"]
+        assert float(grp.attrs["value"]) == 2.0
+        assert grp.attrs["units"] == "mm"
+        assert float(grp.attrs["unitSI"]) == 0.001
+
+
+# ---------------------------------------------------------------------------
+# write() — corrections_applied metadata
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCorrections:
+    def test_corrections_group_created(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        assert "metadata/corrections_applied" in h5file
+
+    def test_corrections_flags(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/corrections_applied"]
+        assert bool(grp.attrs["normalization"]) is True
+        assert bool(grp.attrs["attenuation"]) is True
+        assert bool(grp.attrs["scatter"]) is False
+        assert bool(grp.attrs["randoms"]) is True
+        assert bool(grp.attrs["dead_time"]) is False
+        assert bool(grp.attrs["decay"]) is True
+
+    def test_corrections_description(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/corrections_applied"]
+        assert (
+            grp.attrs["description"]
+            == "Which corrections have been applied to this sinogram"
+        )
+
+
+# ---------------------------------------------------------------------------
+# write() — additive/multiplicative correction datasets
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCorrectionDatasets:
+    def test_additive_correction_written(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        assert "additive_correction" in h5file
+        assert h5file["additive_correction"].dtype == np.float32
+        assert h5file["additive_correction"].shape == (11, 180, 128)
+
+    def test_additive_correction_description(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        ds = h5file["additive_correction"]
+        assert ds.attrs["description"] == "Additive correction term (scatter + randoms)"
+
+    def test_additive_correction_compressed(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        ds = h5file["additive_correction"]
+        assert ds.compression == "gzip"
+        assert ds.compression_opts == 4
+
+    def test_multiplicative_correction_written(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        assert "multiplicative_correction" in h5file
+        assert h5file["multiplicative_correction"].dtype == np.float32
+        assert h5file["multiplicative_correction"].shape == (11, 180, 128)
+
+    def test_multiplicative_correction_description(self, schema, h5file):
+        data = _full_data()
+        schema.write(h5file, data)
+        ds = h5file["multiplicative_correction"]
+        assert ds.attrs["description"] == (
+            "Multiplicative correction term (normalization * attenuation)"
+        )
+
+    def test_no_corrections_when_absent(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "additive_correction" not in h5file
+        assert "multiplicative_correction" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# Entry point registration
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointRegistration:
+    def test_factory_returns_sinogram_schema(self):
+        from fd5.imaging.sinogram import SinogramSchema
+
+        instance = SinogramSchema()
+        assert instance.product_type == "sinogram"
+
+    def test_register_schema_lookup(self):
+        from fd5.imaging.sinogram import SinogramSchema
+        from fd5.registry import get_schema
+
+        register_schema("sinogram", SinogramSchema())
+        result = get_schema("sinogram")
+        assert result.product_type == "sinogram"
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_create_validate_roundtrip(self, schema, h5path):
+        from fd5.schema import embed_schema, validate
+
+        data = _full_data()
+        with h5py.File(h5path, "w") as f:
+            root_attrs = schema.required_root_attrs()
+            for k, v in root_attrs.items():
+                f.attrs[k] = v
+            f.attrs["name"] = "integration-test-sinogram"
+            f.attrs["description"] = "Integration test sinogram file"
+            schema_dict = schema.json_schema()
+            embed_schema(f, schema_dict)
+            schema.write(f, data)
+
+        errors = validate(h5path)
+        assert errors == [], [e.message for e in errors]
+
+    def test_generate_schema_for_sinogram(self, schema):
+        register_schema("sinogram", schema)
+        from fd5.schema import generate_schema
+
+        result = generate_schema("sinogram")
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert result["properties"]["product"]["const"] == "sinogram"


### PR DESCRIPTION
## Summary

- Adds `SinogramSchema` class in `src/fd5/imaging/sinogram.py` implementing the `ProductSchema` protocol per white-paper.md § sinogram
- Supports 3D non-TOF `(n_planes, n_angular, n_radial)` and 4D TOF `(n_planes, n_tof, n_angular, n_radial)` float32 projection arrays with chunked gzip compression
- Writes scanner geometry metadata (acquisition group with ring spacing, crystal pitch) and correction flags (normalization, attenuation, scatter, randoms, dead_time, decay)
- Optional additive and multiplicative correction datasets with matching shape/compression

## Test plan

- [x] 44 tests in `tests/test_sinogram.py` — all pass
- [x] 100% line coverage on `src/fd5/imaging/sinogram.py`
- [x] Protocol conformance: `isinstance(schema, ProductSchema)` verified
- [x] JSON Schema validity: `Draft202012Validator.check_schema()` passes
- [x] Integration round-trip: `embed_schema` → `validate` → zero errors
- [x] `register_schema()` + `generate_schema()` round-trip works
- [x] No regressions: all 50 existing `test_recon.py` tests still pass

Closes #52

Made with [Cursor](https://cursor.com)