### PR TITLE
feat(rocrate): add RO-Crate 1.2 JSON-LD export module and CLI command

### DIFF
--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -18,7 +18,7 @@ from fd5.schema import dump_schema, validate
 @click.group()
 @click.version_option(package_name="fd5")
 def cli() -> None:
-    """fd5 – Fusion Data Format 5 toolkit."""
+    """fd5 \u2013 Fusion Data Format 5 toolkit."""
 
 
 @cli.command()
@@ -45,7 +45,7 @@ def validate_cmd(file: str) -> None:
             click.echo(msg, err=True)
         sys.exit(1)
 
-    click.echo("OK – schema valid, content_hash verified.")
+    click.echo("OK \u2013 schema valid, content_hash verified.")
 
 
 # click registers the command name from the function; override with the decorator
@@ -99,6 +99,29 @@ def manifest(directory: str, output: str | None) -> None:
     dir_path = Path(directory)
     out_path = Path(output) if output else dir_path / "manifest.toml"
     write_manifest(dir_path, out_path)
+    click.echo(f"Wrote {out_path}")
+
+
+@cli.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output path for datacite.yml (default: <directory>/datacite.yml).",
+)
+def datacite(directory: str, output: str | None) -> None:
+    """Generate datacite.yml from manifest.toml in a directory."""
+    from fd5.datacite import write as datacite_write
+
+    dir_path = Path(directory)
+    manifest_path = dir_path / "manifest.toml"
+    if not manifest_path.is_file():
+        click.echo(f"Error: {manifest_path} not found.", err=True)
+        sys.exit(1)
+    out_path = Path(output) if output else dir_path / "datacite.yml"
+    datacite_write(manifest_path, out_path)
     click.echo(f"Wrote {out_path}")
 
 

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -11,6 +11,7 @@ import h5py
 
 from fd5.hash import verify
 from fd5.manifest import write_manifest
+from fd5.rocrate import write as write_rocrate
 from fd5.schema import dump_schema, validate
 
 
@@ -99,6 +100,24 @@ def manifest(directory: str, output: str | None) -> None:
     out_path = Path(output) if output else dir_path / "manifest.toml"
     write_manifest(dir_path, out_path)
     click.echo(f"Wrote {out_path}")
+
+
+@cli.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    default=None,
+    help="Output path for ro-crate-metadata.json (default: <directory>/ro-crate-metadata.json).",
+)
+def rocrate(directory: str, output: str | None) -> None:
+    """Generate ro-crate-metadata.json from fd5 files in a directory."""
+    dir_path = Path(directory)
+    out_path = Path(output) if output else None
+    write_rocrate(dir_path, out_path)
+    written = out_path or dir_path / "ro-crate-metadata.json"
+    click.echo(f"Wrote {written}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fd5/rocrate.py
+++ b/src/fd5/rocrate.py
@@ -1,0 +1,189 @@
+"""fd5.rocrate — RO-Crate 1.2 JSON-LD generation.
+
+Generates ``ro-crate-metadata.json`` from a directory of fd5 HDF5 files.
+Maps fd5 vocabulary to Schema.org terms per white-paper.md § ro-crate-metadata.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import h5py
+
+from fd5.h5io import h5_to_dict
+
+_ROCRATE_CONTEXT = "https://w3id.org/ro/crate/1.2/context"
+_ROCRATE_CONFORMSTO = "https://w3id.org/ro/crate/1.2"
+_HDF5_MEDIA_TYPE = "application/x-hdf5"
+
+
+def generate(directory: Path) -> dict[str, Any]:
+    """Build an RO-Crate JSON-LD dict from fd5 HDF5 files in *directory*."""
+    graph: list[dict[str, Any]] = []
+    graph.append(_metadata_descriptor())
+
+    file_entities: list[dict[str, Any]] = []
+    study: dict[str, Any] | None = None
+
+    for h5_path in sorted(directory.glob("*.h5")):
+        with h5py.File(h5_path, "r") as f:
+            root_attrs = _safe_root_attrs(f)
+
+            if study is None and "study" in f:
+                study = h5_to_dict(f["study"])
+
+            entity = _file_entity(h5_path.name, root_attrs, f)
+            _build_create_action(h5_path.name, f, graph)
+            file_entities.append(entity)
+
+    root_dataset = _root_dataset(directory.name, study, file_entities)
+    graph.append(root_dataset)
+    graph.extend(file_entities)
+
+    return {"@context": _ROCRATE_CONTEXT, "@graph": graph}
+
+
+def write(directory: Path, output_path: Path | None = None) -> None:
+    """Generate RO-Crate JSON-LD and write it to *output_path*.
+
+    Defaults to ``<directory>/ro-crate-metadata.json``.
+    """
+    crate = generate(directory)
+    out = output_path or directory / "ro-crate-metadata.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(crate, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_root_attrs(f: h5py.File) -> dict[str, Any]:
+    """Read root-level HDF5 attributes without recursing into groups.
+
+    Avoids following external links in sources/ which may be unresolvable.
+    """
+    from fd5.h5io import _read_attr
+
+    result: dict[str, Any] = {}
+    for key in sorted(f.attrs.keys()):
+        result[key] = _read_attr(f.attrs[key])
+    return result
+
+
+def _metadata_descriptor() -> dict[str, Any]:
+    return {
+        "@id": "ro-crate-metadata.json",
+        "@type": "CreativeWork",
+        "about": {"@id": "./"},
+        "conformsTo": {"@id": _ROCRATE_CONFORMSTO},
+    }
+
+
+def _root_dataset(
+    dir_name: str,
+    study: dict[str, Any] | None,
+    file_entities: list[dict[str, Any]],
+) -> dict[str, Any]:
+    root: dict[str, Any] = {
+        "@id": "./",
+        "@type": "Dataset",
+        "hasPart": [{"@id": e["@id"]} for e in file_entities],
+    }
+
+    if study:
+        root["name"] = study.get("name", dir_name)
+        if "license" in study:
+            root["license"] = study["license"]
+        authors = _build_authors(study)
+        if authors:
+            root["author"] = authors
+    else:
+        root["name"] = dir_name
+
+    return root
+
+
+def _build_authors(study: dict[str, Any]) -> list[dict[str, Any]]:
+    creators = study.get("creators")
+    if not creators or not isinstance(creators, dict):
+        return []
+
+    authors: list[dict[str, Any]] = []
+    for key in sorted(creators.keys()):
+        c = creators[key]
+        if not isinstance(c, dict):
+            continue
+        person: dict[str, Any] = {"@type": "Person", "name": c["name"]}
+        if "affiliation" in c:
+            person["affiliation"] = c["affiliation"]
+        if "orcid" in c:
+            person["@id"] = c["orcid"]
+        authors.append(person)
+    return authors
+
+
+def _file_entity(
+    filename: str,
+    root_attrs: dict[str, Any],
+    f: h5py.File,
+) -> dict[str, Any]:
+    entity: dict[str, Any] = {
+        "@id": filename,
+        "@type": "File",
+        "encodingFormat": _HDF5_MEDIA_TYPE,
+    }
+
+    if "timestamp" in root_attrs:
+        entity["dateCreated"] = root_attrs["timestamp"]
+
+    if "id" in root_attrs:
+        entity["identifier"] = {
+            "@type": "PropertyValue",
+            "propertyID": "sha256",
+            "value": root_attrs["id"],
+        }
+
+    sources_refs = _build_is_based_on(f)
+    if sources_refs:
+        entity["isBasedOn"] = sources_refs
+
+    return entity
+
+
+def _build_is_based_on(f: h5py.File) -> list[dict[str, str]]:
+    if "sources" not in f:
+        return []
+    refs: list[dict[str, str]] = []
+    sources_grp = f["sources"]
+    for key in sorted(sources_grp.keys()):
+        item = sources_grp[key]
+        if isinstance(item, h5py.Group) and "file" in item.attrs:
+            refs.append({"@id": str(item.attrs["file"])})
+    return refs
+
+
+def _build_create_action(
+    filename: str,
+    f: h5py.File,
+    graph: list[dict[str, Any]],
+) -> None:
+    if "provenance" not in f or "ingest" not in f["provenance"]:
+        return
+    ingest = h5_to_dict(f["provenance/ingest"])
+    action: dict[str, Any] = {
+        "@id": f"#ingest-{filename}",
+        "@type": "CreateAction",
+        "result": {"@id": filename},
+        "instrument": {
+            "@type": "SoftwareApplication",
+            "name": ingest.get("tool", "unknown"),
+            "version": ingest.get("tool_version", "unknown"),
+        },
+    }
+    if "timestamp" in ingest:
+        action["endTime"] = ingest["timestamp"]
+    graph.append(action)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,44 @@ class TestManifestCommand:
 
 
 # ---------------------------------------------------------------------------
+# fd5 rocrate
+# ---------------------------------------------------------------------------
+
+
+class TestRocrateCommand:
+    def test_exits_zero(self, runner: CliRunner, data_dir: Path):
+        result = runner.invoke(cli, ["rocrate", str(data_dir)])
+        assert result.exit_code == 0
+
+    def test_creates_rocrate_file(self, runner: CliRunner, data_dir: Path):
+        runner.invoke(cli, ["rocrate", str(data_dir)])
+        assert (data_dir / "ro-crate-metadata.json").exists()
+
+    def test_output_is_valid_json(self, runner: CliRunner, data_dir: Path):
+        runner.invoke(cli, ["rocrate", str(data_dir)])
+        content = (data_dir / "ro-crate-metadata.json").read_text()
+        parsed = json.loads(content)
+        assert "@context" in parsed
+
+    def test_custom_output_path(
+        self, runner: CliRunner, data_dir: Path, tmp_path: Path
+    ):
+        out = tmp_path / "custom" / "crate.json"
+        result = runner.invoke(cli, ["rocrate", str(data_dir), "--output", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+
+    def test_nonexistent_dir_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["rocrate", str(tmp_path / "nope")])
+        assert result.exit_code != 0
+
+    def test_empty_dir(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["rocrate", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (tmp_path / "ro-crate-metadata.json").exists()
+
+
+# ---------------------------------------------------------------------------
 # fd5 --help
 # ---------------------------------------------------------------------------
 
@@ -306,5 +344,5 @@ class TestHelp:
 
     def test_help_lists_commands(self, runner: CliRunner):
         result = runner.invoke(cli, ["--help"])
-        for cmd in ("validate", "info", "schema-dump", "manifest"):
+        for cmd in ("validate", "info", "schema-dump", "manifest", "rocrate"):
             assert cmd in result.output

--- a/tests/test_rocrate.py
+++ b/tests/test_rocrate.py
@@ -1,0 +1,450 @@
+"""Tests for fd5.rocrate — RO-Crate JSON-LD generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import h5py
+import pytest
+
+from fd5.h5io import dict_to_h5
+from fd5.provenance import write_ingest, write_sources
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_h5(
+    path: Path,
+    root_attrs: dict[str, Any],
+    groups: dict[str, dict[str, Any]] | None = None,
+    sources: list[dict[str, Any]] | None = None,
+    ingest: dict[str, str] | None = None,
+) -> None:
+    with h5py.File(path, "w") as f:
+        dict_to_h5(f, root_attrs)
+        if groups:
+            for name, attrs in groups.items():
+                g = f.create_group(name)
+                dict_to_h5(g, attrs)
+        if sources:
+            write_sources(f, sources)
+        if ingest:
+            write_ingest(f, **ingest)
+
+
+def _graph_by_id(crate: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index @graph entities by @id for convenient lookup."""
+    return {e["@id"]: e for e in crate["@graph"]}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CREATOR_JANE = {
+    "name": "Jane Doe",
+    "affiliation": "ETH Zurich",
+    "orcid": "https://orcid.org/0000-0002-1234-5678",
+}
+
+CREATOR_JOHN = {
+    "name": "John Smith",
+    "affiliation": "MIT",
+    "orcid": "https://orcid.org/0000-0003-9999-0000",
+}
+
+
+@pytest.fixture()
+def full_dir(tmp_path: Path) -> Path:
+    """Directory with two HDF5 files, study metadata, provenance, and sources."""
+    _create_h5(
+        tmp_path / "recon-aabb1122.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "recon",
+            "id": "sha256:aabb112233445566",
+            "content_hash": "sha256:deadbeef",
+            "timestamp": "2024-07-24T19:06:10+02:00",
+        },
+        groups={
+            "study": {
+                "license": "CC-BY-4.0",
+                "name": "DOGPLET DD01",
+                "creators": {
+                    "0": CREATOR_JANE,
+                    "1": CREATOR_JOHN,
+                },
+            },
+        },
+        sources=[
+            {
+                "name": "listmode",
+                "id": "sha256:src111111",
+                "product": "listmode",
+                "file": "listmode-src11111.h5",
+                "content_hash": "sha256:src111111",
+                "role": "primary",
+                "description": "Source listmode",
+            },
+        ],
+        ingest={
+            "tool": "fd5-imaging-ingest",
+            "version": "0.3.0",
+            "timestamp": "2024-07-25T08:00:00Z",
+        },
+    )
+    _create_h5(
+        tmp_path / "roi-ccdd3344.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "roi",
+            "id": "sha256:ccdd334455667788",
+            "content_hash": "sha256:cafebabe",
+            "timestamp": "2026-01-15T10:30:00+01:00",
+        },
+        groups={
+            "study": {
+                "license": "CC-BY-4.0",
+                "name": "DOGPLET DD01",
+                "creators": {
+                    "0": CREATOR_JANE,
+                    "1": CREATOR_JOHN,
+                },
+            },
+        },
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def minimal_dir(tmp_path: Path) -> Path:
+    """Directory with a single HDF5 file, no study/sources/provenance."""
+    _create_h5(
+        tmp_path / "sim-11223344.h5",
+        root_attrs={
+            "_schema_version": 1,
+            "product": "sim",
+            "id": "sha256:1122334455667788",
+            "content_hash": "sha256:00000000",
+            "timestamp": "2025-06-01T12:00:00Z",
+        },
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def empty_dir(tmp_path: Path) -> Path:
+    """Empty directory with no HDF5 files."""
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# generate()
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_returns_dict(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        result = generate(full_dir)
+        assert isinstance(result, dict)
+
+    def test_context(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        result = generate(full_dir)
+        assert result["@context"] == "https://w3id.org/ro/crate/1.2/context"
+
+    def test_graph_is_list(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        result = generate(full_dir)
+        assert isinstance(result["@graph"], list)
+
+    def test_metadata_descriptor(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        desc = entities["ro-crate-metadata.json"]
+        assert desc["@type"] == "CreativeWork"
+        assert desc["about"] == {"@id": "./"}
+        assert desc["conformsTo"] == {"@id": "https://w3id.org/ro/crate/1.2"}
+
+    def test_root_dataset_entity(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        root = entities["./"]
+        assert root["@type"] == "Dataset"
+
+    def test_license_mapped(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        root = entities["./"]
+        assert root["license"] == "CC-BY-4.0"
+
+    def test_dataset_name(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        root = entities["./"]
+        assert root["name"] == "DOGPLET DD01"
+
+    def test_author_persons(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        root = entities["./"]
+        authors = root["author"]
+        assert len(authors) == 2
+        jane = authors[0]
+        assert jane["@type"] == "Person"
+        assert jane["name"] == "Jane Doe"
+        assert jane["affiliation"] == "ETH Zurich"
+        assert jane["@id"] == "https://orcid.org/0000-0002-1234-5678"
+
+    def test_has_part_lists_files(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        root = entities["./"]
+        ids = {p["@id"] for p in root["hasPart"]}
+        assert "recon-aabb1122.h5" in ids
+        assert "roi-ccdd3344.h5" in ids
+
+    def test_file_entities(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        recon = entities["recon-aabb1122.h5"]
+        assert recon["@type"] == "File"
+        assert recon["encodingFormat"] == "application/x-hdf5"
+
+    def test_file_date_created(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        recon = entities["recon-aabb1122.h5"]
+        assert recon["dateCreated"] == "2024-07-24T19:06:10+02:00"
+
+    def test_file_identifier_property_value(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        recon = entities["recon-aabb1122.h5"]
+        ident = recon["identifier"]
+        assert ident["@type"] == "PropertyValue"
+        assert ident["propertyID"] == "sha256"
+        assert ident["value"] == "sha256:aabb112233445566"
+
+    def test_is_based_on_from_sources(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        recon = entities["recon-aabb1122.h5"]
+        assert recon["isBasedOn"] == [{"@id": "listmode-src11111.h5"}]
+
+    def test_create_action_from_ingest(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        actions = [e for e in entities.values() if e.get("@type") == "CreateAction"]
+        assert len(actions) >= 1
+        action = actions[0]
+        assert action["result"] == {"@id": "recon-aabb1122.h5"}
+        instrument = action["instrument"]
+        assert instrument["@type"] == "SoftwareApplication"
+        assert instrument["name"] == "fd5-imaging-ingest"
+        assert instrument["version"] == "0.3.0"
+
+    def test_no_sources_no_is_based_on(self, full_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(full_dir))
+        roi = entities["roi-ccdd3344.h5"]
+        assert "isBasedOn" not in roi
+
+    def test_no_ingest_no_create_action(self, minimal_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(minimal_dir))
+        actions = [e for e in entities.values() if e.get("@type") == "CreateAction"]
+        assert len(actions) == 0
+
+
+class TestGenerateMinimal:
+    def test_no_study_no_license(self, minimal_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(minimal_dir))
+        root = entities["./"]
+        assert "license" not in root
+
+    def test_no_study_no_author(self, minimal_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(minimal_dir))
+        root = entities["./"]
+        assert "author" not in root
+
+    def test_name_falls_back_to_dir(self, minimal_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(minimal_dir))
+        root = entities["./"]
+        assert root["name"] == minimal_dir.name
+
+    def test_single_file_entity(self, minimal_dir: Path):
+        from fd5.rocrate import generate
+
+        entities = _graph_by_id(generate(minimal_dir))
+        assert "sim-11223344.h5" in entities
+
+    def test_empty_dir(self, empty_dir: Path):
+        from fd5.rocrate import generate
+
+        result = generate(empty_dir)
+        entities = _graph_by_id(result)
+        root = entities["./"]
+        assert root["hasPart"] == []
+
+
+# ---------------------------------------------------------------------------
+# write()
+# ---------------------------------------------------------------------------
+
+
+class TestWrite:
+    def test_creates_file(self, full_dir: Path):
+        from fd5.rocrate import write
+
+        write(full_dir)
+        out = full_dir / "ro-crate-metadata.json"
+        assert out.exists()
+
+    def test_output_is_valid_json(self, full_dir: Path):
+        from fd5.rocrate import write
+
+        write(full_dir)
+        parsed = json.loads((full_dir / "ro-crate-metadata.json").read_text())
+        assert "@context" in parsed
+
+    def test_custom_output_path(self, full_dir: Path, tmp_path: Path):
+        from fd5.rocrate import write
+
+        out = tmp_path / "custom" / "crate.json"
+        write(full_dir, out)
+        assert out.exists()
+        parsed = json.loads(out.read_text())
+        assert "@graph" in parsed
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_creator_without_orcid(self, tmp_path: Path):
+        """Creators missing ORCID should still appear as Person, without @id."""
+        from fd5.rocrate import generate
+
+        _create_h5(
+            tmp_path / "recon-aaa.h5",
+            root_attrs={
+                "_schema_version": 1,
+                "product": "recon",
+                "id": "sha256:aaa",
+                "content_hash": "sha256:bbb",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            groups={
+                "study": {
+                    "license": "CC0-1.0",
+                    "name": "Test",
+                    "creators": {
+                        "0": {"name": "No Orcid Person", "affiliation": "Somewhere"},
+                    },
+                },
+            },
+        )
+        entities = _graph_by_id(generate(tmp_path))
+        root = entities["./"]
+        person = root["author"][0]
+        assert person["@type"] == "Person"
+        assert person["name"] == "No Orcid Person"
+        assert "@id" not in person
+
+    def test_creator_without_affiliation(self, tmp_path: Path):
+        from fd5.rocrate import generate
+
+        _create_h5(
+            tmp_path / "recon-aaa.h5",
+            root_attrs={
+                "_schema_version": 1,
+                "product": "recon",
+                "id": "sha256:aaa",
+                "content_hash": "sha256:bbb",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            groups={
+                "study": {
+                    "license": "CC0-1.0",
+                    "name": "Test",
+                    "creators": {
+                        "0": {"name": "Solo Dev"},
+                    },
+                },
+            },
+        )
+        entities = _graph_by_id(generate(tmp_path))
+        person = entities["./"]["author"][0]
+        assert person["name"] == "Solo Dev"
+        assert "affiliation" not in person
+
+    def test_multiple_sources(self, tmp_path: Path):
+        """File with multiple sources should produce multiple isBasedOn refs."""
+        from fd5.rocrate import generate
+
+        _create_h5(
+            tmp_path / "recon-multi.h5",
+            root_attrs={
+                "_schema_version": 1,
+                "product": "recon",
+                "id": "sha256:multi",
+                "content_hash": "sha256:multi",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            sources=[
+                {
+                    "name": "listmode",
+                    "id": "sha256:src1",
+                    "product": "listmode",
+                    "file": "listmode-src1.h5",
+                    "content_hash": "sha256:src1",
+                    "role": "primary",
+                    "description": "Source 1",
+                },
+                {
+                    "name": "ctac",
+                    "id": "sha256:src2",
+                    "product": "ctac",
+                    "file": "ctac-src2.h5",
+                    "content_hash": "sha256:src2",
+                    "role": "attenuation",
+                    "description": "Source 2",
+                },
+            ],
+        )
+        entities = _graph_by_id(generate(tmp_path))
+        recon = entities["recon-multi.h5"]
+        refs = recon["isBasedOn"]
+        files = {r["@id"] for r in refs}
+        assert files == {"listmode-src1.h5", "ctac-src2.h5"}


### PR DESCRIPTION
## Summary

- Add `fd5.rocrate` module (`src/fd5/rocrate.py`) that generates `ro-crate-metadata.json` conforming to RO-Crate 1.2 from fd5 HDF5 files in a directory
- Maps fd5 vocabulary to Schema.org terms per white-paper.md § ro-crate-metadata.json: `study/license`→`license`, `study/creators/`→`author` (Person with ORCID), `id`→`identifier` (PropertyValue sha256), `timestamp`→`dateCreated`, `provenance/ingest/`→`CreateAction` with `SoftwareApplication` instrument, `sources/`→`isBasedOn`
- Add `fd5 rocrate <dir>` CLI command with `--output` option following existing CLI patterns
- Add comprehensive tests in `tests/test_rocrate.py` (27 tests, 98% coverage) and CLI tests in `tests/test_cli.py`

## Test plan

- [x] `python -m pytest tests/test_rocrate.py` — 27 tests pass
- [x] `python -m pytest tests/test_cli.py` — 35 tests pass (including 6 new rocrate CLI tests)
- [x] Coverage ≥90% (`--cov=fd5.rocrate` reports 98%)
- [x] Full suite (770 tests) passes with no regressions
- [ ] CI lint failure is known and pre-existing — not related to this PR

Closes #59

Made with [Cursor](https://cursor.com)