### PR TITLE
chore: register Phase 3 imaging schemas as entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,14 @@ packages = ["src/fd5"]
 
 [project.entry-points."fd5.schemas"]
 recon = "fd5.imaging.recon:ReconSchema"
+listmode = "fd5.imaging.listmode:ListmodeSchema"
+sinogram = "fd5.imaging.sinogram:SinogramSchema"
+sim = "fd5.imaging.sim:SimSchema"
+transform = "fd5.imaging.transform:TransformSchema"
+calibration = "fd5.imaging.calibration:CalibrationSchema"
+spectrum = "fd5.imaging.spectrum:SpectrumSchema"
+roi = "fd5.imaging.roi:RoiSchema"
+device_data = "fd5.imaging.device_data:DeviceDataSchema"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- Register all 8 Phase 3 imaging product schemas as `fd5.schemas` entry points in `pyproject.toml`
- Schemas: listmode, sinogram, sim, transform, calibration, spectrum, roi, device_data

This enables discovery via `fd5.registry` for all Phase 3 schemas.

Refs: #61


Made with [Cursor](https://cursor.com)