### PR TITLE
feat(migrate): implement fd5.migrate module for schema version upgrades

### DIFF
--- a/src/fd5/__init__.py
+++ b/src/fd5/__init__.py
@@ -4,7 +4,8 @@ __version__ = "0.1.0"
 
 from fd5.create import create
 from fd5.hash import verify
+from fd5.migrate import migrate
 from fd5.naming import generate_filename
 from fd5.schema import validate
 
-__all__ = ["create", "generate_filename", "validate", "verify"]
+__all__ = ["create", "generate_filename", "migrate", "validate", "verify"]

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -125,7 +125,6 @@ def datacite(directory: str, output: str | None) -> None:
     click.echo(f"Wrote {out_path}")
 
 
-
 @cli.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option(
@@ -142,6 +141,29 @@ def rocrate(directory: str, output: str | None) -> None:
     write_rocrate(dir_path, out_path)
     written = out_path or dir_path / "ro-crate-metadata.json"
     click.echo(f"Wrote {written}")
+
+
+@cli.command()
+@click.argument("source", type=click.Path(exists=True, dir_okay=False))
+@click.argument("output", type=click.Path())
+@click.option(
+    "--target",
+    "-t",
+    type=int,
+    required=True,
+    help="Target schema version.",
+)
+def migrate(source: str, output: str, target: int) -> None:
+    """Migrate an fd5 file to a newer schema version (copy-on-write)."""
+    from fd5.migrate import MigrationError
+    from fd5.migrate import migrate as do_migrate
+
+    try:
+        dest = do_migrate(Path(source), Path(output), target_version=target)
+        click.echo(f"Migrated to version {target}: {dest}")
+    except (MigrationError, FileNotFoundError) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fd5/migrate.py
+++ b/src/fd5/migrate.py
@@ -1,0 +1,189 @@
+"""fd5.migrate — schema version migration for fd5 files.
+
+Copy-on-write migration: reads a source fd5 file, applies registered
+migration callables to produce a new file at the target schema version,
+records provenance linking the new file to the original, and recomputes
+the content_hash.
+
+See white-paper.md § Versioning / Migration and upgrades.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from fd5.hash import compute_content_hash
+from fd5.provenance import write_sources
+
+
+class MigrationError(Exception):
+    """Raised when a migration cannot be performed."""
+
+
+MigrationCallable = Callable[[h5py.File, h5py.File], None]
+
+_registry: dict[tuple[str, int, int], MigrationCallable] = {}
+
+
+def register_migration(
+    product: str,
+    from_version: int,
+    to_version: int,
+    fn: MigrationCallable,
+) -> None:
+    """Register a migration callable for *product* from *from_version* to *to_version*.
+
+    Raises ``ValueError`` if a migration for the same key is already registered.
+    """
+    key = (product, from_version, to_version)
+    if key in _registry:
+        raise ValueError(
+            f"Migration already registered for {product!r} "
+            f"v{from_version} -> v{to_version}"
+        )
+    _registry[key] = fn
+
+
+def clear_migrations() -> None:
+    """Remove all registered migrations (for testing)."""
+    _registry.clear()
+
+
+def _resolve_chain(
+    product: str, from_version: int, to_version: int
+) -> list[tuple[int, int, MigrationCallable]]:
+    """Build an ordered list of (from, to, callable) steps to reach *to_version*.
+
+    Uses a simple greedy walk: at each step pick the registered migration
+    whose ``from_version`` matches the current version.
+    """
+    chain: list[tuple[int, int, MigrationCallable]] = []
+    current = from_version
+    while current < to_version:
+        key = (product, current, current + 1)
+        if key not in _registry:
+            raise MigrationError(
+                f"No migration registered for {product!r} v{current} -> v{current + 1}"
+            )
+        chain.append((current, current + 1, _registry[key]))
+        current += 1
+    return chain
+
+
+def _copy_root_attrs(src: h5py.File, dst: h5py.File) -> None:
+    """Copy all root-level attributes from *src* to *dst*."""
+    for key in src.attrs:
+        dst.attrs[key] = src.attrs[key]
+
+
+def migrate(
+    source_path: str | Path,
+    dest_path: str | Path,
+    *,
+    target_version: int,
+) -> Path:
+    """Migrate an fd5 file to *target_version*, producing a new file at *dest_path*.
+
+    1. Read ``_schema_version`` and ``product`` from the source file.
+    2. Resolve the chain of registered migration callables.
+    3. Apply each step in sequence (intermediate files use tempdir).
+    4. Write provenance ``sources/migrated_from`` linking to the original.
+    5. Recompute ``content_hash``.
+
+    Returns the resolved *dest_path*.
+    """
+    source_path = Path(source_path)
+    dest_path = Path(dest_path)
+
+    if not source_path.exists():
+        raise FileNotFoundError(source_path)
+
+    with h5py.File(source_path, "r") as src:
+        current_version = int(src.attrs["_schema_version"])
+        product = src.attrs["product"]
+        if isinstance(product, bytes):
+            product = product.decode()
+        original_content_hash = src.attrs.get("content_hash", "")
+        if isinstance(original_content_hash, bytes):
+            original_content_hash = original_content_hash.decode()
+        original_id = src.attrs.get("id", "")
+        if isinstance(original_id, bytes):
+            original_id = original_id.decode()
+
+    if current_version >= target_version:
+        raise MigrationError(
+            f"File is already at version {current_version}, "
+            f"cannot migrate to {target_version}"
+        )
+
+    chain = _resolve_chain(product, current_version, target_version)
+
+    prev_path = source_path
+    tmp_files: list[Path] = []
+
+    try:
+        for step_idx, (v_from, v_to, fn) in enumerate(chain):
+            is_last = step_idx == len(chain) - 1
+            if is_last:
+                next_path = dest_path
+            else:
+                tmp = tempfile.NamedTemporaryFile(
+                    suffix=".h5", delete=False, dir=dest_path.parent
+                )
+                tmp.close()
+                next_path = Path(tmp.name)
+                tmp_files.append(next_path)
+
+            with h5py.File(prev_path, "r") as src, h5py.File(next_path, "w") as dst:
+                _copy_root_attrs(src, dst)
+                fn(src, dst)
+                dst.attrs["_schema_version"] = np.int64(v_to)
+
+            prev_path = next_path
+
+        with h5py.File(dest_path, "a") as dst:
+            _write_migration_provenance(
+                dst,
+                source_path=source_path,
+                product=product,
+                original_id=original_id,
+                original_content_hash=original_content_hash,
+            )
+            dst.attrs["content_hash"] = compute_content_hash(dst)
+
+    finally:
+        for tmp in tmp_files:
+            if tmp.exists():
+                tmp.unlink()
+
+    return dest_path
+
+
+def _write_migration_provenance(
+    dst: h5py.File,
+    *,
+    source_path: Path,
+    product: str,
+    original_id: str,
+    original_content_hash: str,
+) -> None:
+    """Record the migration source in ``sources/migrated_from``."""
+    write_sources(
+        dst,
+        [
+            {
+                "name": "migrated_from",
+                "id": original_id,
+                "product": product,
+                "file": str(source_path),
+                "content_hash": original_content_hash,
+                "role": "migration_source",
+                "description": "Source file before schema migration",
+            }
+        ],
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -343,6 +343,89 @@ class TestFormatAttr:
 
 
 # ---------------------------------------------------------------------------
+# fd5 migrate
+# ---------------------------------------------------------------------------
+
+
+def _make_v1_h5(path: Path) -> Path:
+    """Create a minimal sealed v1 fd5 file for CLI migration tests."""
+    schema_dict = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "_schema_version": {"type": "integer"},
+            "product": {"type": "string"},
+        },
+        "required": ["_schema_version", "product"],
+    }
+    with h5py.File(path, "w") as f:
+        f.attrs["product"] = "test/climock"
+        f.attrs["name"] = "sample"
+        f.attrs["description"] = "A v1 file"
+        f.attrs["timestamp"] = "2026-01-15T10:00:00Z"
+        f.attrs["id"] = "sha256:abc123"
+        f.attrs["id_inputs"] = "product + name + timestamp"
+        f.attrs["_schema_version"] = np.int64(1)
+        embed_schema(f, schema_dict)
+        f.create_dataset("volume", data=np.zeros((4, 4), dtype=np.float32))
+        f.attrs["content_hash"] = compute_content_hash(f)
+    return path
+
+
+def _cli_v1_to_v2(src: h5py.File, dst: h5py.File) -> None:
+    if "volume" in src:
+        dst.create_dataset("volume", data=src["volume"][...])
+    dst.attrs["cli_added"] = "yes"
+
+
+class TestMigrateCommand:
+    @pytest.fixture(autouse=True)
+    def _register(self):
+        from fd5.migrate import clear_migrations, register_migration
+
+        register_migration("test/climock", 1, 2, _cli_v1_to_v2)
+        yield
+        clear_migrations()
+
+    def test_exits_zero(self, runner: CliRunner, tmp_path: Path):
+        src = _make_v1_h5(tmp_path / "src.h5")
+        out = tmp_path / "out.h5"
+        result = runner.invoke(cli, ["migrate", str(src), str(out), "--target", "2"])
+        assert result.exit_code == 0, result.output
+
+    def test_creates_output_file(self, runner: CliRunner, tmp_path: Path):
+        src = _make_v1_h5(tmp_path / "src.h5")
+        out = tmp_path / "out.h5"
+        runner.invoke(cli, ["migrate", str(src), str(out), "--target", "2"])
+        assert out.exists()
+
+    def test_prints_confirmation(self, runner: CliRunner, tmp_path: Path):
+        src = _make_v1_h5(tmp_path / "src.h5")
+        out = tmp_path / "out.h5"
+        result = runner.invoke(cli, ["migrate", str(src), str(out), "--target", "2"])
+        assert "migrated" in result.output.lower() or "out.h5" in result.output
+
+    def test_nonexistent_source_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(
+            cli,
+            [
+                "migrate",
+                str(tmp_path / "ghost.h5"),
+                str(tmp_path / "o.h5"),
+                "--target",
+                "2",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_same_version_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        src = _make_v1_h5(tmp_path / "src.h5")
+        out = tmp_path / "out.h5"
+        result = runner.invoke(cli, ["migrate", str(src), str(out), "--target", "1"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
 # fd5 --help
 # ---------------------------------------------------------------------------
 
@@ -354,5 +437,5 @@ class TestHelp:
 
     def test_help_lists_commands(self, runner: CliRunner):
         result = runner.invoke(cli, ["--help"])
-        for cmd in ("validate", "info", "schema-dump", "manifest"):
+        for cmd in ("validate", "info", "schema-dump", "manifest", "migrate"):
             assert cmd in result.output

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,269 @@
+"""Tests for fd5.migrate — migration registry and schema upgrade function."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.hash import compute_content_hash
+from fd5.schema import embed_schema
+
+
+# ---------------------------------------------------------------------------
+# Helpers — create a v1 fd5 file for migration tests
+# ---------------------------------------------------------------------------
+
+_V1_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "_schema_version": {"type": "integer"},
+        "product": {"type": "string"},
+    },
+    "required": ["_schema_version", "product"],
+}
+
+
+def _create_v1_file(path: Path) -> Path:
+    """Create a minimal v1 fd5 file with a dataset and sealed content_hash."""
+    with h5py.File(path, "w") as f:
+        f.attrs["product"] = "test/mock"
+        f.attrs["name"] = "sample"
+        f.attrs["description"] = "A v1 file"
+        f.attrs["timestamp"] = "2026-01-15T10:00:00Z"
+        f.attrs["id"] = "sha256:abc123"
+        f.attrs["id_inputs"] = "product + name + timestamp"
+        f.attrs["_schema_version"] = np.int64(1)
+        embed_schema(f, _V1_SCHEMA)
+        f.create_dataset("volume", data=np.zeros((4, 4), dtype=np.float32))
+        f.attrs["content_hash"] = compute_content_hash(f)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def v1_file(tmp_path: Path) -> Path:
+    return _create_v1_file(tmp_path / "source_v1.h5")
+
+
+@pytest.fixture()
+def out_path(tmp_path: Path) -> Path:
+    return tmp_path / "migrated_v2.h5"
+
+
+# ---------------------------------------------------------------------------
+# Import — ensures the module exists
+# ---------------------------------------------------------------------------
+
+from fd5.migrate import (  # noqa: E402
+    MigrationError,
+    clear_migrations,
+    migrate,
+    register_migration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock migration function: v1 → v2 for product "test/mock"
+# ---------------------------------------------------------------------------
+
+
+def _v1_to_v2(src: h5py.File, dst: h5py.File) -> None:
+    """Mock migration: copies volume dataset, adds a new_attr."""
+    if "volume" in src:
+        data = src["volume"][...]
+        dst.create_dataset("volume", data=data)
+    dst.attrs["new_attr"] = "added_by_migration"
+
+
+@pytest.fixture(autouse=True)
+def _register_mock_migration():
+    """Register and clean up the mock v1->v2 migration for every test."""
+    register_migration("test/mock", 1, 2, _v1_to_v2)
+    yield
+    clear_migrations()
+
+
+# ---------------------------------------------------------------------------
+# Migration registry
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationRegistry:
+    def test_register_migration_callable(self):
+        clear_migrations()
+        register_migration("test/mock", 1, 2, _v1_to_v2)
+
+    def test_register_duplicate_raises(self):
+        with pytest.raises(ValueError, match="already registered"):
+            register_migration("test/mock", 1, 2, _v1_to_v2)
+
+    def test_clear_migrations_allows_re_register(self):
+        clear_migrations()
+        register_migration("test/mock", 1, 2, _v1_to_v2)
+
+
+# ---------------------------------------------------------------------------
+# migrate() — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateHappyPath:
+    def test_creates_output_file(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        assert out_path.exists()
+
+    def test_output_has_upgraded_schema_version(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            assert int(f.attrs["_schema_version"]) == 2
+
+    def test_output_preserves_product(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            product = f.attrs["product"]
+            if isinstance(product, bytes):
+                product = product.decode()
+            assert product == "test/mock"
+
+    def test_output_preserves_existing_attrs(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            name = f.attrs["name"]
+            if isinstance(name, bytes):
+                name = name.decode()
+            assert name == "sample"
+
+    def test_migration_callable_applied(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            val = f.attrs["new_attr"]
+            if isinstance(val, bytes):
+                val = val.decode()
+            assert val == "added_by_migration"
+
+    def test_dataset_copied(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            assert "volume" in f
+            assert f["volume"].shape == (4, 4)
+
+    def test_content_hash_recomputed(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            stored = f.attrs["content_hash"]
+            if isinstance(stored, bytes):
+                stored = stored.decode()
+            assert stored.startswith("sha256:")
+            recomputed = compute_content_hash(f)
+            assert stored == recomputed
+
+    def test_content_hash_differs_from_source(self, v1_file: Path, out_path: Path):
+        with h5py.File(v1_file, "r") as f:
+            old_hash = f.attrs["content_hash"]
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            new_hash = f.attrs["content_hash"]
+        assert old_hash != new_hash
+
+
+# ---------------------------------------------------------------------------
+# Provenance chain — migrated file links to original
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceChain:
+    def test_sources_group_exists(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            assert "sources" in f
+
+    def test_source_references_original_file(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            src_grp = f["sources/migrated_from"]
+            file_attr = src_grp.attrs["file"]
+            if isinstance(file_attr, bytes):
+                file_attr = file_attr.decode()
+            assert file_attr == str(v1_file)
+
+    def test_source_has_original_content_hash(self, v1_file: Path, out_path: Path):
+        with h5py.File(v1_file, "r") as f:
+            original_hash = f.attrs["content_hash"]
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            src_grp = f["sources/migrated_from"]
+            stored_hash = src_grp.attrs["content_hash"]
+            if isinstance(stored_hash, bytes):
+                stored_hash = stored_hash.decode()
+            if isinstance(original_hash, bytes):
+                original_hash = original_hash.decode()
+            assert stored_hash == original_hash
+
+    def test_source_role_is_migration_source(self, v1_file: Path, out_path: Path):
+        migrate(v1_file, out_path, target_version=2)
+        with h5py.File(out_path, "r") as f:
+            role = f["sources/migrated_from"].attrs["role"]
+            if isinstance(role, bytes):
+                role = role.decode()
+            assert role == "migration_source"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateErrors:
+    def test_source_file_not_found(self, tmp_path: Path, out_path: Path):
+        with pytest.raises(FileNotFoundError):
+            migrate(tmp_path / "nonexistent.h5", out_path, target_version=2)
+
+    def test_no_migration_registered(self, v1_file: Path, out_path: Path):
+        clear_migrations()
+        with pytest.raises(MigrationError, match="No migration"):
+            migrate(v1_file, out_path, target_version=2)
+
+    def test_already_at_target_version(self, v1_file: Path, out_path: Path):
+        with pytest.raises(MigrationError, match="already at"):
+            migrate(v1_file, out_path, target_version=1)
+
+    def test_target_below_current_version(self, v1_file: Path, out_path: Path):
+        with pytest.raises(MigrationError, match="already at"):
+            migrate(v1_file, out_path, target_version=0)
+
+
+# ---------------------------------------------------------------------------
+# Multi-step migration (v1 -> v2 -> v3)
+# ---------------------------------------------------------------------------
+
+
+def _v2_to_v3(src: h5py.File, dst: h5py.File) -> None:
+    """Mock migration: copies volume, copies new_attr, adds another_attr."""
+    if "volume" in src:
+        dst.create_dataset("volume", data=src["volume"][...])
+    new_attr = src.attrs.get("new_attr", "")
+    if new_attr:
+        dst.attrs["new_attr"] = new_attr
+    dst.attrs["another_attr"] = "v3_addition"
+
+
+class TestMultiStepMigration:
+    def test_chain_v1_to_v3(self, v1_file: Path, tmp_path: Path):
+        register_migration("test/mock", 2, 3, _v2_to_v3)
+        out = tmp_path / "migrated_v3.h5"
+        migrate(v1_file, out, target_version=3)
+        with h5py.File(out, "r") as f:
+            assert int(f.attrs["_schema_version"]) == 3
+            val = f.attrs["another_attr"]
+            if isinstance(val, bytes):
+                val = val.decode()
+            assert val == "v3_addition"


### PR DESCRIPTION
## Summary

- Add `fd5.migrate` module with a migration registry (`register_migration`, `clear_migrations`) and a copy-on-write `migrate()` function that reads `_schema_version` and `product` from the source file, resolves a chain of registered migration callables, produces a new fd5 file at the target schema version, writes provenance (`sources/migrated_from`) linking back to the original, and recomputes `content_hash`.
- Add `fd5 migrate` CLI command (`fd5 migrate <source> <output> --target <version>`) in `src/fd5/cli.py`.
- Export `migrate` from `fd5.__init__` for public API access (`fd5.migrate(...)`).
- Add comprehensive tests in `tests/test_migrate.py` (20 tests) and `tests/test_cli.py` (5 CLI tests) covering registry, happy path, provenance chain, error paths, and multi-step migration chains.

## Test plan

- [x] `test_migrate.py::TestMigrationRegistry` — register, duplicate detection, clear
- [x] `test_migrate.py::TestMigrateHappyPath` — output file creation, schema version upgrade, attr preservation, migration callable application, dataset copy, content_hash recomputation
- [x] `test_migrate.py::TestProvenanceChain` — sources group, file reference, content_hash, role
- [x] `test_migrate.py::TestMigrateErrors` — missing source, no migration registered, already at target, downgrade
- [x] `test_migrate.py::TestMultiStepMigration` — chained v1→v2→v3
- [x] `test_cli.py::TestMigrateCommand` — exit codes, output file creation, confirmation message, error cases
- [x] All 845 tests pass locally

Refs: #87

Made with [Cursor](https://cursor.com)