### PR TITLE
feat(datacite): add fd5.datacite module for DataCite metadata export

### DIFF
--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -101,6 +101,29 @@ def manifest(directory: str, output: str | None) -> None:
     click.echo(f"Wrote {out_path}")
 
 
+@cli.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output path for datacite.yml (default: <directory>/datacite.yml).",
+)
+def datacite(directory: str, output: str | None) -> None:
+    """Generate datacite.yml from manifest.toml in a directory."""
+    from fd5.datacite import write as datacite_write
+
+    dir_path = Path(directory)
+    manifest_path = dir_path / "manifest.toml"
+    if not manifest_path.is_file():
+        click.echo(f"Error: {manifest_path} not found.", err=True)
+        sys.exit(1)
+    out_path = Path(output) if output else dir_path / "datacite.yml"
+    datacite_write(manifest_path, out_path)
+    click.echo(f"Wrote {out_path}")
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/src/fd5/datacite.py
+++ b/src/fd5/datacite.py
@@ -1,0 +1,131 @@
+"""fd5.datacite — DataCite metadata export.
+
+Generates ``datacite.yml`` from the manifest and HDF5 metadata.
+See white-paper.md § datacite.yml for the spec.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import yaml
+
+from fd5.manifest import read_manifest
+
+
+def generate(manifest_path: Path) -> dict[str, Any]:
+    """Build a DataCite metadata dict from *manifest_path* and sibling HDF5 files.
+
+    Returns a dict ready for YAML serialisation with keys:
+    ``title``, ``creators``, ``dates``, ``resourceType``, ``subjects``.
+    """
+    manifest = read_manifest(manifest_path)
+    data_dir = manifest_path.parent
+
+    title = _build_title(manifest)
+    creators = _build_creators(manifest)
+    dates = _build_dates(manifest)
+    subjects = _build_subjects(manifest, data_dir)
+
+    return {
+        "title": title,
+        "creators": creators,
+        "dates": dates,
+        "resourceType": "Dataset",
+        "subjects": subjects,
+    }
+
+
+def write(manifest_path: Path, output_path: Path) -> None:
+    """Generate DataCite metadata and write it as YAML to *output_path*."""
+    metadata = generate(manifest_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        yaml.dump(
+            metadata, default_flow_style=False, sort_keys=False, allow_unicode=True
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_title(manifest: dict[str, Any]) -> str:
+    return manifest.get("dataset_name", "Untitled")
+
+
+def _build_creators(manifest: dict[str, Any]) -> list[dict[str, str]]:
+    study = manifest.get("study", {})
+    creators_group = study.get("creators", {})
+    if not creators_group:
+        return []
+
+    result: list[dict[str, str]] = []
+    for key in sorted(creators_group):
+        creator = creators_group[key]
+        entry: dict[str, str] = {"name": creator["name"]}
+        if "affiliation" in creator:
+            entry["affiliation"] = creator["affiliation"]
+        result.append(entry)
+    return result
+
+
+def _build_dates(manifest: dict[str, Any]) -> list[dict[str, str]]:
+    data = manifest.get("data", [])
+    if not data:
+        return []
+
+    timestamps = [entry["timestamp"] for entry in data if "timestamp" in entry]
+    if not timestamps:
+        return []
+
+    earliest = min(timestamps)
+    date_str = earliest[:10]  # "YYYY-MM-DD" prefix from ISO 8601
+    return [{"date": date_str, "dateType": "Collected"}]
+
+
+def _build_subjects(manifest: dict[str, Any], data_dir: Path) -> list[dict[str, str]]:
+    seen: set[tuple[str, str]] = set()
+    subjects: list[dict[str, str]] = []
+
+    for entry in manifest.get("data", []):
+        scan_type = entry.get("scan_type")
+        scheme = entry.get("scan_type_vocabulary")
+        if scan_type and scheme:
+            pair = (scan_type, scheme)
+            if pair not in seen:
+                seen.add(pair)
+                subjects.append({"subject": scan_type, "subjectScheme": scheme})
+
+        h5_file = data_dir / entry.get("file", "")
+        if h5_file.is_file():
+            _collect_tracer_subjects(h5_file, seen, subjects)
+
+    return subjects
+
+
+def _collect_tracer_subjects(
+    h5_path: Path,
+    seen: set[tuple[str, str]],
+    subjects: list[dict[str, str]],
+) -> None:
+    try:
+        with h5py.File(h5_path, "r") as f:
+            tracer_group = f.get("metadata/pet/tracer")
+            if tracer_group is None:
+                return
+            name = tracer_group.attrs.get("name")
+            if name is None:
+                return
+            if isinstance(name, bytes):
+                name = name.decode("utf-8")
+            pair = (name, "Radiotracer")
+            if pair not in seen:
+                seen.add(pair)
+                subjects.append({"subject": name, "subjectScheme": "Radiotracer"})
+    except Exception:
+        return

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -1,0 +1,316 @@
+"""Tests for fd5.datacite — generate and write DataCite metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import pytest
+import yaml
+
+from fd5.datacite import generate, write
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manifest_path(tmp_path: Path) -> Path:
+    """Create a manifest.toml with study/creators and data entries."""
+    toml_text = """\
+_schema_version = 1
+dataset_name = "dd01"
+
+[study]
+type = "clinical"
+license = "CC-BY-4.0"
+
+[study.creators.creator_0]
+name = "Jane Doe"
+affiliation = "ETH Zurich"
+orcid = "https://orcid.org/0000-0002-1234-5678"
+role = "principal_investigator"
+
+[study.creators.creator_1]
+name = "John Smith"
+affiliation = "University Hospital Zurich"
+role = "data_collection"
+
+[subject]
+species = "human"
+birth_date = "1959-03-15"
+
+[[data]]
+product = "recon"
+id = "sha256:aabb1122"
+file = "recon-aabb1122.h5"
+scan_type = "pet"
+scan_type_vocabulary = "DICOM Modality"
+timestamp = "2024-07-24T19:06:10+02:00"
+
+[[data]]
+product = "recon"
+id = "sha256:ccdd3344"
+file = "recon-ccdd3344.h5"
+scan_type = "ct"
+scan_type_vocabulary = "DICOM Modality"
+timestamp = "2024-07-25T10:00:00+02:00"
+"""
+    path = tmp_path / "manifest.toml"
+    path.write_text(toml_text)
+
+    _create_h5_with_tracer(
+        tmp_path / "recon-aabb1122.h5",
+        tracer_name="FDG",
+        scan_type="pet",
+    )
+    _create_h5_with_tracer(
+        tmp_path / "recon-ccdd3344.h5",
+        tracer_name=None,
+        scan_type="ct",
+    )
+    return path
+
+
+@pytest.fixture()
+def minimal_manifest_path(tmp_path: Path) -> Path:
+    """Manifest with no study/creators and minimal data."""
+    toml_text = """\
+_schema_version = 1
+dataset_name = "test-minimal"
+
+[[data]]
+product = "sim"
+id = "sha256:11223344"
+file = "sim-11223344.h5"
+timestamp = "2025-06-01T08:00:00Z"
+"""
+    path = tmp_path / "manifest.toml"
+    path.write_text(toml_text)
+    _create_h5_with_tracer(tmp_path / "sim-11223344.h5", tracer_name=None)
+    return path
+
+
+@pytest.fixture()
+def no_data_manifest_path(tmp_path: Path) -> Path:
+    """Manifest with no [[data]] entries."""
+    toml_text = """\
+_schema_version = 1
+dataset_name = "empty-dataset"
+"""
+    path = tmp_path / "manifest.toml"
+    path.write_text(toml_text)
+    return path
+
+
+def _create_h5_with_tracer(
+    path: Path,
+    tracer_name: str | None = None,
+    scan_type: str | None = None,
+) -> None:
+    with h5py.File(path, "w") as f:
+        if scan_type:
+            f.attrs["scan_type"] = scan_type
+        if tracer_name:
+            meta = f.create_group("metadata")
+            pet = meta.create_group("pet")
+            tracer = pet.create_group("tracer")
+            tracer.attrs["name"] = tracer_name
+
+
+# ---------------------------------------------------------------------------
+# generate()
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_returns_dict(self, manifest_path: Path):
+        result = generate(manifest_path)
+        assert isinstance(result, dict)
+
+    def test_title_contains_dataset_name(self, manifest_path: Path):
+        result = generate(manifest_path)
+        assert "dd01" in result["title"].lower()
+
+    def test_creators_from_study(self, manifest_path: Path):
+        result = generate(manifest_path)
+        assert len(result["creators"]) == 2
+        names = {c["name"] for c in result["creators"]}
+        assert names == {"Jane Doe", "John Smith"}
+
+    def test_creator_has_affiliation(self, manifest_path: Path):
+        result = generate(manifest_path)
+        jane = next(c for c in result["creators"] if c["name"] == "Jane Doe")
+        assert jane["affiliation"] == "ETH Zurich"
+
+    def test_dates_collected(self, manifest_path: Path):
+        result = generate(manifest_path)
+        assert len(result["dates"]) >= 1
+        collected = [d for d in result["dates"] if d["dateType"] == "Collected"]
+        assert len(collected) == 1
+        assert collected[0]["date"] == "2024-07-24"
+
+    def test_resource_type(self, manifest_path: Path):
+        result = generate(manifest_path)
+        assert result["resourceType"] == "Dataset"
+
+    def test_subjects_from_scan_type(self, manifest_path: Path):
+        result = generate(manifest_path)
+        scan_subjects = [
+            s for s in result["subjects"] if s.get("subjectScheme") == "DICOM Modality"
+        ]
+        subject_values = {s["subject"] for s in scan_subjects}
+        assert "pet" in subject_values or "PET" in subject_values
+        assert "ct" in subject_values or "CT" in subject_values
+
+    def test_subjects_from_tracer(self, manifest_path: Path):
+        result = generate(manifest_path)
+        tracer_subjects = [
+            s for s in result["subjects"] if s.get("subjectScheme") == "Radiotracer"
+        ]
+        assert len(tracer_subjects) == 1
+        assert tracer_subjects[0]["subject"] == "FDG"
+
+    def test_subjects_deduplicated(self, manifest_path: Path):
+        result = generate(manifest_path)
+        subject_tuples = [
+            (s["subject"], s.get("subjectScheme")) for s in result["subjects"]
+        ]
+        assert len(subject_tuples) == len(set(subject_tuples))
+
+
+class TestGenerateMinimal:
+    def test_title_from_dataset_name(self, minimal_manifest_path: Path):
+        result = generate(minimal_manifest_path)
+        assert "test-minimal" in result["title"].lower()
+
+    def test_no_creators_when_absent(self, minimal_manifest_path: Path):
+        result = generate(minimal_manifest_path)
+        assert result["creators"] == []
+
+    def test_dates_collected(self, minimal_manifest_path: Path):
+        result = generate(minimal_manifest_path)
+        assert result["dates"][0]["date"] == "2025-06-01"
+
+    def test_resource_type(self, minimal_manifest_path: Path):
+        result = generate(minimal_manifest_path)
+        assert result["resourceType"] == "Dataset"
+
+    def test_no_subjects_when_no_scan_type(self, minimal_manifest_path: Path):
+        result = generate(minimal_manifest_path)
+        assert result["subjects"] == []
+
+
+class TestGenerateNoData:
+    def test_empty_dates(self, no_data_manifest_path: Path):
+        result = generate(no_data_manifest_path)
+        assert result["dates"] == []
+
+    def test_empty_subjects(self, no_data_manifest_path: Path):
+        result = generate(no_data_manifest_path)
+        assert result["subjects"] == []
+
+
+# ---------------------------------------------------------------------------
+# write()
+# ---------------------------------------------------------------------------
+
+
+class TestWrite:
+    def test_creates_file(self, manifest_path: Path, tmp_path: Path):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        assert out.exists()
+
+    def test_output_is_valid_yaml(self, manifest_path: Path, tmp_path: Path):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        parsed = yaml.safe_load(out.read_text())
+        assert isinstance(parsed, dict)
+
+    def test_yaml_has_title(self, manifest_path: Path, tmp_path: Path):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        parsed = yaml.safe_load(out.read_text())
+        assert "title" in parsed
+
+    def test_yaml_has_creators(self, manifest_path: Path, tmp_path: Path):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        parsed = yaml.safe_load(out.read_text())
+        assert "creators" in parsed
+
+    def test_yaml_round_trip_matches_generate(
+        self, manifest_path: Path, tmp_path: Path
+    ):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        parsed = yaml.safe_load(out.read_text())
+        expected = generate(manifest_path)
+        assert parsed == expected
+
+    def test_idempotent(self, manifest_path: Path, tmp_path: Path):
+        out = tmp_path / "output" / "datacite.yml"
+        write(manifest_path, out)
+        content1 = out.read_text()
+        write(manifest_path, out)
+        content2 = out.read_text()
+        assert content1 == content2
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (fd5 datacite)
+# ---------------------------------------------------------------------------
+
+
+class TestDataciteCLI:
+    def test_exits_zero(self, manifest_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["datacite", str(manifest_path.parent)])
+        assert result.exit_code == 0, result.output
+
+    def test_creates_datacite_yml(self, manifest_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        runner.invoke(cli, ["datacite", str(manifest_path.parent)])
+        assert (manifest_path.parent / "datacite.yml").exists()
+
+    def test_custom_output(self, manifest_path: Path, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        out = tmp_path / "custom" / "datacite.yml"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["datacite", str(manifest_path.parent), "--output", str(out)]
+        )
+        assert result.exit_code == 0
+        assert out.exists()
+
+    def test_nonexistent_dir_exits_nonzero(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["datacite", str(tmp_path / "nope")])
+        assert result.exit_code != 0
+
+    def test_missing_manifest_exits_nonzero(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["datacite", str(tmp_path)])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Add `src/fd5/datacite.py` with `generate(manifest_path)` and `write(manifest_path, output_path)` functions that produce DataCite metadata (datacite.yml) from the manifest and HDF5 files
- Map title (from dataset_name), creators (from study/creators), dates (earliest timestamp as Collected), resourceType (Dataset), and subjects (from scan_type vocabulary + tracer metadata)
- Add `fd5 datacite <dir>` CLI command to `src/fd5/cli.py` using the same pattern as existing commands
- Add `tests/test_datacite.py` with 27 tests covering generate(), write(), and CLI integration (93% coverage)

## Test plan

- [x] `generate()` returns correct title, creators, dates, resourceType, subjects from full manifest
- [x] `generate()` handles minimal manifest (no study/creators, no scan_type)
- [x] `generate()` handles empty manifest (no data entries)
- [x] `write()` produces valid YAML that round-trips with `generate()`
- [x] `write()` is idempotent
- [x] CLI `fd5 datacite <dir>` creates datacite.yml, supports `--output`, fails on missing dir/manifest
- [x] All 764 existing tests still pass

Closes #60

Made with [Cursor](https://cursor.com)