### PR TITLE
feat(imaging): add optional schema features per white-paper §recon/§listmode (#88)

### DIFF
--- a/src/fd5/imaging/listmode.py
+++ b/src/fd5/imaging/listmode.py
@@ -3,6 +3,9 @@
 Implements the ``listmode`` product schema per white-paper.md § listmode.
 Handles compound datasets for singles/coincidences/time_markers, mode attr,
 table_pos, duration, z_min, z_max, and metadata/daq/ group.
+
+Optional features (per white-paper.md § listmode):
+- ``device_data/``: embedded device streams (ECG, bellows) following NXlog pattern
 """
 
 from __future__ import annotations
@@ -74,6 +77,10 @@ class ListmodeSchema:
                     "type": "object",
                     "description": "Processed event datasets (compound)",
                 },
+                "device_data": {
+                    "type": "object",
+                    "description": "Embedded device streams (ECG, bellows) following NXlog pattern",
+                },
             },
             "required": ["_schema_version", "product", "name", "description"],
         }
@@ -104,6 +111,7 @@ class ListmodeSchema:
 
         Optional:
         - ``daq``: dict of DAQ parameters written to ``metadata/daq/``
+        - ``device_data``: dict of channel dicts for embedded device signals
         """
         target.attrs["default"] = "raw_data"
 
@@ -117,6 +125,9 @@ class ListmodeSchema:
 
         if "daq" in data:
             self._write_daq(target, data["daq"])
+
+        if "device_data" in data:
+            self._write_device_data(target, data["device_data"])
 
     # ------------------------------------------------------------------
     # Root attributes
@@ -174,3 +185,53 @@ class ListmodeSchema:
                 daq_grp.attrs[key] = value
             else:
                 daq_grp.attrs[key] = value
+
+    # ------------------------------------------------------------------
+    # Embedded device_data (optional, NXlog pattern)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_device_data(
+        target: h5py.File | h5py.Group,
+        channels: dict[str, dict[str, Any]],
+    ) -> None:
+        dd_grp = target.create_group("device_data")
+        dd_grp.attrs["description"] = "Device signals recorded during this acquisition"
+
+        for name, ch in channels.items():
+            ch_grp = dd_grp.create_group(name)
+            ch_grp.attrs["_type"] = ch.get("_type", name)
+            ch_grp.attrs["_version"] = np.int64(ch.get("_version", 1))
+            ch_grp.attrs["description"] = ch["description"]
+
+            if "model" in ch:
+                ch_grp.attrs["model"] = ch["model"]
+            if "measurement" in ch:
+                ch_grp.attrs["measurement"] = ch["measurement"]
+            if "run_control" in ch:
+                ch_grp.attrs["run_control"] = np.bool_(ch["run_control"])
+
+            sr_grp = ch_grp.create_group("sampling_rate")
+            sr_grp.attrs["value"] = np.float64(ch["sampling_rate"])
+            sr_grp.attrs["units"] = "Hz"
+            sr_grp.attrs["unitSI"] = np.float64(1.0)
+
+            sig_ds = ch_grp.create_dataset(
+                "signal",
+                data=np.asarray(ch["signal"], dtype=np.float64),
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            sig_ds.attrs["units"] = ch["units"]
+            sig_ds.attrs["unitSI"] = np.float64(ch["unitSI"])
+
+            time_ds = ch_grp.create_dataset(
+                "time",
+                data=np.asarray(ch["time"], dtype=np.float64),
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            time_ds.attrs["units"] = "s"
+            time_ds.attrs["unitSI"] = np.float64(1.0)
+            if "time_start" in ch:
+                time_ds.attrs["start"] = ch["time_start"]

--- a/src/fd5/imaging/recon.py
+++ b/src/fd5/imaging/recon.py
@@ -3,10 +3,18 @@
 Implements the ``recon`` product schema per white-paper.md § recon.
 Handles 3D/4D/5D float32 volumes with multiscale pyramids, MIP projections,
 dynamic frames, affine transforms, and chunked gzip compression.
+
+Optional features (per white-paper.md § recon):
+- ``mips_per_frame/``: per-frame coronal/sagittal MIPs for 4D+ data
+- ``gate_phase`` and ``gate_trigger/`` sub-groups in ``frames/`` for gated recon
+- ``device_data/``: embedded device streams (ECG, bellows) following NXlog pattern
+- ``provenance/dicom_header``: JSON string from pydicom
+- ``provenance/per_slice_metadata``: compound dataset with per-slice DICOM fields
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import h5py
@@ -39,6 +47,22 @@ class ReconSchema:
                     "type": "object",
                     "description": "Root-level volume dataset (represented as attrs in h5_to_dict)",
                 },
+                "mips_per_frame": {
+                    "type": "object",
+                    "description": "Per-frame MIP projections for dynamic (4D+) data",
+                },
+                "frames": {
+                    "type": "object",
+                    "description": "Frame timing, gating phase, and trigger data for 4D+ volumes",
+                },
+                "device_data": {
+                    "type": "object",
+                    "description": "Embedded device streams (ECG, bellows) following NXlog pattern",
+                },
+                "provenance": {
+                    "type": "object",
+                    "description": "Original file provenance, DICOM header, per-slice metadata",
+                },
             },
             "required": ["_schema_version", "product", "name", "description"],
         }
@@ -65,6 +89,9 @@ class ReconSchema:
         Optional keys:
         - ``frames``: dict with frame timing for 4D+ data
         - ``pyramid``: dict with ``scale_factors`` and ``method``
+        - ``mips_per_frame``: bool — write per-frame MIPs (requires 4D+ volume)
+        - ``device_data``: dict of channel dicts for embedded device signals
+        - ``provenance``: dict with ``dicom_header`` and/or ``per_slice_metadata``
         """
         target.attrs["default"] = "volume"
 
@@ -80,6 +107,15 @@ class ReconSchema:
             self._write_pyramid(target, spatial_vol, data)
 
         self._write_mips(target, spatial_vol)
+
+        if data.get("mips_per_frame") and volume.ndim >= 4:
+            self._write_mips_per_frame(target, volume)
+
+        if "device_data" in data:
+            self._write_device_data(target, data["device_data"])
+
+        if "provenance" in data:
+            self._write_provenance(target, data["provenance"])
 
     # ------------------------------------------------------------------
     # Volume
@@ -145,6 +181,43 @@ class ReconSchema:
             grp.create_dataset("frame_label", data=labels, dtype=dt)
             grp["frame_label"].attrs["description"] = "Human-readable label per frame"
 
+        if "gate_phase" in frames:
+            ds = grp.create_dataset(
+                "gate_phase",
+                data=np.asarray(frames["gate_phase"], dtype=np.float64),
+            )
+            ds.attrs["units"] = "%"
+            ds.attrs["description"] = "Phase within physiological cycle per gate bin"
+
+        if "gate_trigger" in frames:
+            self._write_gate_trigger(grp, frames["gate_trigger"])
+
+    @staticmethod
+    def _write_gate_trigger(
+        frames_grp: h5py.Group,
+        trigger: dict[str, Any],
+    ) -> None:
+        gt_grp = frames_grp.create_group("gate_trigger")
+
+        ds = gt_grp.create_dataset(
+            "signal",
+            data=np.asarray(trigger["signal"], dtype=np.float64),
+        )
+        ds.attrs["description"] = "Raw physiological gating signal"
+
+        sr_grp = gt_grp.create_group("sampling_rate")
+        sr_grp.attrs["value"] = np.float64(trigger["sampling_rate"])
+        sr_grp.attrs["units"] = "Hz"
+        sr_grp.attrs["unitSI"] = np.float64(1.0)
+
+        ds_tt = gt_grp.create_dataset(
+            "trigger_times",
+            data=np.asarray(trigger["trigger_times"], dtype=np.float64),
+        )
+        ds_tt.attrs["units"] = "s"
+        ds_tt.attrs["unitSI"] = np.float64(1.0)
+        ds_tt.attrs["description"] = "Detected trigger timestamps"
+
     # ------------------------------------------------------------------
     # Pyramid
     # ------------------------------------------------------------------
@@ -195,19 +268,129 @@ class ReconSchema:
         target: h5py.File | h5py.Group,
         spatial_vol: np.ndarray,
     ) -> None:
-        # Coronal: project along Y (axis=1) → shape (Z, X)
         mip_cor = spatial_vol.max(axis=1).astype(np.float32)
         ds_cor = target.create_dataset("mip_coronal", data=mip_cor)
         ds_cor.attrs["projection_type"] = "mip"
         ds_cor.attrs["axis"] = np.int64(1)
         ds_cor.attrs["description"] = "Coronal MIP (summed over all frames if dynamic)"
 
-        # Sagittal: project along X (axis=2) → shape (Z, Y)
         mip_sag = spatial_vol.max(axis=2).astype(np.float32)
         ds_sag = target.create_dataset("mip_sagittal", data=mip_sag)
         ds_sag.attrs["projection_type"] = "mip"
         ds_sag.attrs["axis"] = np.int64(2)
         ds_sag.attrs["description"] = "Sagittal MIP (summed over all frames if dynamic)"
+
+    # ------------------------------------------------------------------
+    # Per-frame MIPs (optional, 4D+ only)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_mips_per_frame(
+        target: h5py.File | h5py.Group,
+        volume: np.ndarray,
+    ) -> None:
+        n_frames = volume.shape[0]
+        z, y, x = volume.shape[-3], volume.shape[-2], volume.shape[-1]
+
+        cor_stack = np.empty((n_frames, z, x), dtype=np.float32)
+        sag_stack = np.empty((n_frames, z, y), dtype=np.float32)
+        for i in range(n_frames):
+            frame_3d = volume[i]
+            while frame_3d.ndim > 3:
+                frame_3d = frame_3d.sum(axis=0)
+            cor_stack[i] = frame_3d.max(axis=1).astype(np.float32)
+            sag_stack[i] = frame_3d.max(axis=2).astype(np.float32)
+
+        grp = target.create_group("mips_per_frame")
+
+        ds_cor = grp.create_dataset("coronal", data=cor_stack)
+        ds_cor.attrs["projection_type"] = "mip"
+        ds_cor.attrs["axis"] = np.int64(1)
+        ds_cor.attrs["description"] = "Per-frame coronal MIPs"
+
+        ds_sag = grp.create_dataset("sagittal", data=sag_stack)
+        ds_sag.attrs["projection_type"] = "mip"
+        ds_sag.attrs["axis"] = np.int64(2)
+        ds_sag.attrs["description"] = "Per-frame sagittal MIPs"
+
+    # ------------------------------------------------------------------
+    # Embedded device_data (optional, NXlog pattern)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_device_data(
+        target: h5py.File | h5py.Group,
+        channels: dict[str, dict[str, Any]],
+    ) -> None:
+        dd_grp = target.create_group("device_data")
+        dd_grp.attrs["description"] = "Device signals recorded during this acquisition"
+
+        for name, ch in channels.items():
+            ch_grp = dd_grp.create_group(name)
+            ch_grp.attrs["_type"] = ch.get("_type", name)
+            ch_grp.attrs["_version"] = np.int64(ch.get("_version", 1))
+            ch_grp.attrs["description"] = ch["description"]
+
+            if "model" in ch:
+                ch_grp.attrs["model"] = ch["model"]
+            if "measurement" in ch:
+                ch_grp.attrs["measurement"] = ch["measurement"]
+            if "run_control" in ch:
+                ch_grp.attrs["run_control"] = np.bool_(ch["run_control"])
+
+            sr_grp = ch_grp.create_group("sampling_rate")
+            sr_grp.attrs["value"] = np.float64(ch["sampling_rate"])
+            sr_grp.attrs["units"] = "Hz"
+            sr_grp.attrs["unitSI"] = np.float64(1.0)
+
+            sig_ds = ch_grp.create_dataset(
+                "signal",
+                data=np.asarray(ch["signal"], dtype=np.float64),
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            sig_ds.attrs["units"] = ch["units"]
+            sig_ds.attrs["unitSI"] = np.float64(ch["unitSI"])
+
+            time_ds = ch_grp.create_dataset(
+                "time",
+                data=np.asarray(ch["time"], dtype=np.float64),
+                compression="gzip",
+                compression_opts=_GZIP_LEVEL,
+            )
+            time_ds.attrs["units"] = "s"
+            time_ds.attrs["unitSI"] = np.float64(1.0)
+            if "time_start" in ch:
+                time_ds.attrs["start"] = ch["time_start"]
+
+    # ------------------------------------------------------------------
+    # Provenance (optional)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_provenance(
+        target: h5py.File | h5py.Group,
+        provenance: dict[str, Any],
+    ) -> None:
+        prov_grp = target.require_group("provenance")
+
+        if "dicom_header" in provenance:
+            header_json = provenance["dicom_header"]
+            if not isinstance(header_json, str):
+                header_json = json.dumps(header_json)
+            dt = h5py.special_dtype(vlen=str)
+            ds = prov_grp.create_dataset("dicom_header", data=header_json, dtype=dt)
+            ds.attrs["description"] = (
+                "Full DICOM header from representative source file, round-trippable"
+            )
+
+        if "per_slice_metadata" in provenance:
+            arr = provenance["per_slice_metadata"]
+            ds = prov_grp.create_dataset("per_slice_metadata", data=arr)
+            ds.attrs["description"] = (
+                "Per-slice DICOM metadata (instance_number, slice_location, "
+                "acquisition_time, image_position_patient)"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_listmode.py
+++ b/tests/test_listmode.py
@@ -507,8 +507,119 @@ class TestWriteDaq:
 
 
 # ---------------------------------------------------------------------------
-# Entry point registration (manual via register_schema)
+# write() — device_data (optional embedded device signals)
 # ---------------------------------------------------------------------------
+
+
+def _ecg_channel():
+    n = 500
+    return {
+        "_type": "ecg",
+        "_version": 1,
+        "model": "GE CardioLab",
+        "measurement": "voltage",
+        "run_control": True,
+        "description": "ECG trace for cardiac gating",
+        "sampling_rate": 500.0,
+        "signal": np.sin(np.linspace(0, 4 * np.pi, n)),
+        "time": np.linspace(0.0, 1.0, n),
+        "units": "mV",
+        "unitSI": 0.001,
+    }
+
+
+def _bellows_channel():
+    n = 200
+    return {
+        "_type": "bellows",
+        "description": "Respiratory bellows signal",
+        "sampling_rate": 50.0,
+        "signal": np.sin(np.linspace(0, 2 * np.pi, n)),
+        "time": np.linspace(0.0, 4.0, n),
+        "units": "au",
+        "unitSI": 1.0,
+    }
+
+
+class TestWriteDeviceData:
+    def test_device_data_group_created(self, schema, h5file):
+        data = _minimal_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        assert "device_data" in h5file
+        assert isinstance(h5file["device_data"], h5py.Group)
+        assert h5file["device_data"].attrs["description"] == (
+            "Device signals recorded during this acquisition"
+        )
+
+    def test_ecg_channel_attrs(self, schema, h5file):
+        data = _minimal_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        ch = h5file["device_data/ecg"]
+        assert ch.attrs["_type"] == "ecg"
+        assert int(ch.attrs["_version"]) == 1
+        assert ch.attrs["model"] == "GE CardioLab"
+        assert ch.attrs["measurement"] == "voltage"
+        assert bool(ch.attrs["run_control"]) is True
+
+    def test_ecg_signal_dataset(self, schema, h5file):
+        data = _minimal_data()
+        ecg = _ecg_channel()
+        data["device_data"] = {"ecg": ecg}
+        schema.write(h5file, data)
+        ds = h5file["device_data/ecg/signal"]
+        np.testing.assert_array_almost_equal(ds[:], ecg["signal"])
+        assert ds.attrs["units"] == "mV"
+        assert ds.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_ecg_time_dataset(self, schema, h5file):
+        data = _minimal_data()
+        ecg = _ecg_channel()
+        data["device_data"] = {"ecg": ecg}
+        schema.write(h5file, data)
+        ds = h5file["device_data/ecg/time"]
+        np.testing.assert_array_almost_equal(ds[:], ecg["time"])
+        assert ds.attrs["units"] == "s"
+
+    def test_ecg_sampling_rate(self, schema, h5file):
+        data = _minimal_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        sr = h5file["device_data/ecg/sampling_rate"]
+        assert sr.attrs["value"] == pytest.approx(500.0)
+        assert sr.attrs["units"] == "Hz"
+
+    def test_multiple_channels(self, schema, h5file):
+        data = _minimal_data()
+        data["device_data"] = {
+            "ecg": _ecg_channel(),
+            "bellows": _bellows_channel(),
+        }
+        schema.write(h5file, data)
+        assert "device_data/ecg" in h5file
+        assert "device_data/bellows" in h5file
+
+    def test_no_device_data_when_absent(self, schema, h5file):
+        data = _minimal_data()
+        schema.write(h5file, data)
+        assert "device_data" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# json_schema() — optional properties
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchemaOptionalProperties:
+    def test_has_device_data_property(self, schema):
+        result = schema.json_schema()
+        assert "device_data" in result["properties"]
+
+    def test_device_data_not_required(self, schema):
+        result = schema.json_schema()
+        required = result.get("required", [])
+        assert "device_data" not in required
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -426,6 +426,383 @@ class TestWriteMIP:
 
 
 # ---------------------------------------------------------------------------
+# write() — mips_per_frame (optional, 4D+ only)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMipsPerFrame:
+    def test_mips_per_frame_created_for_4d(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        assert "mips_per_frame" in h5file
+        assert isinstance(h5file["mips_per_frame"], h5py.Group)
+
+    def test_mips_per_frame_coronal_shape(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        ds = h5file["mips_per_frame/coronal"]
+        n_frames, z, y, x = data["volume"].shape
+        assert ds.shape == (n_frames, z, x)
+        assert ds.dtype == np.float32
+
+    def test_mips_per_frame_sagittal_shape(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        ds = h5file["mips_per_frame/sagittal"]
+        n_frames, z, y, x = data["volume"].shape
+        assert ds.shape == (n_frames, z, y)
+        assert ds.dtype == np.float32
+
+    def test_mips_per_frame_coronal_attrs(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        ds = h5file["mips_per_frame/coronal"]
+        assert ds.attrs["projection_type"] == "mip"
+        assert ds.attrs["axis"] == 1
+        assert ds.attrs["description"] == "Per-frame coronal MIPs"
+
+    def test_mips_per_frame_sagittal_attrs(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        ds = h5file["mips_per_frame/sagittal"]
+        assert ds.attrs["projection_type"] == "mip"
+        assert ds.attrs["axis"] == 2
+        assert ds.attrs["description"] == "Per-frame sagittal MIPs"
+
+    def test_mips_per_frame_not_created_for_3d(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        assert "mips_per_frame" not in h5file
+
+    def test_mips_per_frame_absent_when_not_requested(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "mips_per_frame" not in h5file
+
+    def test_mips_per_frame_values_match_manual(self, schema, h5file):
+        data = _minimal_4d_data()
+        data["mips_per_frame"] = True
+        schema.write(h5file, data)
+        vol = data["volume"]
+        expected_cor_0 = vol[0].max(axis=1).astype(np.float32)
+        np.testing.assert_array_almost_equal(
+            h5file["mips_per_frame/coronal"][0], expected_cor_0
+        )
+
+
+# ---------------------------------------------------------------------------
+# write() — gate_phase and gate_trigger (optional gated recon)
+# ---------------------------------------------------------------------------
+
+
+def _gated_cardiac_data():
+    vol = _make_volume_4d((8, 8, 16, 16))
+    return {
+        "volume": vol,
+        "affine": _make_affine(),
+        "dimension_order": "TZYX",
+        "reference_frame": "LPS",
+        "description": "Gated cardiac reconstruction",
+        "frames": {
+            "n_frames": 8,
+            "frame_type": "gate_cardiac",
+            "description": "Cardiac gated frames",
+            "frame_start": np.linspace(0.0, 0.7, 8),
+            "frame_duration": np.full(8, 0.1),
+            "gate_phase": np.linspace(0.0, 87.5, 8),
+            "gate_trigger": {
+                "signal": np.sin(np.linspace(0, 4 * np.pi, 500)),
+                "sampling_rate": 500.0,
+                "trigger_times": np.array([0.0, 0.8, 1.6]),
+            },
+        },
+    }
+
+
+class TestWriteGating:
+    def test_gate_phase_dataset_created(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        assert "frames/gate_phase" in h5file
+
+    def test_gate_phase_values(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/gate_phase"]
+        np.testing.assert_array_almost_equal(ds[:], data["frames"]["gate_phase"])
+
+    def test_gate_phase_attrs(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/gate_phase"]
+        assert ds.attrs["units"] == "%"
+        assert "description" in ds.attrs
+
+    def test_gate_trigger_group_created(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        assert "frames/gate_trigger" in h5file
+        assert isinstance(h5file["frames/gate_trigger"], h5py.Group)
+
+    def test_gate_trigger_signal(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/gate_trigger/signal"]
+        np.testing.assert_array_almost_equal(
+            ds[:], data["frames"]["gate_trigger"]["signal"]
+        )
+        assert ds.attrs["description"] == "Raw physiological gating signal"
+
+    def test_gate_trigger_sampling_rate(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        sr = h5file["frames/gate_trigger/sampling_rate"]
+        assert sr.attrs["value"] == pytest.approx(500.0)
+        assert sr.attrs["units"] == "Hz"
+        assert sr.attrs["unitSI"] == pytest.approx(1.0)
+
+    def test_gate_trigger_times(self, schema, h5file):
+        data = _gated_cardiac_data()
+        schema.write(h5file, data)
+        ds = h5file["frames/gate_trigger/trigger_times"]
+        np.testing.assert_array_almost_equal(ds[:], [0.0, 0.8, 1.6])
+        assert ds.attrs["units"] == "s"
+
+    def test_no_gate_phase_for_time_frames(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "frames/gate_phase" not in h5file
+
+    def test_no_gate_trigger_for_time_frames(self, schema, h5file):
+        data = _minimal_4d_data()
+        schema.write(h5file, data)
+        assert "frames/gate_trigger" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# write() — device_data (optional embedded device signals)
+# ---------------------------------------------------------------------------
+
+
+def _ecg_channel():
+    n = 500
+    return {
+        "_type": "ecg",
+        "_version": 1,
+        "model": "GE CardioLab",
+        "measurement": "voltage",
+        "run_control": True,
+        "description": "ECG trace for cardiac gating",
+        "sampling_rate": 500.0,
+        "signal": np.sin(np.linspace(0, 4 * np.pi, n)),
+        "time": np.linspace(0.0, 1.0, n),
+        "units": "mV",
+        "unitSI": 0.001,
+    }
+
+
+def _bellows_channel():
+    n = 200
+    return {
+        "_type": "bellows",
+        "description": "Respiratory bellows signal",
+        "sampling_rate": 50.0,
+        "signal": np.sin(np.linspace(0, 2 * np.pi, n)),
+        "time": np.linspace(0.0, 4.0, n),
+        "units": "au",
+        "unitSI": 1.0,
+    }
+
+
+class TestWriteDeviceData:
+    def test_device_data_group_created(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        assert "device_data" in h5file
+        assert isinstance(h5file["device_data"], h5py.Group)
+        assert h5file["device_data"].attrs["description"] == (
+            "Device signals recorded during this acquisition"
+        )
+
+    def test_ecg_channel_attrs(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        ch = h5file["device_data/ecg"]
+        assert ch.attrs["_type"] == "ecg"
+        assert int(ch.attrs["_version"]) == 1
+        assert ch.attrs["model"] == "GE CardioLab"
+        assert ch.attrs["measurement"] == "voltage"
+        assert bool(ch.attrs["run_control"]) is True
+
+    def test_ecg_signal_dataset(self, schema, h5file):
+        data = _minimal_3d_data()
+        ecg = _ecg_channel()
+        data["device_data"] = {"ecg": ecg}
+        schema.write(h5file, data)
+        ds = h5file["device_data/ecg/signal"]
+        np.testing.assert_array_almost_equal(ds[:], ecg["signal"])
+        assert ds.attrs["units"] == "mV"
+        assert ds.attrs["unitSI"] == pytest.approx(0.001)
+
+    def test_ecg_time_dataset(self, schema, h5file):
+        data = _minimal_3d_data()
+        ecg = _ecg_channel()
+        data["device_data"] = {"ecg": ecg}
+        schema.write(h5file, data)
+        ds = h5file["device_data/ecg/time"]
+        np.testing.assert_array_almost_equal(ds[:], ecg["time"])
+        assert ds.attrs["units"] == "s"
+
+    def test_ecg_sampling_rate(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["device_data"] = {"ecg": _ecg_channel()}
+        schema.write(h5file, data)
+        sr = h5file["device_data/ecg/sampling_rate"]
+        assert sr.attrs["value"] == pytest.approx(500.0)
+        assert sr.attrs["units"] == "Hz"
+
+    def test_multiple_channels(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["device_data"] = {
+            "ecg": _ecg_channel(),
+            "bellows": _bellows_channel(),
+        }
+        schema.write(h5file, data)
+        assert "device_data/ecg" in h5file
+        assert "device_data/bellows" in h5file
+
+    def test_no_device_data_when_absent(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "device_data" not in h5file
+
+
+# ---------------------------------------------------------------------------
+# write() — provenance (optional DICOM header and per-slice metadata)
+# ---------------------------------------------------------------------------
+
+
+def _per_slice_metadata_dtype():
+    return np.dtype(
+        [
+            ("instance_number", np.int32),
+            ("slice_location", np.float64),
+            ("acquisition_time", "S26"),
+            ("image_position_patient", np.float64, (3,)),
+        ]
+    )
+
+
+class TestWriteProvenance:
+    def test_dicom_header_written(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["provenance"] = {
+            "dicom_header": '{"PatientID": "ANON"}',
+        }
+        schema.write(h5file, data)
+        assert "provenance/dicom_header" in h5file
+        stored = h5file["provenance/dicom_header"][()]
+        if isinstance(stored, bytes):
+            stored = stored.decode()
+        assert "PatientID" in stored
+
+    def test_dicom_header_description_attr(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["provenance"] = {"dicom_header": "{}"}
+        schema.write(h5file, data)
+        ds = h5file["provenance/dicom_header"]
+        assert "description" in ds.attrs
+
+    def test_dicom_header_accepts_dict(self, schema, h5file):
+        data = _minimal_3d_data()
+        data["provenance"] = {"dicom_header": {"PatientID": "ANON"}}
+        schema.write(h5file, data)
+        stored = h5file["provenance/dicom_header"][()]
+        if isinstance(stored, bytes):
+            stored = stored.decode()
+        import json
+
+        parsed = json.loads(stored)
+        assert parsed["PatientID"] == "ANON"
+
+    def test_per_slice_metadata_written(self, schema, h5file):
+        data = _minimal_3d_data()
+        dt = _per_slice_metadata_dtype()
+        slices = np.array(
+            [
+                (1, -50.0, b"2024-07-24T10:00:00.000000", [0.0, 0.0, -50.0]),
+                (2, -49.0, b"2024-07-24T10:00:00.100000", [0.0, 0.0, -49.0]),
+            ],
+            dtype=dt,
+        )
+        data["provenance"] = {"per_slice_metadata": slices}
+        schema.write(h5file, data)
+        assert "provenance/per_slice_metadata" in h5file
+        ds = h5file["provenance/per_slice_metadata"]
+        assert ds.shape == (2,)
+        assert ds.attrs["description"].startswith("Per-slice DICOM metadata")
+
+    def test_no_provenance_when_absent(self, schema, h5file):
+        data = _minimal_3d_data()
+        schema.write(h5file, data)
+        assert "provenance" not in h5file
+
+    def test_both_provenance_fields(self, schema, h5file):
+        data = _minimal_3d_data()
+        dt = _per_slice_metadata_dtype()
+        slices = np.array(
+            [
+                (1, -50.0, b"2024-07-24T10:00:00.000000", [0.0, 0.0, -50.0]),
+            ],
+            dtype=dt,
+        )
+        data["provenance"] = {
+            "dicom_header": '{"PatientID": "ANON"}',
+            "per_slice_metadata": slices,
+        }
+        schema.write(h5file, data)
+        assert "provenance/dicom_header" in h5file
+        assert "provenance/per_slice_metadata" in h5file
+
+
+# ---------------------------------------------------------------------------
+# json_schema() — optional properties
+# ---------------------------------------------------------------------------
+
+
+class TestJsonSchemaOptionalProperties:
+    def test_has_mips_per_frame_property(self, schema):
+        result = schema.json_schema()
+        assert "mips_per_frame" in result["properties"]
+
+    def test_has_frames_property(self, schema):
+        result = schema.json_schema()
+        assert "frames" in result["properties"]
+
+    def test_has_device_data_property(self, schema):
+        result = schema.json_schema()
+        assert "device_data" in result["properties"]
+
+    def test_has_provenance_property(self, schema):
+        result = schema.json_schema()
+        assert "provenance" in result["properties"]
+
+    def test_optional_properties_not_required(self, schema):
+        result = schema.json_schema()
+        required = result.get("required", [])
+        for prop in ("mips_per_frame", "frames", "device_data", "provenance"):
+            assert prop not in required
+
+
+# ---------------------------------------------------------------------------
 # Entry point registration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add optional `mips_per_frame/` group with per-frame coronal/sagittal MIPs when volume is 4D+ (white-paper.md §recon)
- Add optional `gate_phase` dataset and `gate_trigger/` sub-group in `frames/` for cardiac/respiratory gated reconstructions
- Add optional embedded `device_data/` group (ECG, bellows signals following NXlog pattern) to both `recon` and `listmode` schemas
- Add optional `provenance/dicom_header` (JSON string) and `provenance/per_slice_metadata` (compound dataset) to `recon`
- Update JSON schemas in both `ReconSchema` and `ListmodeSchema` classes to include optional properties
- 44 new tests covering each optional feature (present and absent paths)

Closes #88

## Test plan

- [x] All 148 recon + listmode tests pass (104 existing + 44 new)
- [x] Full suite (864 tests) passes with no regressions
- [x] Pre-commit hooks (ruff, ruff-format, bandit, typos) pass
- [x] `mips_per_frame` tested: created for 4D, skipped for 3D, absent when not requested, values match manual computation
- [x] Gating tested: `gate_phase`/`gate_trigger` present for gated, absent for time frames
- [x] `device_data` tested: single/multiple channels, absent when not provided (both recon and listmode)
- [x] Provenance tested: `dicom_header` (string and dict input), `per_slice_metadata`, both together, absent when not provided
- [x] JSON schema optional properties tested: present but not in `required`


Made with [Cursor](https://cursor.com)