### PR TITLE
feat: integrate streaming chunk hashing into fd5.create() write path

### DIFF
--- a/src/fd5/create.py
+++ b/src/fd5/create.py
@@ -8,6 +8,8 @@ See white-paper.md § Immutability and write-once semantics.
 
 from __future__ import annotations
 
+import hashlib
+import itertools
 import os
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -18,7 +20,12 @@ import h5py
 import numpy as np
 
 from fd5.h5io import dict_to_h5
-from fd5.hash import compute_content_hash, compute_id
+from fd5.hash import (
+    ChunkHasher,
+    _CHUNK_HASHES_SUFFIX,
+    compute_content_hash,
+    compute_id,
+)
 from fd5.naming import generate_filename
 from fd5.provenance import write_ingest, write_original_files, write_sources
 from fd5.registry import get_schema
@@ -27,6 +34,72 @@ from fd5.schema import embed_schema
 
 class Fd5ValidationError(Exception):
     """Raised when required attributes are missing or empty before sealing."""
+
+
+# ---------------------------------------------------------------------------
+# Hash-tracking wrappers — intercept create_dataset to hash data inline
+# ---------------------------------------------------------------------------
+
+
+class _HashTrackingGroup:
+    """Wraps an ``h5py.Group`` to compute data hashes during ``create_dataset``.
+
+    Cached data hashes (``sha256(data.tobytes())``) and per-chunk digests are
+    stored in *_data_hash_cache* and *_chunk_digest_cache* respectively, keyed
+    by the dataset's absolute HDF5 path.
+    """
+
+    def __init__(
+        self,
+        group: h5py.Group,
+        data_hash_cache: dict[str, str],
+        chunk_digest_cache: dict[str, list[str]],
+    ) -> None:
+        object.__setattr__(self, "_group", group)
+        object.__setattr__(self, "_data_hash_cache", data_hash_cache)
+        object.__setattr__(self, "_chunk_digest_cache", chunk_digest_cache)
+
+    def create_dataset(self, name: str, **kwargs: Any) -> h5py.Dataset:
+        ds = self._group.create_dataset(name, **kwargs)
+        data = kwargs.get("data")
+        if data is not None and ds.chunks is not None:
+            arr = np.asarray(data)
+            self._data_hash_cache[ds.name] = hashlib.sha256(arr.tobytes()).hexdigest()
+
+            hasher = ChunkHasher()
+            chunk_shape = ds.chunks
+            _iter_chunks(arr, chunk_shape, hasher)
+            self._chunk_digest_cache[ds.name] = hasher.digests()
+        return ds
+
+    def create_group(self, name: str) -> "_HashTrackingGroup":
+        grp = self._group.create_group(name)
+        return _HashTrackingGroup(grp, self._data_hash_cache, self._chunk_digest_cache)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._group, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._group, name, value)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._group
+
+    def __getitem__(self, key: str) -> Any:
+        return self._group[key]
+
+
+def _iter_chunks(
+    arr: np.ndarray, chunk_shape: tuple[int, ...], hasher: ChunkHasher
+) -> None:
+    """Feed *arr* to *hasher* in row-major chunk order matching *chunk_shape*."""
+    ranges = [range(0, s, c) for s, c in zip(arr.shape, chunk_shape)]
+    for starts in itertools.product(*ranges):
+        slices = tuple(
+            slice(st, min(st + cs, sh))
+            for st, cs, sh in zip(starts, chunk_shape, arr.shape)
+        )
+        hasher.update(arr[slices])
 
 
 class Fd5Builder:
@@ -53,6 +126,8 @@ class Fd5Builder:
         self._description = description
         self._timestamp = timestamp
         self._schema = get_schema(product_type)
+        self._data_hash_cache: dict[str, str] = {}
+        self._chunk_digest_cache: dict[str, list[str]] = {}
 
     @property
     def file(self) -> h5py.File:
@@ -115,8 +190,15 @@ class Fd5Builder:
         dict_to_h5(grp, data)
 
     def write_product(self, data: Any) -> None:
-        """Delegate product-specific writes to the registered ProductSchema."""
-        self._schema.write(self._file, data)
+        """Delegate product-specific writes to the registered ProductSchema.
+
+        The schema receives a hash-tracking wrapper so that chunked-dataset
+        data hashes are computed inline during the write.
+        """
+        tracking = _HashTrackingGroup(
+            self._file, self._data_hash_cache, self._chunk_digest_cache
+        )
+        self._schema.write(tracking, data)
 
     # -- sealing -----------------------------------------------------------
 
@@ -131,9 +213,25 @@ class Fd5Builder:
                     f"Required attribute {attr!r} is missing or empty"
                 )
 
+    def _write_chunk_hashes(self) -> None:
+        """Store ``_chunk_hashes`` datasets for every inline-hashed dataset."""
+        dt = h5py.special_dtype(vlen=str)
+        for ds_path, digests in self._chunk_digest_cache.items():
+            parent = self._file[ds_path].parent
+            ds_name = ds_path.rsplit("/", 1)[-1]
+            hashes_name = f"{ds_name}{_CHUNK_HASHES_SUFFIX}"
+            parent.create_dataset(
+                hashes_name,
+                data=np.array(digests, dtype=object),
+                dtype=dt,
+            )
+            parent[hashes_name].attrs["algorithm"] = "sha256"
+
     def _seal(self) -> Path:
         """Embed schema, compute hashes, write id, rename to final path."""
         self._validate()
+
+        self._write_chunk_hashes()
 
         schema_dict = self._schema.json_schema()
         embed_schema(self._file, schema_dict)
@@ -151,7 +249,9 @@ class Fd5Builder:
         self._file.attrs["id"] = file_id
         self._file.attrs["id_inputs"] = id_desc
 
-        content_hash = compute_content_hash(self._file)
+        content_hash = compute_content_hash(
+            self._file, data_hash_cache=self._data_hash_cache or None
+        )
         self._file.attrs["content_hash"] = content_hash
 
         self._file.close()

--- a/src/fd5/hash.py
+++ b/src/fd5/hash.py
@@ -135,6 +135,35 @@ def _group_hash(group: h5py.Group) -> str:
     return h.hexdigest()
 
 
+def _dataset_hash_cached(ds: h5py.Dataset, data_hash: str) -> str:
+    """Like :func:`_dataset_hash` but uses a pre-computed *data_hash*."""
+    attrs_h = _sorted_attrs_hash(ds)
+    return hashlib.sha256((attrs_h + data_hash).encode("utf-8")).hexdigest()
+
+
+def _group_hash_cached(group: h5py.Group, cache: dict[str, str]) -> str:
+    """Like :func:`_group_hash` but looks up dataset data hashes in *cache*."""
+    h = hashlib.sha256()
+    h.update(_sorted_attrs_hash(group).encode("utf-8"))
+
+    for key in sorted(group.keys()):
+        if _is_chunk_hashes_dataset(key):
+            continue
+        link = group.get(key, getlink=True)
+        if isinstance(link, h5py.ExternalLink):
+            continue
+        child = group[key]
+        if isinstance(child, h5py.Group):
+            h.update(_group_hash_cached(child, cache).encode("utf-8"))
+        elif isinstance(child, h5py.Dataset):
+            if child.name in cache:
+                h.update(_dataset_hash_cached(child, cache[child.name]).encode("utf-8"))
+            else:
+                h.update(_dataset_hash(child).encode("utf-8"))
+
+    return h.hexdigest()
+
+
 class MerkleTree:
     """Computes the Merkle root hash of an HDF5 file/group.
 
@@ -155,9 +184,22 @@ class MerkleTree:
 # ---------------------------------------------------------------------------
 
 
-def compute_content_hash(root: h5py.File | h5py.Group) -> str:
-    """Return the algorithm-prefixed content hash: ``sha256:<hex>``."""
-    return f"sha256:{MerkleTree(root).root_hash()}"
+def compute_content_hash(
+    root: h5py.File | h5py.Group,
+    data_hash_cache: dict[str, str] | None = None,
+) -> str:
+    """Return the algorithm-prefixed content hash: ``sha256:<hex>``.
+
+    When *data_hash_cache* is provided, datasets whose absolute HDF5 path
+    appears in the mapping use the cached ``sha256(data.tobytes())`` hex
+    digest instead of re-reading the dataset.  Datasets not in the cache
+    fall back to the standard full-read path.
+    """
+    if data_hash_cache:
+        root_h = _group_hash_cached(root, data_hash_cache)
+    else:
+        root_h = _group_hash(root)
+    return f"sha256:{hashlib.sha256(root_h.encode('utf-8')).hexdigest()}"
 
 
 def verify(path: Union[str, Path]) -> bool:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -10,12 +10,12 @@ import h5py
 import numpy as np
 import pytest
 
-from fd5.hash import verify
+from fd5.hash import compute_content_hash, verify
 from fd5.registry import register_schema
 
 
 # ---------------------------------------------------------------------------
-# Stub schema
+# Stub schemas
 # ---------------------------------------------------------------------------
 
 
@@ -49,11 +49,45 @@ class _StubSchema:
         return ["product", "name", "timestamp"]
 
 
+class _ChunkedStubSchema:
+    """ProductSchema that creates chunked datasets — exercises inline hashing."""
+
+    product_type: str = "test/chunked"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "test/chunked"},
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "timestamp": {"type": "string"},
+            },
+            "required": ["_schema_version", "product", "name"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product": "test/chunked"}
+
+    def write(self, target: Any, data: Any) -> None:
+        ds = target.create_dataset(
+            "volume", data=data, chunks=(2, 4), compression="gzip"
+        )
+        ds.attrs["units"] = "mm"
+
+    def id_inputs(self) -> list[str]:
+        return ["product", "name", "timestamp"]
+
+
 @pytest.fixture(autouse=True)
 def _register_stub():
     import fd5.registry as reg
 
     register_schema("test/product", _StubSchema())
+    register_schema("test/chunked", _ChunkedStubSchema())
     reg._ep_loaded = True
 
 
@@ -589,6 +623,171 @@ class TestExceptionFileHandleInvalid:
             ) as builder:
                 builder.file.close()
                 raise RuntimeError("after close")
+
+
+# ---------------------------------------------------------------------------
+# Inline chunk hashing — _chunk_hashes stored alongside chunked datasets
+# ---------------------------------------------------------------------------
+
+
+class TestInlineChunkHashing:
+    def test_chunk_hashes_dataset_created(self, out_dir: Path):
+        """Chunked datasets should get a sibling ``_chunk_hashes`` dataset."""
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            assert "volume_chunk_hashes" in f
+
+    def test_chunk_hashes_algorithm_attr(self, out_dir: Path):
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            assert f["volume_chunk_hashes"].attrs["algorithm"] == "sha256"
+
+    def test_chunk_hashes_count_matches_chunks(self, out_dir: Path):
+        """Number of stored digests equals the number of HDF5 chunks."""
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            n_hashes = len(f["volume_chunk_hashes"][...])
+            assert n_hashes == 3  # 6 rows / 2-row chunks
+
+    def test_no_chunk_hashes_for_non_chunked_dataset(self, out_dir: Path):
+        data = np.zeros((4, 4), dtype=np.float32)
+        with create(
+            out_dir,
+            product="test/product",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            assert "volume_chunk_hashes" not in f
+
+    def test_content_hash_verifies_with_chunk_hashes(self, out_dir: Path):
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        assert verify(final) is True
+
+
+# ---------------------------------------------------------------------------
+# Inline vs second-pass hash identity
+# ---------------------------------------------------------------------------
+
+
+class TestInlineVsSecondPassHashIdentity:
+    """The content_hash must be identical whether computed from the inline
+    data-hash cache or by the standard full-read Merkle tree walk."""
+
+    def test_chunked_dataset_inline_matches_second_pass(self, out_dir: Path):
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            stored = f.attrs["content_hash"]
+            second_pass = compute_content_hash(f, data_hash_cache=None)
+            assert stored == second_pass
+
+    def test_non_chunked_dataset_hash_unchanged(self, out_dir: Path):
+        data = np.zeros((4, 4), dtype=np.float32)
+        with create(
+            out_dir,
+            product="test/product",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            stored = f.attrs["content_hash"]
+            second_pass = compute_content_hash(f, data_hash_cache=None)
+            assert stored == second_pass
+
+    def test_large_chunked_dataset(self, out_dir: Path):
+        """Larger dataset with many chunks to exercise chunk iteration order."""
+        data = np.random.default_rng(42).standard_normal((32, 16), dtype=np.float32)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            stored = f.attrs["content_hash"]
+            second_pass = compute_content_hash(f, data_hash_cache=None)
+            assert stored == second_pass
+
+    def test_mixed_chunked_and_non_chunked(self, out_dir: Path):
+        """File with both chunked and non-chunked datasets (via extra)."""
+        data = np.arange(24, dtype=np.float32).reshape(6, 4)
+        with create(
+            out_dir,
+            product="test/chunked",
+            name="sample",
+            description="desc",
+            timestamp="2026-02-25T12:00:00Z",
+        ) as builder:
+            builder.write_product(data)
+            builder.write_metadata({"algorithm": "osem"})
+
+        final = _find_h5(out_dir)
+        with h5py.File(final, "r") as f:
+            stored = f.attrs["content_hash"]
+            second_pass = compute_content_hash(f, data_hash_cache=None)
+            assert stored == second_pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `_HashTrackingGroup` wrapper in `create.py` that intercepts `create_dataset` calls during `write_product()` to compute SHA-256 data hashes and per-chunk digests inline, avoiding a full file re-read during sealing.
- Store `_chunk_hashes` sibling datasets alongside each chunked dataset, with per-chunk SHA-256 hex digests and an `algorithm` attribute.
- In `_seal()`, use cached data hashes via `compute_content_hash(data_hash_cache=...)` for chunked datasets; non-chunked datasets fall back to the existing second-pass `_dataset_hash()` full-read path.

## Test plan

- [x] `TestInlineChunkHashing` — verifies `_chunk_hashes` dataset creation, algorithm attr, digest count, absence for non-chunked datasets, and `verify()` passes
- [x] `TestInlineVsSecondPassHashIdentity` — asserts `content_hash` is identical whether computed inline or via second-pass for: chunked, non-chunked, large multi-chunk, and mixed datasets
- [x] All 70 existing tests continue to pass unchanged (79 total with new tests)

Closes #86

Made with [Cursor](https://cursor.com)