### PR TITLE
feat(datalad): add DataLad integration hooks and CLI command

### DIFF
--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -125,7 +125,6 @@ def datacite(directory: str, output: str | None) -> None:
     click.echo(f"Wrote {out_path}")
 
 
-
 @cli.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option(
@@ -142,6 +141,40 @@ def rocrate(directory: str, output: str | None) -> None:
     write_rocrate(dir_path, out_path)
     written = out_path or dir_path / "ro-crate-metadata.json"
     click.echo(f"Wrote {written}")
+
+
+@cli.command("datalad-register")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--dataset",
+    "-d",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Path to the DataLad dataset (default: parent directory of FILE).",
+)
+def datalad_register(file: str, dataset: str | None) -> None:
+    """Register an fd5 file with a DataLad dataset."""
+    from fd5.datalad import extract_metadata, register_with_datalad
+
+    path = Path(file)
+
+    try:
+        result = register_with_datalad(path, dataset)
+    except ImportError:
+        click.echo(
+            "Error: datalad is not installed. Install it with: pip install datalad",
+            err=True,
+        )
+        sys.exit(1)
+    except Exception as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(f"Registered {path.name} with dataset {result['dataset']}")
+    metadata = extract_metadata(path)
+    click.echo(f"  title: {metadata.get('title', 'N/A')}")
+    click.echo(f"  product: {metadata.get('product', 'N/A')}")
+    click.echo(f"  id: {metadata.get('id', 'N/A')}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/fd5/datalad.py
+++ b/src/fd5/datalad.py
@@ -1,0 +1,128 @@
+"""fd5.datalad — DataLad integration hooks.
+
+Provides metadata extraction in DataLad-compatible format and optional
+registration of fd5 files with DataLad datasets.  Gracefully degrades
+when DataLad is not installed (datalad is an optional dependency).
+
+See issue #92 and white-paper § Scope and Non-Goals (DataLad integration).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+
+from fd5.h5io import h5_to_dict
+
+
+def _has_datalad() -> bool:
+    """Return True if datalad is importable."""
+    try:
+        import datalad  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def extract_metadata(path: str | Path) -> dict[str, Any]:
+    """Read an fd5 HDF5 file and return metadata in DataLad-compatible format.
+
+    Returns a dict with keys: ``title``, ``creators``, ``id``, ``product``,
+    ``timestamp``, ``content_hash``.  Missing attributes are omitted.
+    """
+    path = Path(path)
+    metadata: dict[str, Any] = {}
+
+    with h5py.File(path, "r") as f:
+        root_attrs = _safe_root_attrs(f)
+
+        if "product" in root_attrs:
+            metadata["product"] = root_attrs["product"]
+        if "id" in root_attrs:
+            metadata["id"] = root_attrs["id"]
+        if "timestamp" in root_attrs:
+            metadata["timestamp"] = root_attrs["timestamp"]
+        if "content_hash" in root_attrs:
+            metadata["content_hash"] = root_attrs["content_hash"]
+
+        title = root_attrs.get("name", path.stem)
+        metadata["title"] = title
+
+        creators = _extract_creators(f)
+        if creators:
+            metadata["creators"] = creators
+
+    return metadata
+
+
+def register_with_datalad(
+    path: str | Path, dataset_path: str | Path | None = None
+) -> dict[str, Any]:
+    """Register an fd5 file with a DataLad dataset.
+
+    If *dataset_path* is ``None``, uses the parent directory of *path*.
+
+    Returns a dict with ``status``, ``path``, and ``metadata`` on success.
+
+    Raises ``ImportError`` if datalad is not installed.
+    """
+    if not _has_datalad():
+        raise ImportError(
+            "datalad is not installed. Install it with: pip install datalad"
+        )
+
+    import importlib
+
+    dl_api = importlib.import_module("datalad.api")
+
+    path = Path(path)
+    dataset_path = Path(dataset_path) if dataset_path else path.parent
+
+    ds = dl_api.Dataset(str(dataset_path))
+    ds.save(str(path), message=f"Register fd5 file: {path.name}")
+
+    metadata = extract_metadata(path)
+
+    return {
+        "status": "ok",
+        "path": str(path),
+        "dataset": str(dataset_path),
+        "metadata": metadata,
+    }
+
+
+def _safe_root_attrs(f: h5py.File) -> dict[str, Any]:
+    """Read root-level HDF5 attributes using fd5.h5io helpers."""
+    from fd5.h5io import _read_attr
+
+    result: dict[str, Any] = {}
+    for key in sorted(f.attrs.keys()):
+        result[key] = _read_attr(f.attrs[key])
+    return result
+
+
+def _extract_creators(f: h5py.File) -> list[dict[str, str]]:
+    """Extract creator metadata from study group if present."""
+    if "study" not in f:
+        return []
+
+    study = h5_to_dict(f["study"])
+    creators_group = study.get("creators")
+    if not creators_group or not isinstance(creators_group, dict):
+        return []
+
+    creators: list[dict[str, str]] = []
+    for key in sorted(creators_group.keys()):
+        c = creators_group[key]
+        if not isinstance(c, dict):
+            continue
+        entry: dict[str, str] = {"name": c["name"]}
+        if "affiliation" in c:
+            entry["affiliation"] = c["affiliation"]
+        if "orcid" in c:
+            entry["orcid"] = c["orcid"]
+        creators.append(entry)
+    return creators

--- a/tests/test_datalad.py
+++ b/tests/test_datalad.py
@@ -1,0 +1,487 @@
+"""Tests for fd5.datalad — DataLad integration hooks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import h5py
+import pytest
+
+from fd5.h5io import dict_to_h5
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_h5(
+    path: Path,
+    root_attrs: dict[str, Any],
+    groups: dict[str, dict[str, Any]] | None = None,
+) -> None:
+    with h5py.File(path, "w") as f:
+        dict_to_h5(f, root_attrs)
+        if groups:
+            for name, attrs in groups.items():
+                g = f.create_group(name)
+                dict_to_h5(g, attrs)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CREATOR_JANE = {
+    "name": "Jane Doe",
+    "affiliation": "ETH Zurich",
+    "orcid": "https://orcid.org/0000-0002-1234-5678",
+}
+
+CREATOR_JOHN = {
+    "name": "John Smith",
+    "affiliation": "MIT",
+}
+
+
+@pytest.fixture()
+def full_h5(tmp_path: Path) -> Path:
+    path = tmp_path / "recon-aabb1122.h5"
+    _create_h5(
+        path,
+        root_attrs={
+            "_schema_version": 1,
+            "product": "recon",
+            "id": "sha256:aabb112233445566",
+            "content_hash": "sha256:deadbeef",
+            "timestamp": "2024-07-24T19:06:10+02:00",
+            "name": "DOGPLET DD01 Recon",
+        },
+        groups={
+            "study": {
+                "license": "CC-BY-4.0",
+                "name": "DOGPLET DD01",
+                "creators": {
+                    "0": CREATOR_JANE,
+                    "1": CREATOR_JOHN,
+                },
+            },
+        },
+    )
+    return path
+
+
+@pytest.fixture()
+def minimal_h5(tmp_path: Path) -> Path:
+    path = tmp_path / "sim-11223344.h5"
+    _create_h5(
+        path,
+        root_attrs={
+            "_schema_version": 1,
+            "product": "sim",
+            "id": "sha256:1122334455667788",
+            "content_hash": "sha256:00000000",
+            "timestamp": "2025-06-01T12:00:00Z",
+        },
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata()
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMetadata:
+    def test_returns_dict(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert isinstance(result, dict)
+
+    def test_has_title(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert result["title"] == "DOGPLET DD01 Recon"
+
+    def test_has_product(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert result["product"] == "recon"
+
+    def test_has_id(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert result["id"] == "sha256:aabb112233445566"
+
+    def test_has_timestamp(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert result["timestamp"] == "2024-07-24T19:06:10+02:00"
+
+    def test_has_content_hash(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert result["content_hash"] == "sha256:deadbeef"
+
+    def test_has_creators(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        assert len(result["creators"]) == 2
+        names = {c["name"] for c in result["creators"]}
+        assert names == {"Jane Doe", "John Smith"}
+
+    def test_creator_has_affiliation(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        jane = next(c for c in result["creators"] if c["name"] == "Jane Doe")
+        assert jane["affiliation"] == "ETH Zurich"
+
+    def test_creator_has_orcid(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        jane = next(c for c in result["creators"] if c["name"] == "Jane Doe")
+        assert jane["orcid"] == "https://orcid.org/0000-0002-1234-5678"
+
+    def test_creator_without_orcid(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(full_h5)
+        john = next(c for c in result["creators"] if c["name"] == "John Smith")
+        assert "orcid" not in john
+
+    def test_title_falls_back_to_stem(self, minimal_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(minimal_h5)
+        assert result["title"] == "sim-11223344"
+
+    def test_no_creators_when_no_study(self, minimal_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(minimal_h5)
+        assert "creators" not in result
+
+    def test_accepts_string_path(self, full_h5: Path):
+        from fd5.datalad import extract_metadata
+
+        result = extract_metadata(str(full_h5))
+        assert result["product"] == "recon"
+
+
+class TestExtractMetadataEdgeCases:
+    def test_no_study_creators_key(self, tmp_path: Path):
+        """Study group exists but has no creators sub-group."""
+        from fd5.datalad import extract_metadata
+
+        path = tmp_path / "no-creators.h5"
+        _create_h5(
+            path,
+            root_attrs={"_schema_version": 1, "product": "recon"},
+            groups={"study": {"name": "Test"}},
+        )
+        result = extract_metadata(path)
+        assert "creators" not in result
+
+    def test_non_dict_creator_entry_skipped(self, tmp_path: Path):
+        """Non-dict entry in creators group is skipped."""
+        from fd5.datalad import extract_metadata
+
+        path = tmp_path / "bad-creator.h5"
+        with h5py.File(path, "w") as f:
+            dict_to_h5(f, {"_schema_version": 1, "product": "recon"})
+            study = f.create_group("study")
+            study.attrs["name"] = "Test"
+            creators = study.create_group("creators")
+            creators.attrs["bad_entry"] = "not-a-dict"
+            good = creators.create_group("good_entry")
+            good.attrs["name"] = "Good Person"
+
+        result = extract_metadata(path)
+        assert len(result["creators"]) == 1
+        assert result["creators"][0]["name"] == "Good Person"
+
+    def test_missing_optional_attrs(self, tmp_path: Path):
+        """File with only _schema_version — no product, id, etc."""
+        from fd5.datalad import extract_metadata
+
+        path = tmp_path / "bare.h5"
+        _create_h5(path, root_attrs={"_schema_version": 1})
+        result = extract_metadata(path)
+        assert "product" not in result
+        assert "id" not in result
+        assert "timestamp" not in result
+        assert "content_hash" not in result
+        assert result["title"] == "bare"
+
+
+# ---------------------------------------------------------------------------
+# _has_datalad()
+# ---------------------------------------------------------------------------
+
+
+class TestHasDatalad:
+    def test_returns_false_when_not_installed(self):
+        from fd5.datalad import _has_datalad
+
+        with patch.dict("sys.modules", {"datalad": None}):
+            assert _has_datalad() is False
+
+    def test_returns_true_when_installed(self):
+        from fd5.datalad import _has_datalad
+
+        mock_datalad = MagicMock()
+        with patch.dict("sys.modules", {"datalad": mock_datalad}):
+            assert _has_datalad() is True
+
+
+# ---------------------------------------------------------------------------
+# register_with_datalad()
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterWithDatalad:
+    def test_raises_import_error_when_no_datalad(self, full_h5: Path):
+        from fd5.datalad import register_with_datalad
+
+        with patch("fd5.datalad._has_datalad", return_value=False):
+            with pytest.raises(ImportError, match="datalad is not installed"):
+                register_with_datalad(full_h5)
+
+    def test_success_with_mocked_datalad(self, full_h5: Path):
+        from fd5.datalad import register_with_datalad
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = register_with_datalad(full_h5)
+
+        assert result["status"] == "ok"
+        assert result["path"] == str(full_h5)
+        assert "metadata" in result
+        assert result["metadata"]["product"] == "recon"
+
+    def test_uses_parent_dir_when_no_dataset_path(self, full_h5: Path):
+        from fd5.datalad import register_with_datalad
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = register_with_datalad(full_h5)
+
+        assert result["dataset"] == str(full_h5.parent)
+        mock_dl_api.Dataset.assert_called_once_with(str(full_h5.parent))
+
+    def test_uses_explicit_dataset_path(self, full_h5: Path, tmp_path: Path):
+        from fd5.datalad import register_with_datalad
+
+        ds_path = tmp_path / "my-dataset"
+        ds_path.mkdir()
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = register_with_datalad(full_h5, ds_path)
+
+        assert result["dataset"] == str(ds_path)
+        mock_dl_api.Dataset.assert_called_once_with(str(ds_path))
+
+    def test_calls_save_with_message(self, full_h5: Path):
+        from fd5.datalad import register_with_datalad
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            register_with_datalad(full_h5)
+
+        mock_ds.save.assert_called_once()
+        call_args = mock_ds.save.call_args
+        assert full_h5.name in call_args.kwargs.get(
+            "message", call_args.args[1] if len(call_args.args) > 1 else ""
+        )
+
+    def test_accepts_string_paths(self, full_h5: Path):
+        from fd5.datalad import register_with_datalad
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = register_with_datalad(str(full_h5), str(full_h5.parent))
+
+        assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# CLI: fd5 datalad-register
+# ---------------------------------------------------------------------------
+
+
+class TestDataladRegisterCLI:
+    def test_success_with_mocked_datalad(self, full_h5: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        runner = CliRunner()
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = runner.invoke(cli, ["datalad-register", str(full_h5)])
+
+        assert result.exit_code == 0, result.output
+        assert "Registered" in result.output
+
+    def test_shows_metadata_fields(self, full_h5: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        runner = CliRunner()
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = runner.invoke(cli, ["datalad-register", str(full_h5)])
+
+        assert "recon" in result.output
+        assert "sha256:" in result.output
+
+    def test_with_dataset_option(self, full_h5: Path, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        ds_path = tmp_path / "ds"
+        ds_path.mkdir()
+
+        mock_ds = MagicMock()
+        mock_dl_api = MagicMock()
+        mock_dl_api.Dataset.return_value = mock_ds
+
+        runner = CliRunner()
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch.dict(
+                "sys.modules",
+                {"datalad": MagicMock(), "datalad.api": mock_dl_api},
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["datalad-register", str(full_h5), "--dataset", str(ds_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_error_when_datalad_not_installed(self, full_h5: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        with patch("fd5.datalad._has_datalad", return_value=False):
+            result = runner.invoke(cli, ["datalad-register", str(full_h5)])
+
+        assert result.exit_code == 1
+        assert "datalad is not installed" in result.output
+
+    def test_nonexistent_file_exits_nonzero(self, tmp_path: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["datalad-register", str(tmp_path / "ghost.h5")])
+        assert result.exit_code != 0
+
+    def test_generic_error_exits_nonzero(self, full_h5: Path):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        with (
+            patch("fd5.datalad._has_datalad", return_value=True),
+            patch(
+                "fd5.datalad.register_with_datalad",
+                side_effect=RuntimeError("something broke"),
+            ),
+        ):
+            result = runner.invoke(cli, ["datalad-register", str(full_h5)])
+
+        assert result.exit_code == 1
+        assert "something broke" in result.output
+
+    def test_appears_in_help(self):
+        from click.testing import CliRunner
+
+        from fd5.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert "datalad-register" in result.output


### PR DESCRIPTION
## Summary

- Add `src/fd5/datalad.py` with `extract_metadata(path)` (returns DataLad-compatible metadata dict with title, creators, id, product, timestamp, content_hash) and `register_with_datalad(path, dataset_path)` (registers fd5 file with DataLad dataset)
- Graceful degradation when datalad is not installed — `ImportError` is handled cleanly both in the library and CLI
- Add `fd5 datalad-register <file> [--dataset <path>]` CLI command in `src/fd5/cli.py`
- Add `tests/test_datalad.py` with 31 test cases using mocked datalad, covering all code paths (extract_metadata, register_with_datalad, _has_datalad, CLI command, edge cases)

Closes #92

## Test plan

- [x] All 31 new tests pass (`pytest tests/test_datalad.py`)
- [x] All 34 existing CLI tests still pass (`pytest tests/test_cli.py`)
- [x] Pre-commit hooks pass (ruff, bandit, typos, etc.)
- [ ] CI lint failure is known and pre-existing — not introduced by this PR

Made with [Cursor](https://cursor.com)