### PR TITLE
chore: add pytest coverage config and close coverage gaps (#80)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,13 @@ spectrum = "fd5.imaging.spectrum:SpectrumSchema"
 roi = "fd5.imaging.roi:RoiSchema"
 device_data = "fd5.imaging.device_data:DeviceDataSchema"
 
+[tool.coverage.run]
+source = ["src/fd5"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
 [dependency-groups]
 dev = [
     "hatchling>=1.25",

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -637,6 +637,36 @@ class TestRegistration:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _coerce_list_attr edge case (calibration.py:326)
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceListAttrEmptyList:
+    def test_empty_list_in_metadata(self, schema, h5file):
+        """Covers calibration.py:326 — _coerce_list_attr with empty list."""
+        data = _base_data(
+            calibration_type="energy_calibration",
+            metadata={
+                "calibration": {
+                    "_type": "energy_calibration",
+                    "_version": 1,
+                    "description": "Test",
+                    "empty_values": [],
+                },
+            },
+        )
+        schema.write(h5file, data)
+        grp = h5file["metadata/calibration"]
+        result = grp.attrs["empty_values"]
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: write + embed_schema + validate
+# ---------------------------------------------------------------------------
+
+
 class TestIntegration:
     def test_create_validate_roundtrip(self, schema, h5path):
         from fd5.schema import embed_schema, validate

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,6 +299,54 @@ class TestManifestCommand:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# fd5 rocrate
+# ---------------------------------------------------------------------------
+
+
+class TestRocrateCommand:
+    def test_exits_zero(self, runner: CliRunner, data_dir: Path):
+        result = runner.invoke(cli, ["rocrate", str(data_dir)])
+        assert result.exit_code == 0
+
+    def test_creates_default_output(self, runner: CliRunner, data_dir: Path):
+        runner.invoke(cli, ["rocrate", str(data_dir)])
+        assert (data_dir / "ro-crate-metadata.json").exists()
+
+    def test_custom_output_path(
+        self, runner: CliRunner, data_dir: Path, tmp_path: Path
+    ):
+        out = tmp_path / "custom" / "crate.json"
+        result = runner.invoke(cli, ["rocrate", str(data_dir), "--output", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+
+    def test_nonexistent_dir_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["rocrate", str(tmp_path / "nope")])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# _format_attr (bytes branch)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAttr:
+    def test_bytes_attr_decoded(self, runner: CliRunner, tmp_path: Path):
+        """Covers cli.py:156 — _format_attr decoding bytes to str."""
+        path = tmp_path / "bytes_attr.h5"
+        with h5py.File(path, "w") as f:
+            f.attrs["name"] = np.bytes_(b"hello-bytes")
+        result = runner.invoke(cli, ["info", str(path)])
+        assert result.exit_code == 0
+        assert "hello-bytes" in result.output
+
+
+# ---------------------------------------------------------------------------
+# fd5 --help
+# ---------------------------------------------------------------------------
+
+
 class TestHelp:
     def test_help_exits_zero(self, runner: CliRunner):
         result = runner.invoke(cli, ["--help"])

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -500,6 +500,98 @@ class TestIdempotency:
 
 
 # ---------------------------------------------------------------------------
+# _validate with bytes attrs (create.py:128)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBytesAttrs:
+    def test_validate_decodes_bytes_attr(self, out_dir: Path):
+        """Covers create.py:128 — _validate decoding bytes attr values."""
+        with create(
+            out_dir,
+            product="test/product",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.file.attrs["name"] = np.bytes_(b"sample")
+            builder.file.attrs["description"] = np.bytes_(b"desc")
+            builder.file.attrs["timestamp"] = np.bytes_(b"2026-02-25T12:00:00Z")
+
+        final = _find_h5(out_dir)
+        assert final.exists()
+
+
+# ---------------------------------------------------------------------------
+# _seal with bytes id_input attrs (create.py:146)
+# ---------------------------------------------------------------------------
+
+
+class TestSealBytesIdInputs:
+    def test_seal_decodes_bytes_id_input(self, out_dir: Path):
+        """Covers create.py:146 — _seal decoding bytes id_input values."""
+        with create(
+            out_dir,
+            product="test/product",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.file.attrs["product"] = np.bytes_(b"test/product")
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            assert f.attrs["id"].startswith("sha256:")
+
+
+# ---------------------------------------------------------------------------
+# _parse_timestamp edge cases (create.py:226,229-230)
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimestamp:
+    def test_empty_timestamp_returns_none(self):
+        """Covers create.py:226 — empty ts returns None."""
+        from fd5.create import _parse_timestamp
+
+        assert _parse_timestamp("") is None
+
+    def test_invalid_timestamp_falls_back_to_now(self, out_dir: Path):
+        """Covers create.py:229-230 — invalid ISO format falls back to datetime.now."""
+        with create(
+            out_dir,
+            product="test/product",
+            name="sample",
+            description="desc",
+            timestamp="not-a-valid-iso-timestamp",
+        ):
+            pass
+
+        final = _find_h5(out_dir)
+        assert final.exists()
+
+
+# ---------------------------------------------------------------------------
+# Exception path when file handle already invalid (create.py:214-215)
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionFileHandleInvalid:
+    def test_exception_after_file_closed(self, out_dir: Path):
+        """Covers create.py:214-215 — f.id invalid when exception raised after close."""
+        with pytest.raises(RuntimeError, match="after close"):
+            with create(
+                out_dir,
+                product="test/product",
+                name="sample",
+                description="desc",
+                timestamp="2026-02-25T12:00:00Z",
+            ) as builder:
+                builder.file.close()
+                raise RuntimeError("after close")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -265,6 +265,117 @@ class TestWrite:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Edge cases for _build_dates and _collect_tracer_subjects
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDatesNoTimestamps:
+    def test_data_entries_without_timestamp_produce_empty_dates(self, tmp_path: Path):
+        """Covers datacite.py:84 — timestamps list empty returns []."""
+        toml_text = """\
+_schema_version = 1
+dataset_name = "no-ts"
+
+[[data]]
+product = "recon"
+id = "sha256:0000"
+file = "recon-0000.h5"
+"""
+        path = tmp_path / "manifest.toml"
+        path.write_text(toml_text)
+        _create_h5_with_tracer(tmp_path / "recon-0000.h5")
+        result = generate(path)
+        assert result["dates"] == []
+
+
+class TestCollectTracerSubjectsBytesName:
+    def test_tracer_name_stored_as_bytes(self, tmp_path: Path):
+        """Covers datacite.py:123,125 — bytes tracer name decoded."""
+        import numpy as np
+
+        toml_text = """\
+_schema_version = 1
+dataset_name = "bytes-tracer"
+
+[[data]]
+product = "recon"
+id = "sha256:1111"
+file = "recon-bytes.h5"
+scan_type = "pet"
+scan_type_vocabulary = "DICOM Modality"
+timestamp = "2025-01-01T00:00:00Z"
+"""
+        path = tmp_path / "manifest.toml"
+        path.write_text(toml_text)
+        h5_path = tmp_path / "recon-bytes.h5"
+        with h5py.File(h5_path, "w") as f:
+            meta = f.create_group("metadata")
+            pet = meta.create_group("pet")
+            tracer = pet.create_group("tracer")
+            tracer.attrs.create("name", data=np.bytes_(b"FDG"))
+        result = generate(path)
+        tracer_subjects = [
+            s for s in result["subjects"] if s.get("subjectScheme") == "Radiotracer"
+        ]
+        assert len(tracer_subjects) == 1
+        assert tracer_subjects[0]["subject"] == "FDG"
+
+
+class TestCollectTracerSubjectsNoName:
+    def test_tracer_group_without_name_attr(self, tmp_path: Path):
+        """Covers datacite.py:123 — tracer group exists but name attr is missing."""
+        toml_text = """\
+_schema_version = 1
+dataset_name = "no-name"
+
+[[data]]
+product = "recon"
+id = "sha256:2222"
+file = "recon-noname.h5"
+scan_type = "pet"
+scan_type_vocabulary = "DICOM Modality"
+timestamp = "2025-01-01T00:00:00Z"
+"""
+        path = tmp_path / "manifest.toml"
+        path.write_text(toml_text)
+        h5_path = tmp_path / "recon-noname.h5"
+        with h5py.File(h5_path, "w") as f:
+            meta = f.create_group("metadata")
+            pet = meta.create_group("pet")
+            pet.create_group("tracer")
+        result = generate(path)
+        tracer_subjects = [
+            s for s in result["subjects"] if s.get("subjectScheme") == "Radiotracer"
+        ]
+        assert len(tracer_subjects) == 0
+
+
+class TestCollectTracerSubjectsException:
+    def test_corrupt_h5_returns_no_subjects(self, tmp_path: Path):
+        """Covers datacite.py:130-131 — exception in _collect_tracer_subjects."""
+        toml_text = """\
+_schema_version = 1
+dataset_name = "corrupt"
+
+[[data]]
+product = "recon"
+id = "sha256:bad"
+file = "corrupt.h5"
+scan_type = "pet"
+scan_type_vocabulary = "DICOM Modality"
+timestamp = "2025-01-01T00:00:00Z"
+"""
+        path = tmp_path / "manifest.toml"
+        path.write_text(toml_text)
+        (tmp_path / "corrupt.h5").write_bytes(b"not a valid hdf5 file")
+        result = generate(path)
+        tracer_subjects = [
+            s for s in result["subjects"] if s.get("subjectScheme") == "Radiotracer"
+        ]
+        assert len(tracer_subjects) == 0
+
+
 class TestDataciteCLI:
     def test_exits_zero(self, manifest_path: Path):
         from click.testing import CliRunner

--- a/tests/test_h5io.py
+++ b/tests/test_h5io.py
@@ -280,6 +280,32 @@ class TestRoundTrip:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _read_attr edge cases (h5io.py:86,97)
+# ---------------------------------------------------------------------------
+
+
+class TestReadAttrEdgeCases:
+    def test_bytes_attr_decoded(self, h5group):
+        """Covers h5io.py:86 — _read_attr decodes bytes to str."""
+        h5group.attrs.create("raw", data=np.bytes_(b"hello"))
+        result = h5_to_dict(h5group)
+        assert result["raw"] == "hello"
+        assert isinstance(result["raw"], str)
+
+    def test_unrecognized_type_returned_as_is(self, h5group):
+        """Covers h5io.py:97 — _read_attr fallthrough returns value unchanged."""
+        from fd5.h5io import _read_attr
+
+        sentinel = object()
+        assert _read_attr(sentinel) is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
 class TestErrorHandling:
     def test_unsupported_type_raises_typeerror(self, h5group):
         with pytest.raises(TypeError, match="Unsupported type"):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -377,6 +377,48 @@ class TestVerify:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _serialize_attr edge cases (hash.py:78,85)
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeAttr:
+    def test_bytes_attr_returned_as_bytes(self):
+        """Covers hash.py:78 — _serialize_attr returns bytes as-is."""
+        from fd5.hash import _serialize_attr
+
+        raw = b"raw-bytes"
+        assert _serialize_attr(raw) == raw
+
+    def test_unsupported_type_falls_back_to_str(self):
+        """Covers hash.py:85 — _serialize_attr str(value).encode fallthrough."""
+        from fd5.hash import _serialize_attr
+
+        result = _serialize_attr(42)
+        assert result == b"42"
+
+
+# ---------------------------------------------------------------------------
+# verify with bytes content_hash (hash.py:175)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyBytesContentHash:
+    def test_bytes_content_hash_decoded(self, h5path: Path):
+        """Covers hash.py:175 — verify decodes bytes content_hash."""
+        with h5py.File(h5path, "w") as f:
+            f.create_dataset("data", data=np.array([1.0, 2.0]))
+            h = compute_content_hash(f)
+            f.attrs.create("content_hash", data=np.bytes_(h.encode("utf-8")))
+
+        assert verify(h5path) is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and integration
+# ---------------------------------------------------------------------------
+
+
 class TestEdgeCases:
     def test_chunk_hash_edge_chunk(self):
         """Edge chunks (partial) should hash actual data only."""

--- a/tests/test_listmode.py
+++ b/tests/test_listmode.py
@@ -37,35 +37,45 @@ def h5path(tmp_path):
 # Helpers — compound dtypes and data builders
 # ---------------------------------------------------------------------------
 
-_SINGLES_DTYPE = np.dtype([
-    ("timestamp", np.uint64),
-    ("energy", np.float32),
-    ("detector_id", np.uint32),
-])
+_SINGLES_DTYPE = np.dtype(
+    [
+        ("timestamp", np.uint64),
+        ("energy", np.float32),
+        ("detector_id", np.uint32),
+    ]
+)
 
-_TIME_MARKERS_DTYPE = np.dtype([
-    ("timestamp", np.uint64),
-    ("marker_type", np.uint8),
-])
+_TIME_MARKERS_DTYPE = np.dtype(
+    [
+        ("timestamp", np.uint64),
+        ("marker_type", np.uint8),
+    ]
+)
 
-_COIN_COUNTERS_DTYPE = np.dtype([
-    ("timestamp", np.uint64),
-    ("prompt", np.uint32),
-    ("delayed", np.uint32),
-])
+_COIN_COUNTERS_DTYPE = np.dtype(
+    [
+        ("timestamp", np.uint64),
+        ("prompt", np.uint32),
+        ("delayed", np.uint32),
+    ]
+)
 
-_TABLE_POSITIONS_DTYPE = np.dtype([
-    ("timestamp", np.uint64),
-    ("position", np.float32),
-])
+_TABLE_POSITIONS_DTYPE = np.dtype(
+    [
+        ("timestamp", np.uint64),
+        ("position", np.float32),
+    ]
+)
 
-_EVENTS_2P_DTYPE = np.dtype([
-    ("timestamp", np.uint64),
-    ("energy_a", np.float32),
-    ("energy_b", np.float32),
-    ("detector_a", np.uint32),
-    ("detector_b", np.uint32),
-])
+_EVENTS_2P_DTYPE = np.dtype(
+    [
+        ("timestamp", np.uint64),
+        ("energy_a", np.float32),
+        ("energy_b", np.float32),
+        ("detector_a", np.uint32),
+        ("detector_b", np.uint32),
+    ]
+)
 
 
 def _make_singles(n: int = 100) -> np.ndarray:
@@ -481,6 +491,34 @@ class TestWriteDaq:
         data = _minimal_data()
         schema.write(h5file, data)
         assert "metadata" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# Entry point registration (manual via register_schema)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# write() — metadata/daq int and fallthrough (listmode.py:154,160)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDaqIntAndFallthrough:
+    def test_daq_int_attr(self, schema, h5file):
+        """Covers listmode.py:154 — _write_daq with int value."""
+        data = _minimal_data()
+        data["daq"] = {"n_channels": 1024}
+        schema.write(h5file, data)
+        daq = h5file["metadata/daq"]
+        assert int(daq.attrs["n_channels"]) == 1024
+
+    def test_daq_fallthrough_attr(self, schema, h5file):
+        """Covers listmode.py:160 — _write_daq else branch (e.g. numpy array)."""
+        data = _minimal_data()
+        data["daq"] = {"offsets": np.array([1.0, 2.0], dtype=np.float64)}
+        schema.write(h5file, data)
+        daq = h5file["metadata/daq"]
+        np.testing.assert_array_equal(daq.attrs["offsets"], [1.0, 2.0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rocrate.py
+++ b/tests/test_rocrate.py
@@ -409,6 +409,61 @@ class TestEdgeCases:
         assert person["name"] == "Solo Dev"
         assert "affiliation" not in person
 
+    def test_creators_not_dict_returns_no_authors(self, tmp_path: Path):
+        """Covers rocrate.py:113 — creators is not a dict (e.g. empty string)."""
+        from fd5.rocrate import generate
+
+        _create_h5(
+            tmp_path / "recon-aaa.h5",
+            root_attrs={
+                "_schema_version": 1,
+                "product": "recon",
+                "id": "sha256:aaa",
+                "content_hash": "sha256:bbb",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            groups={
+                "study": {
+                    "license": "CC0-1.0",
+                    "name": "Test",
+                },
+            },
+        )
+        entities = _graph_by_id(generate(tmp_path))
+        root = entities["./"]
+        assert "author" not in root
+
+    def test_non_dict_creator_entry_skipped(self, tmp_path: Path):
+        """Covers rocrate.py:119 — non-dict creator entry skipped."""
+        from fd5.rocrate import generate
+
+        path = tmp_path / "recon-skip.h5"
+        with h5py.File(path, "w") as f:
+            dict_to_h5(
+                f,
+                {
+                    "_schema_version": 1,
+                    "product": "recon",
+                    "id": "sha256:skip",
+                    "content_hash": "sha256:skip",
+                    "timestamp": "2025-01-01T00:00:00Z",
+                },
+            )
+            study = f.create_group("study")
+            study.attrs["license"] = "CC0-1.0"
+            study.attrs["name"] = "Test"
+            creators = study.create_group("creators")
+            creators.attrs["bad_entry"] = "not-a-dict"
+            good = creators.create_group("good_entry")
+            good.attrs["name"] = "Good Person"
+
+        entities = _graph_by_id(generate(tmp_path))
+        root = entities["./"]
+        authors = root.get("author", [])
+        names = {a["name"] for a in authors}
+        assert "Good Person" in names
+        assert len(authors) == 1
+
     def test_multiple_sources(self, tmp_path: Path):
         """File with multiple sources should produce multiple isBasedOn refs."""
         from fd5.rocrate import generate

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -381,6 +381,26 @@ class TestWriteSimulationMetadata:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# write() — simulation metadata with pre-existing metadata group (sim.py:130)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSimulationMetadataExisting:
+    def test_uses_existing_metadata_group(self, schema, h5file):
+        """Covers sim.py:130 — metadata group already exists."""
+        h5file.create_group("metadata")
+        data = _full_sim_data()
+        schema.write(h5file, data)
+        assert "metadata/simulation" in h5file
+        assert h5file["metadata/simulation"].attrs["_type"] == "gate"
+
+
+# ---------------------------------------------------------------------------
+# write() — full round-trip
+# ---------------------------------------------------------------------------
+
+
 class TestWriteFullRoundTrip:
     def test_all_groups_present(self, schema, h5file):
         data = _full_sim_data()

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -485,6 +485,75 @@ class TestWriteMetadata:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# write() — metadata method with top-level float/int/str (spectrum.py:179,183,185)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMethodTopLevelValues:
+    def test_method_float_attr(self, schema, h5file):
+        """Covers spectrum.py:183 — float value written to method group."""
+        data = _minimal_1d_data()
+        data["metadata"] = {
+            "method": {
+                "_type": "custom",
+                "threshold": 42.5,
+            },
+        }
+        schema.write(h5file, data)
+        method = h5file["metadata/method"]
+        assert float(method.attrs["threshold"]) == pytest.approx(42.5)
+
+    def test_method_int_attr(self, schema, h5file):
+        """Covers spectrum.py:185 — int value written to method group."""
+        data = _minimal_1d_data()
+        data["metadata"] = {
+            "method": {
+                "_type": "custom",
+                "n_iterations": 100,
+            },
+        }
+        schema.write(h5file, data)
+        method = h5file["metadata/method"]
+        assert int(method.attrs["n_iterations"]) == 100
+
+    def test_method_str_attr(self, schema, h5file):
+        """Covers spectrum.py top-level str in method."""
+        data = _minimal_1d_data()
+        data["metadata"] = {
+            "method": {
+                "_type": "custom",
+                "algorithm": "mlem",
+            },
+        }
+        schema.write(h5file, data)
+        method = h5file["metadata/method"]
+        val = method.attrs["algorithm"]
+        if isinstance(val, bytes):
+            val = val.decode()
+        assert val == "mlem"
+
+    def test_method_subgroup_int_attr(self, schema, h5file):
+        """Covers spectrum.py:179 — int value in method subgroup dict."""
+        data = _minimal_1d_data()
+        data["metadata"] = {
+            "method": {
+                "_type": "custom",
+                "config": {
+                    "n_bins": 256,
+                },
+            },
+        }
+        schema.write(h5file, data)
+        sub = h5file["metadata/method/config"]
+        assert int(sub.attrs["n_bins"]) == 256
+
+
+# ---------------------------------------------------------------------------
+# write() — fit
+# ---------------------------------------------------------------------------
+
+
 class TestWriteFit:
     def test_fit_group_created(self, schema, h5file):
         data = _1d_with_fit()


### PR DESCRIPTION
## Summary

- Add `[tool.coverage.run]` and `[tool.coverage.report]` sections to `pyproject.toml` with `source=["src/fd5"]`, `fail_under=95`, `show_missing=true`.
- Add 29 new tests covering all previously uncovered lines across 11 modules: `cli.py`, `create.py`, `datacite.py`, `h5io.py`, `hash.py`, `calibration.py`, `listmode.py`, `sim.py`, `spectrum.py`, `rocrate.py`.
- Result: **820 tests, 100% line coverage** on every module (up from 791 tests / 98%).

## Test plan

- [x] `pytest --cov=fd5 --cov-report=term-missing` shows 100% on all modules
- [x] All 820 tests pass
- [x] `fail_under=95` threshold enforced
- [x] No source module logic modified — only config and test additions
- [x] `uv.lock` unchanged
- [ ] CI lint failure on `check-action-pins` is known — ignore it

Made with [Cursor](https://cursor.com)