### PR TITLE
feat(imaging): add sim product schema for Monte Carlo simulation data

### DIFF
--- a/src/fd5/imaging/sim.py
+++ b/src/fd5/imaging/sim.py
@@ -1,0 +1,152 @@
+"""fd5.imaging.sim — Sim product schema for Monte Carlo simulation data.
+
+Implements the ``sim`` product schema per white-paper.md § sim.
+Handles ground truth phantom volumes (activity, attenuation), simulated
+detector events (compound tables), and simulation parameters (GATE config,
+geometry, source distribution).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+_SCHEMA_VERSION = "1.0.0"
+
+_GZIP_LEVEL = 4
+
+_ID_INPUTS = ["simulator", "phantom", "random_seed"]
+
+
+class SimSchema:
+    """Product schema for Monte Carlo simulation data (``sim``)."""
+
+    product_type: str = "sim"
+    schema_version: str = _SCHEMA_VERSION
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "sim"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "domain": {"type": "string"},
+                "ground_truth": {
+                    "type": "object",
+                    "description": "Ground truth distributions (activity, attenuation)",
+                },
+            },
+            "required": ["_schema_version", "product", "name", "description"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {
+            "product": "sim",
+            "domain": "medical_imaging",
+        }
+
+    def id_inputs(self) -> list[str]:
+        return list(_ID_INPUTS)
+
+    def write(self, target: h5py.File | h5py.Group, data: dict[str, Any]) -> None:
+        """Write sim data to *target*.
+
+        *data* must contain:
+        - ``ground_truth``: dict with ``activity`` and/or ``attenuation``
+          numpy float32 arrays of shape (Z, Y, X)
+
+        Optional keys:
+        - ``events``: dict with ``events_2p`` and/or ``events_3p``
+          structured numpy arrays
+        - ``simulation``: dict with simulation parameters (written to
+          ``metadata/simulation/``)
+        """
+        self._write_ground_truth(target, data["ground_truth"])
+
+        if "events" in data:
+            self._write_events(target, data["events"])
+
+        if "simulation" in data:
+            self._write_simulation_metadata(target, data["simulation"])
+
+    # ------------------------------------------------------------------
+    # Ground truth
+    # ------------------------------------------------------------------
+
+    def _write_ground_truth(
+        self,
+        target: h5py.File | h5py.Group,
+        ground_truth: dict[str, np.ndarray],
+    ) -> None:
+        grp = target.create_group("ground_truth")
+        grp.attrs["description"] = "Known true distributions (unique to simulation)"
+
+        for name, volume in ground_truth.items():
+            chunks = (1,) + volume.shape[1:]
+            ds = grp.create_dataset(
+                name,
+                data=volume,
+                chunks=chunks,
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            ds.attrs["description"] = f"Ground truth {name} map"
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+
+    def _write_events(
+        self,
+        target: h5py.File | h5py.Group,
+        events: dict[str, np.ndarray],
+    ) -> None:
+        grp = target.create_group("events")
+        grp.attrs["description"] = (
+            "Simulated detector events (same structure as listmode)"
+        )
+
+        for name, table in events.items():
+            grp.create_dataset(name, data=table)
+            grp[name].attrs["description"] = f"Simulated {name} event table"
+
+    # ------------------------------------------------------------------
+    # Simulation metadata
+    # ------------------------------------------------------------------
+
+    def _write_simulation_metadata(
+        self,
+        target: h5py.File | h5py.Group,
+        simulation: dict[str, Any],
+    ) -> None:
+        if "metadata" not in target:
+            meta_grp = target.create_group("metadata")
+        else:
+            meta_grp = target["metadata"]
+
+        sim_grp = meta_grp.create_group("simulation")
+        sim_grp.attrs["_type"] = simulation.get("_type", "gate")
+        sim_grp.attrs["_version"] = np.int64(simulation.get("_version", 1))
+
+        for key in ("gate_version", "physics_list", "n_primaries", "random_seed"):
+            if key in simulation:
+                val = simulation[key]
+                if isinstance(val, int):
+                    sim_grp.attrs[key] = np.int64(val)
+                else:
+                    sim_grp.attrs[key] = val
+
+        if "geometry" in simulation:
+            geo_grp = sim_grp.create_group("geometry")
+            for k, v in simulation["geometry"].items():
+                geo_grp.attrs[k] = v
+
+        if "source" in simulation:
+            src_grp = sim_grp.create_group("source")
+            for k, v in simulation["source"].items():
+                src_grp.attrs[k] = v

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,0 +1,452 @@
+"""Tests for fd5.imaging.sim — SimSchema product schema."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.registry import ProductSchema, register_schema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def schema():
+    from fd5.imaging.sim import SimSchema
+
+    return SimSchema()
+
+
+@pytest.fixture()
+def h5file(tmp_path):
+    path = tmp_path / "sim.h5"
+    with h5py.File(path, "w") as f:
+        yield f
+
+
+@pytest.fixture()
+def h5path(tmp_path):
+    return tmp_path / "sim.h5"
+
+
+def _make_volume_3d(shape=(16, 32, 32)):
+    return np.random.default_rng(42).random(shape, dtype=np.float32)
+
+
+def _make_events_2p(n=100):
+    dt = np.dtype(
+        [
+            ("time", np.float64),
+            ("energy_1", np.float32),
+            ("energy_2", np.float32),
+            ("x_1", np.float32),
+            ("x_2", np.float32),
+        ]
+    )
+    rng = np.random.default_rng(42)
+    arr = np.empty(n, dtype=dt)
+    arr["time"] = rng.random(n)
+    arr["energy_1"] = rng.random(n).astype(np.float32)
+    arr["energy_2"] = rng.random(n).astype(np.float32)
+    arr["x_1"] = rng.random(n).astype(np.float32)
+    arr["x_2"] = rng.random(n).astype(np.float32)
+    return arr
+
+
+def _make_events_3p(n=50):
+    dt = np.dtype(
+        [
+            ("time", np.float64),
+            ("energy_1", np.float32),
+            ("energy_2", np.float32),
+            ("energy_3", np.float32),
+        ]
+    )
+    rng = np.random.default_rng(99)
+    arr = np.empty(n, dtype=dt)
+    arr["time"] = rng.random(n)
+    arr["energy_1"] = rng.random(n).astype(np.float32)
+    arr["energy_2"] = rng.random(n).astype(np.float32)
+    arr["energy_3"] = rng.random(n).astype(np.float32)
+    return arr
+
+
+def _minimal_ground_truth():
+    return {
+        "ground_truth": {
+            "activity": _make_volume_3d((8, 16, 16)),
+            "attenuation": _make_volume_3d((8, 16, 16)),
+        },
+    }
+
+
+def _full_sim_data():
+    return {
+        "ground_truth": {
+            "activity": _make_volume_3d((8, 16, 16)),
+            "attenuation": _make_volume_3d((8, 16, 16)),
+        },
+        "events": {
+            "events_2p": _make_events_2p(100),
+            "events_3p": _make_events_3p(50),
+        },
+        "simulation": {
+            "_type": "gate",
+            "_version": 1,
+            "gate_version": "9.3",
+            "physics_list": "QGSP_BERT_HP_EMZ",
+            "n_primaries": 1000000,
+            "random_seed": 12345,
+            "geometry": {
+                "phantom": "XCAT",
+            },
+            "source": {
+                "activity_distribution": "uniform",
+                "activities": "37.0 MBq",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_satisfies_product_schema_protocol(self, schema):
+        assert isinstance(schema, ProductSchema)
+
+    def test_product_type_is_sim(self, schema):
+        assert schema.product_type == "sim"
+
+    def test_schema_version_is_string(self, schema):
+        assert isinstance(schema.schema_version, str)
+
+    def test_has_required_methods(self, schema):
+        assert callable(schema.json_schema)
+        assert callable(schema.required_root_attrs)
+        assert callable(schema.write)
+        assert callable(schema.id_inputs)
+
+
+# ---------------------------------------------------------------------------
+# json_schema()
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchema:
+    def test_returns_dict(self, schema):
+        result = schema.json_schema()
+        assert isinstance(result, dict)
+
+    def test_has_draft_2020_12_meta(self, schema):
+        result = schema.json_schema()
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_product_const_is_sim(self, schema):
+        result = schema.json_schema()
+        assert result["properties"]["product"]["const"] == "sim"
+
+    def test_requires_ground_truth(self, schema):
+        result = schema.json_schema()
+        assert "ground_truth" in result.get(
+            "required", []
+        ) or "ground_truth" in result.get("properties", {})
+
+    def test_valid_json_schema(self, schema):
+        import jsonschema
+
+        result = schema.json_schema()
+        jsonschema.Draft202012Validator.check_schema(result)
+
+
+# ---------------------------------------------------------------------------
+# required_root_attrs()
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredRootAttrs:
+    def test_returns_dict(self, schema):
+        result = schema.required_root_attrs()
+        assert isinstance(result, dict)
+
+    def test_contains_product_sim(self, schema):
+        result = schema.required_root_attrs()
+        assert result["product"] == "sim"
+
+    def test_contains_domain(self, schema):
+        result = schema.required_root_attrs()
+        assert result["domain"] == "medical_imaging"
+
+
+# ---------------------------------------------------------------------------
+# id_inputs()
+# ---------------------------------------------------------------------------
+
+
+class TestIdInputs:
+    def test_returns_list_of_strings(self, schema):
+        result = schema.id_inputs()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_contains_simulation_identity_fields(self, schema):
+        result = schema.id_inputs()
+        assert "simulator" in result
+        assert "phantom" in result
+        assert "random_seed" in result
+
+
+# ---------------------------------------------------------------------------
+# write() — ground truth only (minimal)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteGroundTruth:
+    def test_creates_ground_truth_group(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "ground_truth" in h5file
+        assert isinstance(h5file["ground_truth"], h5py.Group)
+
+    def test_ground_truth_has_description(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "description" in h5file["ground_truth"].attrs
+
+    def test_activity_dataset_exists(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "activity" in h5file["ground_truth"]
+        assert h5file["ground_truth/activity"].dtype == np.float32
+
+    def test_attenuation_dataset_exists(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "attenuation" in h5file["ground_truth"]
+        assert h5file["ground_truth/attenuation"].dtype == np.float32
+
+    def test_activity_shape_matches(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert h5file["ground_truth/activity"].shape == (8, 16, 16)
+
+    def test_attenuation_shape_matches(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert h5file["ground_truth/attenuation"].shape == (8, 16, 16)
+
+    def test_ground_truth_data_roundtrip(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        np.testing.assert_array_equal(
+            h5file["ground_truth/activity"][:],
+            data["ground_truth"]["activity"],
+        )
+        np.testing.assert_array_equal(
+            h5file["ground_truth/attenuation"][:],
+            data["ground_truth"]["attenuation"],
+        )
+
+    def test_ground_truth_chunking(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        chunks = h5file["ground_truth/activity"].chunks
+        assert chunks == (1, 16, 16)
+
+    def test_ground_truth_compression(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        ds = h5file["ground_truth/activity"]
+        assert ds.compression == "gzip"
+        assert ds.compression_opts == 4
+
+    def test_no_events_group_for_minimal(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "events" not in h5file
+
+    def test_no_metadata_group_for_minimal(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "metadata" not in h5file
+
+    def test_dataset_has_description_attr(self, schema, h5file):
+        data = _minimal_ground_truth()
+        schema.write(h5file, data)
+        assert "description" in h5file["ground_truth/activity"].attrs
+        assert "description" in h5file["ground_truth/attenuation"].attrs
+
+
+# ---------------------------------------------------------------------------
+# write() — events
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEvents:
+    def test_events_group_created(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "events" in h5file
+        assert isinstance(h5file["events"], h5py.Group)
+
+    def test_events_group_has_description(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "description" in h5file["events"].attrs
+
+    def test_events_2p_dataset(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        ds = h5file["events/events_2p"]
+        assert ds.shape == (100,)
+        assert ds.dtype.names is not None
+
+    def test_events_3p_dataset(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        ds = h5file["events/events_3p"]
+        assert ds.shape == (50,)
+        assert ds.dtype.names is not None
+
+    def test_events_2p_data_roundtrip(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        stored = h5file["events/events_2p"][:]
+        np.testing.assert_array_equal(
+            stored["time"], data["events"]["events_2p"]["time"]
+        )
+
+    def test_events_dataset_has_description(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "description" in h5file["events/events_2p"].attrs
+        assert "description" in h5file["events/events_3p"].attrs
+
+
+# ---------------------------------------------------------------------------
+# write() — simulation metadata
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSimulationMetadata:
+    def test_metadata_simulation_group(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "metadata" in h5file
+        assert "simulation" in h5file["metadata"]
+
+    def test_simulation_type_attr(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/simulation"]
+        assert grp.attrs["_type"] == "gate"
+
+    def test_simulation_version_attr(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/simulation"]
+        assert grp.attrs["_version"] == 1
+
+    def test_simulation_params(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/simulation"]
+        assert grp.attrs["gate_version"] == "9.3"
+        assert grp.attrs["physics_list"] == "QGSP_BERT_HP_EMZ"
+        assert grp.attrs["n_primaries"] == 1000000
+        assert grp.attrs["random_seed"] == 12345
+
+    def test_geometry_subgroup(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/simulation/geometry"]
+        assert grp.attrs["phantom"] == "XCAT"
+
+    def test_source_subgroup(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        grp = h5file["metadata/simulation/source"]
+        assert grp.attrs["activity_distribution"] == "uniform"
+        assert grp.attrs["activities"] == "37.0 MBq"
+
+
+# ---------------------------------------------------------------------------
+# write() — full round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFullRoundTrip:
+    def test_all_groups_present(self, schema, h5file):
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "ground_truth" in h5file
+        assert "events" in h5file
+        assert "metadata" in h5file
+
+
+# ---------------------------------------------------------------------------
+# Entry point registration
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointRegistration:
+    def test_factory_returns_sim_schema(self):
+        from fd5.imaging.sim import SimSchema
+
+        instance = SimSchema()
+        assert instance.product_type == "sim"
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_create_validate_roundtrip(self, schema, h5path):
+        from fd5.schema import embed_schema, validate
+
+        data = _minimal_ground_truth()
+        with h5py.File(h5path, "w") as f:
+            root_attrs = schema.required_root_attrs()
+            for k, v in root_attrs.items():
+                f.attrs[k] = v
+            f.attrs["name"] = "integration-test-sim"
+            f.attrs["description"] = "Integration test sim file"
+            schema_dict = schema.json_schema()
+            embed_schema(f, schema_dict)
+            schema.write(f, data)
+
+        errors = validate(h5path)
+        assert errors == [], [e.message for e in errors]
+
+    def test_generate_schema_for_sim(self, schema):
+        register_schema("sim", schema)
+        from fd5.schema import generate_schema
+
+        result = generate_schema("sim")
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert result["properties"]["product"]["const"] == "sim"
+
+    def test_full_data_validate_roundtrip(self, schema, h5path):
+        from fd5.schema import embed_schema, validate
+
+        data = _full_sim_data()
+        with h5py.File(h5path, "w") as f:
+            root_attrs = schema.required_root_attrs()
+            for k, v in root_attrs.items():
+                f.attrs[k] = v
+            f.attrs["name"] = "full-sim-test"
+            f.attrs["description"] = "Full sim round-trip test"
+            schema_dict = schema.json_schema()
+            embed_schema(f, schema_dict)
+            schema.write(f, data)
+
+        errors = validate(h5path)
+        assert errors == [], [e.message for e in errors]


### PR DESCRIPTION
## Summary

- Add `SimSchema` class in `src/fd5/imaging/sim.py` implementing the `ProductSchema` protocol per white-paper.md § sim
- Handles ground truth phantom volumes (activity, attenuation) with gzip-compressed chunked HDF5 datasets, simulated detector events (compound dtype tables), and GATE simulation metadata (geometry, source sub-groups)
- Add comprehensive test suite in `tests/test_sim.py` with 43 tests covering protocol conformance, JSON Schema validation, HDF5 round-trip, events, simulation metadata, and full integration with `embed_schema`/`validate`

## Test plan

- [x] `SimSchema` satisfies `ProductSchema` protocol (`isinstance` check)
- [x] `json_schema()` returns valid JSON Schema Draft 2020-12 with `product: "sim"`
- [x] `required_root_attrs()` returns `product: "sim"`, `domain: "medical_imaging"`
- [x] `id_inputs()` returns simulation-specific identity fields (`simulator`, `phantom`, `random_seed`)
- [x] `write()` creates `ground_truth/` group with `activity` and `attenuation` float32 datasets (chunked, gzip level 4)
- [x] `write()` creates `events/` group with compound-dtype event tables when provided
- [x] `write()` creates `metadata/simulation/` with `_type`, `_version`, params, `geometry/`, `source/` sub-groups
- [x] Round-trip data integrity verified for both volumes and events
- [x] Integration: `embed_schema` + `validate` round-trip passes with zero errors
- [x] 98% code coverage (56 statements, 1 miss)

Closes #53

Made with [Cursor](https://cursor.com)