### PR TITLE
feat(benchmarks): add performance benchmarks for fd5 core operations

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,65 @@
+# fd5 Performance Benchmarks
+
+Standalone timing scripts for fd5 core operations. No external benchmark framework required.
+
+## Prerequisites
+
+Install fd5 in development mode from the repository root:
+
+```bash
+uv pip install -e ".[dev]"
+```
+
+## Running All Benchmarks
+
+From the repository root:
+
+```bash
+python -m benchmarks.run_all
+```
+
+This runs every benchmark module and prints a summary table with mean, standard deviation, min, and max timings.
+
+## Running Individual Benchmarks
+
+Each script is self-contained and can be run directly:
+
+```bash
+python -m benchmarks.bench_create
+python -m benchmarks.bench_hash
+python -m benchmarks.bench_validate
+python -m benchmarks.bench_manifest
+```
+
+## Benchmark Descriptions
+
+### bench_create
+
+Measures end-to-end `fd5.create()` time (open file, write dataset, compute hashes, seal) for 1 MB, 10 MB, and 100 MB
+float32 datasets.
+
+### bench_hash
+
+Measures `compute_content_hash()` (Merkle tree walk over HDF5 file) for 1 MB, 10 MB, and 100 MB datasets.
+Reports throughput in MB/s.
+
+### bench_validate
+
+Measures two operations on sealed fd5 files of 1 MB, 10 MB, and 100 MB:
+
+- **schema.validate** — JSON Schema validation of root attributes against the embedded schema.
+- **hash.verify** — full Merkle tree recomputation and comparison with stored `content_hash`.
+
+### bench_manifest
+
+Measures `build_manifest()` for directories containing 10 and 100 `.h5` files. Reports per-file cost in ms.
+
+## Interpreting Results
+
+- **Mean** — average across repeated runs (see `REPEATS` constant in each script).
+- **StDev** — standard deviation; high values suggest I/O or system noise.
+- **Min / Max** — best and worst observed times.
+- **Extra** — throughput (MB/s) for hash benchmarks; per-file cost (ms/file) for manifest benchmarks.
+
+All timings use `time.perf_counter()` for high-resolution wall-clock measurement. Temporary files are created in
+the system temp directory and cleaned up after each run.

--- a/benchmarks/bench_create.py
+++ b/benchmarks/bench_create.py
@@ -1,0 +1,119 @@
+"""Benchmark fd5.create() for files with 1 MB, 10 MB, and 100 MB datasets."""
+
+from __future__ import annotations
+
+import shutil
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fd5.create import create
+from fd5.registry import register_schema
+
+SIZES_MB = [1, 10, 100]
+REPEATS = 3
+FLOAT32_BYTES = 4
+
+
+class _BenchSchema:
+    """Minimal schema for benchmarking fd5.create()."""
+
+    product_type: str = "bench/create"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "bench/create"},
+                "name": {"type": "string"},
+            },
+            "required": ["_schema_version", "product", "name"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product": "bench/create"}
+
+    def write(self, target: Any, data: Any) -> None:
+        target.create_dataset("volume", data=data, chunks=True)
+
+    def id_inputs(self) -> list[str]:
+        return ["product", "name", "timestamp"]
+
+
+def _make_array(size_mb: int) -> np.ndarray:
+    n_elements = (size_mb * 1024 * 1024) // FLOAT32_BYTES
+    return np.random.default_rng(42).standard_normal(n_elements, dtype=np.float32)
+
+
+def _bench_create(size_mb: int, repeats: int) -> list[float]:
+    register_schema("bench/create", _BenchSchema())
+    import fd5.registry as reg
+
+    reg._ep_loaded = True
+
+    data = _make_array(size_mb)
+    timings: list[float] = []
+
+    for _ in range(repeats):
+        work_dir = Path(tempfile.mkdtemp())
+        try:
+            t0 = time.perf_counter()
+            with create(
+                work_dir,
+                product="bench/create",
+                name="bench",
+                description="benchmark file",
+                timestamp="2026-01-01T00:00:00Z",
+            ) as builder:
+                builder.write_product(data)
+            elapsed = time.perf_counter() - t0
+            timings.append(elapsed)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    return timings
+
+
+def run() -> list[dict[str, Any]]:
+    """Run all create benchmarks and return structured results."""
+    results: list[dict[str, Any]] = []
+    for size_mb in SIZES_MB:
+        timings = _bench_create(size_mb, REPEATS)
+        results.append(
+            {
+                "benchmark": "fd5.create",
+                "parameter": f"{size_mb} MB",
+                "mean_s": statistics.mean(timings),
+                "stdev_s": statistics.stdev(timings) if len(timings) > 1 else 0.0,
+                "min_s": min(timings),
+                "max_s": max(timings),
+                "repeats": REPEATS,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    print(
+        f"{'Size':<10} {'Mean (s)':<12} {'StDev (s)':<12} {'Min (s)':<12} {'Max (s)':<12}"
+    )
+    print("-" * 58)
+    for row in run():
+        print(
+            f"{row['parameter']:<10} "
+            f"{row['mean_s']:<12.4f} "
+            f"{row['stdev_s']:<12.4f} "
+            f"{row['min_s']:<12.4f} "
+            f"{row['max_s']:<12.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_hash.py
+++ b/benchmarks/bench_hash.py
@@ -1,0 +1,85 @@
+"""Benchmark compute_content_hash() for various file sizes."""
+
+from __future__ import annotations
+
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+from fd5.hash import compute_content_hash
+
+SIZES_MB = [1, 10, 100]
+REPEATS = 5
+FLOAT32_BYTES = 4
+
+
+def _create_h5(size_mb: int, path: Path) -> None:
+    n_elements = (size_mb * 1024 * 1024) // FLOAT32_BYTES
+    data = np.random.default_rng(42).standard_normal(n_elements, dtype=np.float32)
+    with h5py.File(path, "w") as f:
+        f.attrs["name"] = "bench"
+        f.attrs["product"] = "bench"
+        f.create_dataset("volume", data=data, chunks=True)
+
+
+def _bench_hash(size_mb: int, repeats: int) -> list[float]:
+    with tempfile.TemporaryDirectory() as tmp:
+        h5_path = Path(tmp) / "bench.h5"
+        _create_h5(size_mb, h5_path)
+        timings: list[float] = []
+        for _ in range(repeats):
+            with h5py.File(h5_path, "r") as f:
+                t0 = time.perf_counter()
+                compute_content_hash(f)
+                elapsed = time.perf_counter() - t0
+            timings.append(elapsed)
+    return timings
+
+
+def run() -> list[dict[str, Any]]:
+    """Run all hash benchmarks and return structured results."""
+    results: list[dict[str, Any]] = []
+    for size_mb in SIZES_MB:
+        timings = _bench_hash(size_mb, REPEATS)
+        throughput = (
+            size_mb / statistics.mean(timings) if statistics.mean(timings) > 0 else 0
+        )
+        results.append(
+            {
+                "benchmark": "compute_content_hash",
+                "parameter": f"{size_mb} MB",
+                "mean_s": statistics.mean(timings),
+                "stdev_s": statistics.stdev(timings) if len(timings) > 1 else 0.0,
+                "min_s": min(timings),
+                "max_s": max(timings),
+                "throughput_mb_s": throughput,
+                "repeats": REPEATS,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    print(
+        f"{'Size':<10} {'Mean (s)':<12} {'StDev (s)':<12} "
+        f"{'Min (s)':<12} {'Max (s)':<12} {'MB/s':<10}"
+    )
+    print("-" * 68)
+    for row in run():
+        print(
+            f"{row['parameter']:<10} "
+            f"{row['mean_s']:<12.4f} "
+            f"{row['stdev_s']:<12.4f} "
+            f"{row['min_s']:<12.4f} "
+            f"{row['max_s']:<12.4f} "
+            f"{row['throughput_mb_s']:<10.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_manifest.py
+++ b/benchmarks/bench_manifest.py
@@ -1,0 +1,100 @@
+"""Benchmark manifest generation for directories with 10 and 100 fd5 files."""
+
+from __future__ import annotations
+
+import shutil
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+from fd5.h5io import dict_to_h5
+from fd5.manifest import build_manifest
+
+FILE_COUNTS = [10, 100]
+REPEATS = 3
+
+
+def _populate_dir(directory: Path, n_files: int) -> None:
+    for i in range(n_files):
+        path = directory / f"product-{i:04d}.h5"
+        with h5py.File(path, "w") as f:
+            dict_to_h5(
+                f,
+                {
+                    "_schema_version": 1,
+                    "product": "bench",
+                    "id": f"sha256:{i:064d}",
+                    "id_inputs": "product + name",
+                    "name": f"file-{i}",
+                    "description": f"Benchmark file {i}",
+                    "content_hash": f"sha256:{i:064x}",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                },
+            )
+            data = np.zeros(64, dtype=np.float32)
+            f.create_dataset("volume", data=data)
+            if i == 0:
+                g = f.create_group("study")
+                g.attrs["type"] = "benchmark"
+
+
+def _bench_manifest(n_files: int, repeats: int) -> list[float]:
+    work_dir = Path(tempfile.mkdtemp())
+    try:
+        _populate_dir(work_dir, n_files)
+        timings: list[float] = []
+        for _ in range(repeats):
+            t0 = time.perf_counter()
+            build_manifest(work_dir)
+            elapsed = time.perf_counter() - t0
+            timings.append(elapsed)
+        return timings
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def run() -> list[dict[str, Any]]:
+    """Run all manifest benchmarks and return structured results."""
+    results: list[dict[str, Any]] = []
+    for n_files in FILE_COUNTS:
+        timings = _bench_manifest(n_files, REPEATS)
+        per_file = statistics.mean(timings) / n_files if n_files > 0 else 0
+        results.append(
+            {
+                "benchmark": "build_manifest",
+                "parameter": f"{n_files} files",
+                "mean_s": statistics.mean(timings),
+                "stdev_s": statistics.stdev(timings) if len(timings) > 1 else 0.0,
+                "min_s": min(timings),
+                "max_s": max(timings),
+                "per_file_ms": per_file * 1000,
+                "repeats": REPEATS,
+            }
+        )
+    return results
+
+
+def main() -> None:
+    print(
+        f"{'Files':<12} {'Mean (s)':<12} {'StDev (s)':<12} "
+        f"{'Min (s)':<12} {'Max (s)':<12} {'ms/file':<10}"
+    )
+    print("-" * 70)
+    for row in run():
+        print(
+            f"{row['parameter']:<12} "
+            f"{row['mean_s']:<12.4f} "
+            f"{row['stdev_s']:<12.4f} "
+            f"{row['min_s']:<12.4f} "
+            f"{row['max_s']:<12.4f} "
+            f"{row['per_file_ms']:<10.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_validate.py
+++ b/benchmarks/bench_validate.py
@@ -1,0 +1,155 @@
+"""Benchmark fd5 validate (schema validation + content_hash verification)."""
+
+from __future__ import annotations
+
+import shutil
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fd5.create import create
+from fd5.hash import verify
+from fd5.registry import register_schema
+from fd5.schema import validate
+
+SIZES_MB = [1, 10, 100]
+REPEATS = 3
+FLOAT32_BYTES = 4
+
+
+class _BenchSchema:
+    """Minimal schema for benchmarking validation."""
+
+    product_type: str = "bench/validate"
+    schema_version: str = "1.0.0"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "_schema_version": {"type": "integer"},
+                "product": {"type": "string", "const": "bench/validate"},
+                "name": {"type": "string"},
+            },
+            "required": ["_schema_version", "product", "name"],
+        }
+
+    def required_root_attrs(self) -> dict[str, Any]:
+        return {"product": "bench/validate"}
+
+    def write(self, target: Any, data: Any) -> None:
+        target.create_dataset("volume", data=data, chunks=True)
+
+    def id_inputs(self) -> list[str]:
+        return ["product", "name", "timestamp"]
+
+
+def _make_array(size_mb: int) -> np.ndarray:
+    n_elements = (size_mb * 1024 * 1024) // FLOAT32_BYTES
+    return np.random.default_rng(42).standard_normal(n_elements, dtype=np.float32)
+
+
+def _create_test_file(size_mb: int, work_dir: Path) -> Path:
+    register_schema("bench/validate", _BenchSchema())
+    import fd5.registry as reg
+
+    reg._ep_loaded = True
+
+    data = _make_array(size_mb)
+    with create(
+        work_dir,
+        product="bench/validate",
+        name="bench",
+        description="benchmark file",
+        timestamp="2026-01-01T00:00:00Z",
+    ) as builder:
+        builder.write_product(data)
+
+    return next(work_dir.glob("*.h5"))
+
+
+def _bench_schema_validate(h5_path: Path, repeats: int) -> list[float]:
+    timings: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        validate(h5_path)
+        elapsed = time.perf_counter() - t0
+        timings.append(elapsed)
+    return timings
+
+
+def _bench_content_hash_verify(h5_path: Path, repeats: int) -> list[float]:
+    timings: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        result = verify(h5_path)
+        elapsed = time.perf_counter() - t0
+        assert result is True, "verify() returned False — file may be corrupt"
+        timings.append(elapsed)
+    return timings
+
+
+def run() -> list[dict[str, Any]]:
+    """Run all validation benchmarks and return structured results."""
+    results: list[dict[str, Any]] = []
+
+    for size_mb in SIZES_MB:
+        work_dir = Path(tempfile.mkdtemp())
+        try:
+            h5_path = _create_test_file(size_mb, work_dir)
+
+            timings = _bench_schema_validate(h5_path, REPEATS)
+            results.append(
+                {
+                    "benchmark": "schema.validate",
+                    "parameter": f"{size_mb} MB",
+                    "mean_s": statistics.mean(timings),
+                    "stdev_s": statistics.stdev(timings) if len(timings) > 1 else 0.0,
+                    "min_s": min(timings),
+                    "max_s": max(timings),
+                    "repeats": REPEATS,
+                }
+            )
+
+            timings = _bench_content_hash_verify(h5_path, REPEATS)
+            results.append(
+                {
+                    "benchmark": "hash.verify",
+                    "parameter": f"{size_mb} MB",
+                    "mean_s": statistics.mean(timings),
+                    "stdev_s": statistics.stdev(timings) if len(timings) > 1 else 0.0,
+                    "min_s": min(timings),
+                    "max_s": max(timings),
+                    "repeats": REPEATS,
+                }
+            )
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    return results
+
+
+def main() -> None:
+    print(
+        f"{'Benchmark':<20} {'Size':<10} {'Mean (s)':<12} "
+        f"{'StDev (s)':<12} {'Min (s)':<12} {'Max (s)':<12}"
+    )
+    print("-" * 78)
+    for row in run():
+        print(
+            f"{row['benchmark']:<20} "
+            f"{row['parameter']:<10} "
+            f"{row['mean_s']:<12.4f} "
+            f"{row['stdev_s']:<12.4f} "
+            f"{row['min_s']:<12.4f} "
+            f"{row['max_s']:<12.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -1,0 +1,71 @@
+"""Run all fd5 benchmarks and print a summary table."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from benchmarks import bench_create, bench_hash, bench_manifest, bench_validate
+
+HEADER = (
+    f"{'Benchmark':<24} {'Parameter':<14} {'Mean (s)':<12} "
+    f"{'StDev (s)':<12} {'Min (s)':<12} {'Max (s)':<12} {'Extra':<16}"
+)
+SEP = "-" * len(HEADER)
+
+
+def _extra(row: dict) -> str:
+    if "throughput_mb_s" in row:
+        return f"{row['throughput_mb_s']:.1f} MB/s"
+    if "per_file_ms" in row:
+        return f"{row['per_file_ms']:.2f} ms/file"
+    return ""
+
+
+def main() -> None:
+    wall_start = time.perf_counter()
+
+    print("Running fd5 benchmarks...\n")
+
+    all_results: list[dict] = []
+
+    modules = [
+        ("bench_create", bench_create),
+        ("bench_hash", bench_hash),
+        ("bench_validate", bench_validate),
+        ("bench_manifest", bench_manifest),
+    ]
+
+    for name, mod in modules:
+        print(f"  {name} ...", end=" ", flush=True)
+        t0 = time.perf_counter()
+        results = mod.run()
+        elapsed = time.perf_counter() - t0
+        print(f"done ({elapsed:.1f}s)")
+        all_results.extend(results)
+
+    wall_elapsed = time.perf_counter() - wall_start
+
+    print(f"\n{'=' * len(HEADER)}")
+    print("fd5 Benchmark Summary")
+    print(f"{'=' * len(HEADER)}\n")
+    print(HEADER)
+    print(SEP)
+
+    for row in all_results:
+        print(
+            f"{row['benchmark']:<24} "
+            f"{row['parameter']:<14} "
+            f"{row['mean_s']:<12.4f} "
+            f"{row['stdev_s']:<12.4f} "
+            f"{row['min_s']:<12.4f} "
+            f"{row['max_s']:<12.4f} "
+            f"{_extra(row):<16}"
+        )
+
+    print(SEP)
+    print(f"\nTotal wall time: {wall_elapsed:.1f}s")
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
## Summary

- Add `benchmarks/` directory with standalone Python timing scripts for fd5 core operations: `create`, `validate`/`verify`, `compute_content_hash`, and `build_manifest`.
- Each script (`bench_create.py`, `bench_validate.py`, `bench_hash.py`, `bench_manifest.py`) prints structured timing results and exposes a `run()` function for programmatic use.
- `run_all.py` orchestrates all benchmarks and produces a summary table with mean, stdev, min, max, and throughput/per-file metrics.

## Test plan

- [x] `python -m benchmarks.bench_create` — completes, prints timing table for 1/10/100 MB
- [x] `python -m benchmarks.bench_hash` — completes, prints timing table with MB/s throughput
- [x] `python -m benchmarks.bench_validate` — completes, prints schema.validate + hash.verify timings
- [x] `python -m benchmarks.bench_manifest` — completes, prints timing table with ms/file metric
- [x] `python -m benchmarks.run_all` — runs all benchmarks, prints combined summary table

Resolves #90

Made with [Cursor](https://cursor.com)