### PR TITLE
feat(tests): add testing and benchmarking commands to justfile

### DIFF
--- a/benchmarks/bench_create.py
+++ b/benchmarks/bench_create.py
@@ -10,11 +10,10 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-
 from fd5.create import create
 from fd5.registry import register_schema
 
-SIZES_MB = [1, 10, 100]
+SIZES_MB = [1, 10, 100, 1000]
 REPEATS = 3
 FLOAT32_BYTES = 4
 

--- a/benchmarks/bench_hash.py
+++ b/benchmarks/bench_hash.py
@@ -10,10 +10,9 @@ from typing import Any
 
 import h5py
 import numpy as np
-
 from fd5.hash import compute_content_hash
 
-SIZES_MB = [1, 10, 100]
+SIZES_MB = [1, 10, 100, 1000]
 REPEATS = 5
 FLOAT32_BYTES = 4
 

--- a/justfile.project
+++ b/justfile.project
@@ -19,6 +19,45 @@ info:
     @echo "Project: {{ project }}"
 
 # ===============================================================================
+# TESTING
+# ===============================================================================
+
+# Run all tests (alias for test-pytest)
+[group('test')]
+test *args:
+    just test-pytest {{ args }}
+
+# Run a single test file by short name (e.g. just test-one recon)
+[group('test')]
+test-one name *args:
+    uv run pytest tests/test_{{ name }}.py -v {{ args }}
+
+# Run only integration tests
+[group('test')]
+test-integration *args:
+    uv run pytest tests/test_integration.py -v {{ args }}
+
+# Run tests matching a keyword expression (pytest -k)
+[group('test')]
+test-k expr *args:
+    uv run pytest -k "{{ expr }}" -v {{ args }}
+
+# Run tests that failed in the last run
+[group('test')]
+test-failed:
+    uv run pytest --lf -v
+
+# Run all benchmarks
+[group('bench')]
+bench:
+    uv run python -m benchmarks.run_all
+
+# Run a single benchmark by short name (e.g. just bench-one hash)
+[group('bench')]
+bench-one name:
+    uv run python -m benchmarks.bench_{{ name }}
+
+# ===============================================================================
 # PROJECT-SPECIFIC RECIPES
 # ===============================================================================
 # Uncomment and customize for your project:

--- a/src/fd5/cli.py
+++ b/src/fd5/cli.py
@@ -11,15 +11,15 @@ import h5py
 
 from fd5.hash import verify
 from fd5.manifest import write_manifest
-from fd5.rocrate import write as write_rocrate
 from fd5.quality import check_descriptions
+from fd5.rocrate import write as write_rocrate
 from fd5.schema import dump_schema, validate
 
 
 @click.group()
 @click.version_option(package_name="fd5")
 def cli() -> None:
-    """fd5 – Fusion Data Format 5 toolkit."""
+    """fd5 – FAIR Data Format 5 toolkit."""
 
 
 @cli.command()
@@ -167,7 +167,6 @@ def migrate(source: str, output: str, target: int) -> None:
         sys.exit(1)
 
 
-
 @cli.command("datalad-register")
 @click.argument("file", type=click.Path(exists=True, dir_okay=False))
 @click.option(
@@ -200,7 +199,6 @@ def datalad_register(file: str, dataset: str | None) -> None:
     click.echo(f"  title: {metadata.get('title', 'N/A')}")
     click.echo(f"  product: {metadata.get('product', 'N/A')}")
     click.echo(f"  id: {metadata.get('id', 'N/A')}")
-
 
 
 @cli.command("check-descriptions")


### PR DESCRIPTION
## Summary

- Adds `just` recipes for running tests (`test`, `test-one`, `test-integration`, `test-k`, `test-failed`) and benchmarks (`bench`, `bench-one`) to `justfile.project`
- Extends benchmark sizes to include 1 GB tier
- Minor import sort and docstring fix in `cli.py`

Follows up on #90 / PR #104.

## Test plan

- [x] Verify `justfile.project` recipes parse correctly
- [x] Confirm no merge conflicts with `dev`

Made with [Cursor](https://cursor.com)