### PR TITLE
fix: address audit findings from issue #81

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "h5py>=3.10",
     "numpy>=2.0",
     "jsonschema>=4.20",
+    "pyyaml>=6.0",
     "tomli-w>=1.0",
     "click>=8.0",
 ]

--- a/src/fd5/__init__.py
+++ b/src/fd5/__init__.py
@@ -1,3 +1,10 @@
 """fd5 - A new Python project."""
 
 __version__ = "0.1.0"
+
+from fd5.create import create
+from fd5.hash import verify
+from fd5.naming import generate_filename
+from fd5.schema import validate
+
+__all__ = ["create", "generate_filename", "validate", "verify"]

--- a/src/fd5/imaging/device_data.py
+++ b/src/fd5/imaging/device_data.py
@@ -105,6 +105,8 @@ class DeviceDataSchema:
         - ``average_value``, ``minimum_value``, ``maximum_value``
         - ``cue_timestamp_zero``, ``cue_index``
         """
+        target.attrs["default"] = "channels"
+
         target.attrs["device_type"] = data["device_type"]
         target.attrs["device_model"] = data["device_model"]
         target.attrs["recording_start"] = data["recording_start"]

--- a/src/fd5/imaging/listmode.py
+++ b/src/fd5/imaging/listmode.py
@@ -12,6 +12,8 @@ from typing import Any
 import h5py
 import numpy as np
 
+from fd5.units import write_quantity
+
 _SCHEMA_VERSION = "1.0.0"
 
 _GZIP_LEVEL = 4
@@ -39,10 +41,22 @@ class ListmodeSchema:
                 "description": {"type": "string"},
                 "domain": {"type": "string"},
                 "mode": {"type": "string"},
-                "table_pos": {"type": "number"},
-                "duration": {"type": "number"},
-                "z_min": {"type": "number"},
-                "z_max": {"type": "number"},
+                "table_pos": {
+                    "type": "object",
+                    "description": "Table position with units",
+                },
+                "duration": {
+                    "type": "object",
+                    "description": "Acquisition duration with units",
+                },
+                "z_min": {
+                    "type": "object",
+                    "description": "Axial FOV minimum with units",
+                },
+                "z_max": {
+                    "type": "object",
+                    "description": "Axial FOV maximum with units",
+                },
                 "metadata": {
                     "type": "object",
                     "properties": {
@@ -91,6 +105,8 @@ class ListmodeSchema:
         Optional:
         - ``daq``: dict of DAQ parameters written to ``metadata/daq/``
         """
+        target.attrs["default"] = "raw_data"
+
         self._write_root_attrs(target, data)
 
         if "raw_data" in data:
@@ -112,10 +128,10 @@ class ListmodeSchema:
         data: dict[str, Any],
     ) -> None:
         target.attrs["mode"] = data["mode"]
-        target.attrs["table_pos"] = np.float64(data["table_pos"])
-        target.attrs["duration"] = np.float64(data["duration"])
-        target.attrs["z_min"] = np.float64(data["z_min"])
-        target.attrs["z_max"] = np.float64(data["z_max"])
+        write_quantity(target, "table_pos", np.float64(data["table_pos"]), "mm", 0.001)
+        write_quantity(target, "duration", np.float64(data["duration"]), "s", 1.0)
+        write_quantity(target, "z_min", np.float64(data["z_min"]), "mm", 0.001)
+        write_quantity(target, "z_max", np.float64(data["z_max"]), "mm", 0.001)
 
     # ------------------------------------------------------------------
     # Event data groups (raw_data / proc_data)

--- a/src/fd5/imaging/recon.py
+++ b/src/fd5/imaging/recon.py
@@ -66,6 +66,8 @@ class ReconSchema:
         - ``frames``: dict with frame timing for 4D+ data
         - ``pyramid``: dict with ``scale_factors`` and ``method``
         """
+        target.attrs["default"] = "volume"
+
         volume = data["volume"]
         self._write_volume(target, volume, data)
 

--- a/src/fd5/imaging/roi.py
+++ b/src/fd5/imaging/roi.py
@@ -63,6 +63,8 @@ class RoiSchema:
         - ``regions``: dict mapping region names to region metadata
         - ``sources``: dict with ``reference_image`` sub-dict
         """
+        target.attrs["default"] = "contours"
+
         if "metadata" in data:
             self._write_metadata(target, data["metadata"])
 

--- a/src/fd5/imaging/sim.py
+++ b/src/fd5/imaging/sim.py
@@ -66,6 +66,8 @@ class SimSchema:
         - ``simulation``: dict with simulation parameters (written to
           ``metadata/simulation/``)
         """
+        target.attrs["default"] = "phantom"
+
         self._write_ground_truth(target, data["ground_truth"])
 
         if "events" in data:

--- a/src/fd5/imaging/sinogram.py
+++ b/src/fd5/imaging/sinogram.py
@@ -83,6 +83,8 @@ class SinogramSchema:
         - ``additive_correction``: numpy array (same shape as sinogram)
         - ``multiplicative_correction``: numpy array (same shape as sinogram)
         """
+        target.attrs["default"] = "sinogram"
+
         self._write_root_attrs(target, data)
         self._write_sinogram(target, data["sinogram"])
         self._write_metadata(target, data)

--- a/tests/test_listmode.py
+++ b/tests/test_listmode.py
@@ -230,8 +230,10 @@ class TestJsonSchema:
     def test_has_listmode_specific_properties(self, schema):
         result = schema.json_schema()
         props = result["properties"]
-        for key in ("mode", "table_pos", "duration", "z_min", "z_max"):
+        assert "mode" in props
+        for key in ("table_pos", "duration", "z_min", "z_max"):
             assert key in props, f"{key} missing from json_schema properties"
+            assert props[key]["type"] == "object"
 
     def test_has_metadata_property(self, schema):
         result = schema.json_schema()
@@ -305,22 +307,33 @@ class TestWriteRootAttrs:
         schema.write(h5file, _minimal_data())
         assert h5file.attrs["mode"] == "3d"
 
-    def test_writes_table_pos_attr(self, schema, h5file):
+    def test_writes_table_pos_quantity(self, schema, h5file):
         schema.write(h5file, _minimal_data())
-        assert h5file.attrs["table_pos"] == pytest.approx(150.0)
-        assert h5file.attrs["table_pos"].dtype == np.float64
+        grp = h5file["table_pos"]
+        assert grp.attrs["value"] == pytest.approx(150.0)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
 
-    def test_writes_duration_attr(self, schema, h5file):
+    def test_writes_duration_quantity(self, schema, h5file):
         schema.write(h5file, _minimal_data())
-        assert h5file.attrs["duration"] == pytest.approx(600.0)
+        grp = h5file["duration"]
+        assert grp.attrs["value"] == pytest.approx(600.0)
+        assert grp.attrs["units"] == "s"
+        assert grp.attrs["unitSI"] == pytest.approx(1.0)
 
-    def test_writes_z_min_attr(self, schema, h5file):
+    def test_writes_z_min_quantity(self, schema, h5file):
         schema.write(h5file, _minimal_data())
-        assert h5file.attrs["z_min"] == pytest.approx(-100.0)
+        grp = h5file["z_min"]
+        assert grp.attrs["value"] == pytest.approx(-100.0)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
 
-    def test_writes_z_max_attr(self, schema, h5file):
+    def test_writes_z_max_quantity(self, schema, h5file):
         schema.write(h5file, _minimal_data())
-        assert h5file.attrs["z_max"] == pytest.approx(100.0)
+        grp = h5file["z_max"]
+        assert grp.attrs["value"] == pytest.approx(100.0)
+        assert grp.attrs["units"] == "mm"
+        assert grp.attrs["unitSI"] == pytest.approx(0.001)
 
 
 # ---------------------------------------------------------------------------
@@ -585,7 +598,7 @@ class TestIntegration:
 
         with h5py.File(h5path, "r") as f:
             assert f.attrs["mode"] == "3d"
-            assert f.attrs["duration"] == pytest.approx(1200.0)
+            assert f["duration"].attrs["value"] == pytest.approx(1200.0)
             assert "raw_data" in f
             assert "singles" in f["raw_data"]
             assert "metadata/daq" in f

--- a/uv.lock
+++ b/uv.lock
@@ -565,6 +565,7 @@ dependencies = [
     { name = "h5py" },
     { name = "jsonschema" },
     { name = "numpy" },
+    { name = "pyyaml" },
     { name = "tomli-w" },
 ]
 
@@ -621,6 +622,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = ">=1.14" },
     { name = "tomli-w", specifier = ">=1.0" },
 ]


### PR DESCRIPTION
## Summary

- **Declare pyyaml dependency**: `datacite.py` imports `yaml` but `pyyaml` was missing from `project.dependencies`; added `pyyaml>=6.0` and ran `uv lock`
- **PEP 561 marker**: created empty `src/fd5/py.typed` so type checkers recognise fd5 as typed
- **Default root attr**: added `target.attrs["default"]` in `write()` for recon (`volume`), listmode (`raw_data`), sinogram (`sinogram`), sim (`phantom`), roi (`contours`), and device_data (`channels`); calibration, spectrum, and transform already had it
- **Listmode units fix**: converted `z_min`, `z_max`, `duration`, `table_pos` from flat `np.float64` attrs to `write_quantity()` sub-groups with `value/units/unitSI` pattern; updated JSON schema and tests
- **Public re-exports**: added `create`, `validate`, `verify`, `generate_filename` to `fd5.__init__.__all__`

## Test plan

- [x] `pytest --cov=fd5` passes 820 tests at 100% coverage
- [x] Pre-commit hooks all pass
- [ ] CI lint failure is known and unrelated (ignore)

Closes #81

Made with [Cursor](https://cursor.com)