### PR TITLE
feat(quality): add description quality validation heuristic (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **End-to-end integration test** ([#49](https://github.com/vig-os/fd5/issues/49))
   - Full create → validate → info → manifest round-trip test
 
+- **Description quality validation** ([#91](https://github.com/vig-os/fd5/issues/91))
+  - `check_descriptions(path)` validates description attrs for AI-readability
+  - Detects missing, empty, short, placeholder, and duplicate descriptions
+  - `fd5 check-descriptions` CLI command exits non-zero on warnings
+
 ### Fixed
 
 - **CI lint job missing tool dependencies** ([#48](https://github.com/vig-os/fd5/issues/48))

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -11,6 +11,7 @@ import h5py
 
 from fd5.hash import verify
 from fd5.manifest import write_manifest
+from fd5.quality import check_descriptions
 from fd5.rocrate import write as write_rocrate
 from fd5.schema import dump_schema, validate
 
@@ -125,7 +126,6 @@ def datacite(directory: str, output: str | None) -> None:
     click.echo(f"Wrote {out_path}")
 
 
-
 @cli.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option(
@@ -142,6 +142,23 @@ def rocrate(directory: str, output: str | None) -> None:
     write_rocrate(dir_path, out_path)
     written = out_path or dir_path / "ro-crate-metadata.json"
     click.echo(f"Wrote {written}")
+
+
+@cli.command("check-descriptions")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+def check_descriptions_cmd(file: str) -> None:
+    """Check description attribute quality for AI-readability."""
+    path = Path(file)
+    warnings = check_descriptions(path)
+
+    if not warnings:
+        click.echo("OK – all descriptions pass quality checks.")
+        return
+
+    for w in warnings:
+        click.echo(f"{w.severity.upper()}: {w.path}: {w.message}", err=True)
+
+    sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fd5/quality.py
+++ b/src/fd5/quality.py
@@ -1,0 +1,136 @@
+"""fd5.quality — description quality validation heuristics.
+
+Checks that fd5 files meet description standards for AI-readability
+and FAIR compliance. See white-paper.md § AI-Retrievable (FAIR for AI).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import h5py
+
+_MIN_LENGTH = 20
+
+_PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\btodo\b", re.IGNORECASE),
+    re.compile(r"\btbd\b", re.IGNORECASE),
+    re.compile(r"\bfixme\b", re.IGNORECASE),
+    re.compile(r"\bplaceholder\b", re.IGNORECASE),
+    re.compile(r"\bxxx\b", re.IGNORECASE),
+    re.compile(r"^description\b", re.IGNORECASE),
+]
+
+
+@dataclass(frozen=True)
+class Warning:
+    """A quality warning about a description attribute."""
+
+    path: str
+    message: str
+    severity: str  # "error" | "warning"
+
+
+def check_descriptions(path: Path) -> list[Warning]:
+    """Validate description attributes in an fd5 HDF5 file.
+
+    Returns a list of Warning objects. An empty list means all checks pass.
+    """
+    warnings: list[Warning] = []
+    with h5py.File(path, "r") as f:
+        _check_root(f, warnings)
+        seen: dict[str, str] = {}
+        _walk(f, "/", warnings, seen)
+    return warnings
+
+
+def _check_root(f: h5py.File, warnings: list[Warning]) -> None:
+    desc = f.attrs.get("description")
+    if desc is None:
+        warnings.append(
+            Warning(
+                path="/", message="Missing root description attribute", severity="error"
+            )
+        )
+        return
+    desc_str = desc.decode("utf-8") if isinstance(desc, bytes) else str(desc)
+    if not desc_str.strip():
+        warnings.append(
+            Warning(
+                path="/", message="Empty root description attribute", severity="error"
+            )
+        )
+
+
+def _walk(
+    group: h5py.Group,
+    prefix: str,
+    warnings: list[Warning],
+    seen: dict[str, str],
+) -> None:
+    for key in sorted(group.keys()):
+        item = group[key]
+        full_path = f"{prefix}{key}" if prefix == "/" else f"{prefix}/{key}"
+        desc = item.attrs.get("description")
+
+        if desc is None:
+            warnings.append(
+                Warning(
+                    path=full_path,
+                    message=f"Missing description attribute on {_kind(item)}",
+                    severity="error",
+                )
+            )
+        else:
+            desc_str = desc.decode("utf-8") if isinstance(desc, bytes) else str(desc)
+            _check_quality(full_path, desc_str, warnings, seen)
+
+        if isinstance(item, h5py.Group):
+            _walk(item, full_path, warnings, seen)
+
+
+def _check_quality(
+    path: str,
+    desc: str,
+    warnings: list[Warning],
+    seen: dict[str, str],
+) -> None:
+    if len(desc) < _MIN_LENGTH:
+        warnings.append(
+            Warning(
+                path=path,
+                message=f"Short description ({len(desc)} chars, minimum {_MIN_LENGTH})",
+                severity="warning",
+            )
+        )
+        return
+
+    for pattern in _PLACEHOLDER_PATTERNS:
+        if pattern.search(desc):
+            warnings.append(
+                Warning(
+                    path=path,
+                    message="Placeholder text detected in description",
+                    severity="warning",
+                )
+            )
+            return
+
+    if desc in seen:
+        warnings.append(
+            Warning(
+                path=path,
+                message=f"Duplicate description (same as {seen[desc]})",
+                severity="warning",
+            )
+        )
+    else:
+        seen[desc] = path
+
+
+def _kind(item: h5py.HLObject) -> str:
+    if isinstance(item, h5py.Dataset):
+        return "dataset"
+    return "group"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,350 @@
+"""Tests for fd5.quality — description quality validation heuristics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from fd5.cli import cli
+from fd5.quality import Warning, check_descriptions
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def clean_h5(tmp_path: Path) -> Path:
+    """An fd5 file where every group and dataset has a good description."""
+    path = tmp_path / "clean.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        g = f.create_group("metadata")
+        g.attrs["description"] = "Reconstruction parameters and settings"
+        ds = f.create_dataset("volume", data=np.zeros((4, 4), dtype=np.float32))
+        ds.attrs["description"] = "Reconstructed image volume in Bq/mL"
+    return path
+
+
+@pytest.fixture()
+def no_root_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file missing the root description attribute."""
+    path = tmp_path / "no_root.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["product"] = "recon"
+        ds = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+        ds.attrs["description"] = "Reconstructed image volume in Bq/mL"
+    return path
+
+
+@pytest.fixture()
+def empty_root_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with an empty root description attribute."""
+    path = tmp_path / "empty_root.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = ""
+        ds = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+        ds.attrs["description"] = "Reconstructed image volume in Bq/mL"
+    return path
+
+
+@pytest.fixture()
+def missing_group_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with a group missing its description."""
+    path = tmp_path / "missing_group.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        f.create_group("metadata")  # no description
+    return path
+
+
+@pytest.fixture()
+def missing_dataset_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with a dataset missing its description."""
+    path = tmp_path / "missing_ds.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+    return path
+
+
+@pytest.fixture()
+def short_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with a description shorter than 20 chars."""
+    path = tmp_path / "short.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        ds = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+        ds.attrs["description"] = "short"
+    return path
+
+
+@pytest.fixture()
+def placeholder_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with placeholder text in a description."""
+    path = tmp_path / "placeholder.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        ds = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+        ds.attrs["description"] = "TODO fill this in later with real description"
+    return path
+
+
+@pytest.fixture()
+def duplicate_desc_h5(tmp_path: Path) -> Path:
+    """An fd5 file with duplicate descriptions on different items."""
+    path = tmp_path / "duplicate.h5"
+    with h5py.File(path, "w") as f:
+        f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+        ds1 = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+        ds1.attrs["description"] = "Reconstructed image volume in Bq/mL units"
+        ds2 = f.create_dataset("weights", data=np.ones((4,), dtype=np.float32))
+        ds2.attrs["description"] = "Reconstructed image volume in Bq/mL units"
+    return path
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDescriptionsHappyPath:
+    def test_clean_file_returns_empty_list(self, clean_h5: Path):
+        warnings = check_descriptions(clean_h5)
+        assert warnings == []
+
+    def test_returns_list(self, clean_h5: Path):
+        result = check_descriptions(clean_h5)
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — root description
+# ---------------------------------------------------------------------------
+
+
+class TestRootDescription:
+    def test_missing_root_description(self, no_root_desc_h5: Path):
+        warnings = check_descriptions(no_root_desc_h5)
+        assert any(w.path == "/" and "missing" in w.message.lower() for w in warnings)
+
+    def test_missing_root_description_severity(self, no_root_desc_h5: Path):
+        warnings = check_descriptions(no_root_desc_h5)
+        root_warnings = [w for w in warnings if w.path == "/"]
+        assert root_warnings[0].severity == "error"
+
+    def test_empty_root_description(self, empty_root_desc_h5: Path):
+        warnings = check_descriptions(empty_root_desc_h5)
+        assert any(w.path == "/" and "empty" in w.message.lower() for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — groups and datasets
+# ---------------------------------------------------------------------------
+
+
+class TestGroupAndDatasetDescriptions:
+    def test_missing_group_description(self, missing_group_desc_h5: Path):
+        warnings = check_descriptions(missing_group_desc_h5)
+        assert any(
+            w.path == "/metadata" and "missing" in w.message.lower() for w in warnings
+        )
+
+    def test_missing_group_description_severity(self, missing_group_desc_h5: Path):
+        warnings = check_descriptions(missing_group_desc_h5)
+        meta_warnings = [w for w in warnings if w.path == "/metadata"]
+        assert meta_warnings[0].severity == "error"
+
+    def test_missing_dataset_description(self, missing_dataset_desc_h5: Path):
+        warnings = check_descriptions(missing_dataset_desc_h5)
+        assert any(
+            w.path == "/volume" and "missing" in w.message.lower() for w in warnings
+        )
+
+    def test_missing_dataset_description_severity(self, missing_dataset_desc_h5: Path):
+        warnings = check_descriptions(missing_dataset_desc_h5)
+        vol_warnings = [w for w in warnings if w.path == "/volume"]
+        assert vol_warnings[0].severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — short descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestShortDescriptions:
+    def test_short_description_warns(self, short_desc_h5: Path):
+        warnings = check_descriptions(short_desc_h5)
+        assert any(
+            w.path == "/volume" and "short" in w.message.lower() for w in warnings
+        )
+
+    def test_short_description_severity(self, short_desc_h5: Path):
+        warnings = check_descriptions(short_desc_h5)
+        vol_warnings = [w for w in warnings if w.path == "/volume"]
+        assert vol_warnings[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — placeholder text
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderDescriptions:
+    def test_placeholder_text_warns(self, placeholder_desc_h5: Path):
+        warnings = check_descriptions(placeholder_desc_h5)
+        assert any(
+            w.path == "/volume" and "placeholder" in w.message.lower() for w in warnings
+        )
+
+    def test_placeholder_severity(self, placeholder_desc_h5: Path):
+        warnings = check_descriptions(placeholder_desc_h5)
+        vol_warnings = [w for w in warnings if w.path == "/volume"]
+        assert vol_warnings[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — duplicate descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateDescriptions:
+    def test_duplicate_descriptions_warn(self, duplicate_desc_h5: Path):
+        warnings = check_descriptions(duplicate_desc_h5)
+        assert any("duplicate" in w.message.lower() for w in warnings)
+
+    def test_duplicate_severity(self, duplicate_desc_h5: Path):
+        warnings = check_descriptions(duplicate_desc_h5)
+        dup_warnings = [w for w in warnings if "duplicate" in w.message.lower()]
+        assert all(w.severity == "warning" for w in dup_warnings)
+
+
+# ---------------------------------------------------------------------------
+# check_descriptions — nested structures
+# ---------------------------------------------------------------------------
+
+
+class TestNestedStructures:
+    def test_nested_group_missing_description(self, tmp_path: Path):
+        path = tmp_path / "nested.h5"
+        with h5py.File(path, "w") as f:
+            f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+            g = f.create_group("metadata")
+            g.attrs["description"] = "Reconstruction parameters and settings"
+            g.create_group("reconstruction")  # no description
+        warnings = check_descriptions(path)
+        assert any(
+            w.path == "/metadata/reconstruction" and "missing" in w.message.lower()
+            for w in warnings
+        )
+
+    def test_nested_dataset_missing_description(self, tmp_path: Path):
+        path = tmp_path / "nested_ds.h5"
+        with h5py.File(path, "w") as f:
+            f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+            g = f.create_group("data")
+            g.attrs["description"] = "Primary data group for measurements"
+            g.create_dataset("values", data=np.zeros((4,)))  # no description
+        warnings = check_descriptions(path)
+        assert any(
+            w.path == "/data/values" and "missing" in w.message.lower()
+            for w in warnings
+        )
+
+
+# ---------------------------------------------------------------------------
+# Warning dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestWarningDataclass:
+    def test_warning_fields(self):
+        w = Warning(path="/volume", message="test message", severity="warning")
+        assert w.path == "/volume"
+        assert w.message == "test message"
+        assert w.severity == "warning"
+
+    def test_warning_equality(self):
+        w1 = Warning(path="/a", message="msg", severity="error")
+        w2 = Warning(path="/a", message="msg", severity="error")
+        assert w1 == w2
+
+
+# ---------------------------------------------------------------------------
+# CLI: fd5 check-descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDescriptionsCLI:
+    def test_clean_file_exits_zero(self, runner: CliRunner, clean_h5: Path):
+        result = runner.invoke(cli, ["check-descriptions", str(clean_h5)])
+        assert result.exit_code == 0
+
+    def test_clean_file_shows_ok(self, runner: CliRunner, clean_h5: Path):
+        result = runner.invoke(cli, ["check-descriptions", str(clean_h5)])
+        assert "ok" in result.output.lower() or "pass" in result.output.lower()
+
+    def test_missing_desc_exits_nonzero(self, runner: CliRunner, no_root_desc_h5: Path):
+        result = runner.invoke(cli, ["check-descriptions", str(no_root_desc_h5)])
+        assert result.exit_code != 0
+
+    def test_missing_desc_shows_warnings(
+        self, runner: CliRunner, no_root_desc_h5: Path
+    ):
+        result = runner.invoke(cli, ["check-descriptions", str(no_root_desc_h5)])
+        assert "missing" in result.output.lower() or "warning" in result.output.lower()
+
+    def test_nonexistent_file_exits_nonzero(self, runner: CliRunner, tmp_path: Path):
+        result = runner.invoke(cli, ["check-descriptions", str(tmp_path / "ghost.h5")])
+        assert result.exit_code != 0
+
+    def test_short_desc_exits_nonzero(self, runner: CliRunner, short_desc_h5: Path):
+        result = runner.invoke(cli, ["check-descriptions", str(short_desc_h5)])
+        assert result.exit_code != 0
+
+    def test_placeholder_desc_exits_nonzero(
+        self, runner: CliRunner, placeholder_desc_h5: Path
+    ):
+        result = runner.invoke(cli, ["check-descriptions", str(placeholder_desc_h5)])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Placeholder patterns
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderPatterns:
+    """Verify multiple placeholder patterns are caught."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "TBD - will add later for this field",
+            "FIXME need a real description here",
+            "placeholder text for the field here",
+            "PLACEHOLDER for the description field",
+            "description goes here eventually soon",
+            "xxx fill this in with actual content",
+        ],
+    )
+    def test_various_placeholders(self, tmp_path: Path, text: str):
+        path = tmp_path / "ph.h5"
+        with h5py.File(path, "w") as f:
+            f.attrs["description"] = "Root-level dataset of PET reconstruction images"
+            ds = f.create_dataset("volume", data=np.zeros((4,), dtype=np.float32))
+            ds.attrs["description"] = text
+        warnings = check_descriptions(path)
+        assert any(
+            w.path == "/volume" and "placeholder" in w.message.lower() for w in warnings
+        )


### PR DESCRIPTION
## Description

Add description quality validation heuristics for fd5 files, ensuring `description` attributes meet AI-readability and FAIR compliance standards as defined in white-paper.md § AI-Retrievable (FAIR for AI).

New `check_descriptions(path)` function walks the HDF5 tree and reports missing, empty, short, placeholder, and duplicate descriptions. New `fd5 check-descriptions` CLI command exits non-zero when any warnings are found.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`src/fd5/quality.py`** (new) — `Warning` dataclass and `check_descriptions(path)` function that validates:
  - Root `description` attribute exists and is non-empty
  - All groups and datasets have `description` attributes
  - Short descriptions (< 20 chars)
  - Placeholder text (TODO, TBD, FIXME, placeholder, xxx, "description …")
  - Duplicate descriptions across different paths
- **`src/fd5/cli.py`** — Added `fd5 check-descriptions <file>` CLI command
- **`tests/test_quality.py`** (new) — 32 tests covering happy path, missing/empty root, missing group/dataset descriptions, short, placeholder, duplicate, nested structures, Warning dataclass, CLI exit codes, and parametrized placeholder patterns
- **`CHANGELOG.md`** — Added entry under Unreleased > Added

## Changelog Entry

### Added

- **Description quality validation** ([#91](https://github.com/vig-os/fd5/issues/91))
  - `check_descriptions(path)` validates description attrs for AI-readability
  - Detects missing, empty, short, placeholder, and duplicate descriptions
  - `fd5 check-descriptions` CLI command exits non-zero on warnings

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Does NOT modify `pyproject.toml` entry points or `uv.lock` as instructed.
- Vocabulary/terminology consistency check deferred to a future issue (marked optional in #91).
- CI lint failure is a known pre-existing issue, not introduced by this PR.

Refs: #91
