### PR TITLE
feat(ingest): add Loader protocol and shared helpers (#109)

### DIFF
--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,1 +1,5 @@
 """fd5.ingest — loader protocol and shared ingest helpers."""
+
+from fd5.ingest._base import Loader, discover_loaders, hash_source_files
+
+__all__ = ["Loader", "discover_loaders", "hash_source_files"]

--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,0 +1,1 @@
+"""fd5.ingest — loader protocol and shared ingest helpers."""

--- a/src/fd5/ingest/_base.py
+++ b/src/fd5/ingest/_base.py
@@ -1,0 +1,102 @@
+"""fd5.ingest._base — Loader protocol and shared ingest helpers.
+
+Defines the interface all format-specific loaders must implement and
+provides utility functions for source-file hashing and loader discovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from fd5._types import Fd5Path
+
+_READ_CHUNK = 1024 * 1024  # 1 MiB
+
+_EP_GROUP = "fd5.loaders"
+
+
+@runtime_checkable
+class Loader(Protocol):
+    """Protocol that all fd5 ingest loaders must satisfy."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        """Product types this loader can produce (e.g. ``['recon', 'listmode']``)."""
+        ...
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        """Read source data and produce a sealed fd5 file."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def hash_source_files(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    """Hash source files for ``provenance/original_files`` records.
+
+    Returns a list of dicts with keys ``path``, ``sha256``, and
+    ``size_bytes`` — matching the schema expected by
+    :func:`fd5.provenance.write_original_files`.
+    """
+    records: list[dict[str, Any]] = []
+    for p in paths:
+        p = Path(p)
+        h = hashlib.sha256()
+        size = 0
+        with p.open("rb") as fh:
+            while chunk := fh.read(_READ_CHUNK):
+                h.update(chunk)
+                size += len(chunk)
+        records.append(
+            {
+                "path": str(p),
+                "sha256": f"sha256:{h.hexdigest()}",
+                "size_bytes": size,
+            }
+        )
+    return records
+
+
+def _load_loader_entry_points() -> dict[str, Any]:
+    """Load callables from the ``fd5.loaders`` entry-point group."""
+    factories: dict[str, Any] = {}
+    for ep in importlib.metadata.entry_points(group=_EP_GROUP):
+        factories[ep.name] = ep.load()
+    return factories
+
+
+def discover_loaders() -> dict[str, Loader]:
+    """Discover available loaders based on installed optional deps.
+
+    Iterates over entry points in the ``fd5.loaders`` group.  Each entry
+    point should be a callable returning a :class:`Loader` instance.
+    Loaders whose dependencies are missing (``ImportError``) are silently
+    skipped.
+    """
+    factories = _load_loader_entry_points()
+    loaders: dict[str, Loader] = {}
+    for name, factory in factories.items():
+        try:
+            loader = factory()
+        except ImportError:
+            continue
+        if isinstance(loader, Loader):
+            loaders[name] = loader
+    return loaders

--- a/tests/test_ingest_base.py
+++ b/tests/test_ingest_base.py
@@ -9,7 +9,12 @@ from typing import Any
 import pytest
 
 from fd5._types import Fd5Path
-from fd5.ingest._base import Loader, discover_loaders, hash_source_files
+from fd5.ingest._base import (
+    Loader,
+    _load_loader_entry_points,
+    discover_loaders,
+    hash_source_files,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -203,3 +208,54 @@ class TestDiscoverLoaders:
         monkeypatch.setattr(base_mod, "_load_loader_entry_points", _fake_eps)
         result = discover_loaders()
         assert "broken" not in result
+
+    def test_valid_loader_discovered(self, monkeypatch):
+        """A factory returning a valid Loader is included in the result."""
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {"good": _ValidLoader},
+        )
+        result = discover_loaders()
+        assert "good" in result
+        assert isinstance(result["good"], Loader)
+
+    def test_non_loader_object_excluded(self, monkeypatch):
+        """If a factory returns something that isn't a Loader, skip it."""
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {"bad": lambda: object()},
+        )
+        result = discover_loaders()
+        assert "bad" not in result
+
+
+class TestLoadLoaderEntryPoints:
+    """_load_loader_entry_points reads the fd5.loaders entry-point group."""
+
+    def test_returns_dict(self):
+        result = _load_loader_entry_points()
+        assert isinstance(result, dict)
+
+    def test_loads_entry_point_callables(self, monkeypatch):
+        """Each entry point's .load() result is stored by name."""
+        import importlib.metadata
+        from unittest.mock import MagicMock
+
+        ep = MagicMock()
+        ep.name = "mock_loader"
+        ep.load.return_value = _ValidLoader
+
+        monkeypatch.setattr(
+            importlib.metadata,
+            "entry_points",
+            lambda group: [ep] if group == "fd5.loaders" else [],
+        )
+        result = _load_loader_entry_points()
+        assert "mock_loader" in result
+        assert result["mock_loader"] is _ValidLoader

--- a/tests/test_ingest_base.py
+++ b/tests/test_ingest_base.py
@@ -1,0 +1,205 @@
+"""Tests for fd5.ingest._base — Loader protocol and shared helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fd5._types import Fd5Path
+from fd5.ingest._base import Loader, discover_loaders, hash_source_files
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ValidLoader:
+    """Minimal concrete class satisfying the Loader protocol."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        return ["recon"]
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        return output_dir / "out.h5"
+
+
+class _MissingIngest:
+    """Has supported_product_types but no ingest method."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        return ["recon"]
+
+
+class _MissingProductTypes:
+    """Has ingest but no supported_product_types."""
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        return output_dir / "out.h5"
+
+
+# ---------------------------------------------------------------------------
+# Loader protocol
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderProtocol:
+    """Loader is a runtime_checkable Protocol."""
+
+    def test_valid_loader_is_instance(self):
+        assert isinstance(_ValidLoader(), Loader)
+
+    def test_missing_ingest_not_instance(self):
+        assert not isinstance(_MissingIngest(), Loader)
+
+    def test_missing_product_types_not_instance(self):
+        assert not isinstance(_MissingProductTypes(), Loader)
+
+    def test_protocol_requires_supported_product_types(self):
+        import inspect
+
+        members = {
+            name for name, _ in inspect.getmembers(Loader) if not name.startswith("_")
+        }
+        attrs = set(Loader.__protocol_attrs__)
+        assert (members | attrs) >= {"supported_product_types", "ingest"}
+
+    def test_plain_object_not_instance(self):
+        assert not isinstance(object(), Loader)
+
+
+# ---------------------------------------------------------------------------
+# hash_source_files
+# ---------------------------------------------------------------------------
+
+
+class TestHashSourceFiles:
+    """hash_source_files computes SHA-256 + size for provenance records."""
+
+    def test_single_file(self, tmp_path: Path):
+        p = tmp_path / "data.bin"
+        content = b"hello world"
+        p.write_bytes(content)
+
+        result = hash_source_files([p])
+
+        assert len(result) == 1
+        rec = result[0]
+        assert rec["path"] == str(p)
+        assert rec["sha256"] == f"sha256:{hashlib.sha256(content).hexdigest()}"
+        assert rec["size_bytes"] == len(content)
+
+    def test_multiple_files(self, tmp_path: Path):
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"file_{i}.dat"
+            p.write_bytes(f"content-{i}".encode())
+            paths.append(p)
+
+        result = hash_source_files(paths)
+        assert len(result) == 3
+        assert all(r["sha256"].startswith("sha256:") for r in result)
+
+    def test_empty_iterable(self):
+        result = hash_source_files([])
+        assert result == []
+
+    def test_large_file_chunked(self, tmp_path: Path):
+        """Hash must be correct even for files larger than a typical read buffer."""
+        p = tmp_path / "large.bin"
+        data = b"x" * (2 * 1024 * 1024)
+        p.write_bytes(data)
+
+        result = hash_source_files([p])
+        expected = f"sha256:{hashlib.sha256(data).hexdigest()}"
+        assert result[0]["sha256"] == expected
+
+    def test_record_keys(self, tmp_path: Path):
+        p = tmp_path / "keys.bin"
+        p.write_bytes(b"abc")
+
+        rec = hash_source_files([p])[0]
+        assert set(rec.keys()) == {"path", "sha256", "size_bytes"}
+
+    def test_size_bytes_is_int(self, tmp_path: Path):
+        p = tmp_path / "sz.bin"
+        p.write_bytes(b"12345")
+
+        rec = hash_source_files([p])[0]
+        assert isinstance(rec["size_bytes"], int)
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        missing = tmp_path / "no_such_file.bin"
+        with pytest.raises((FileNotFoundError, OSError)):
+            hash_source_files([missing])
+
+
+# ---------------------------------------------------------------------------
+# discover_loaders
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverLoaders:
+    """discover_loaders returns loaders whose optional deps are installed."""
+
+    def test_returns_dict(self):
+        result = discover_loaders()
+        assert isinstance(result, dict)
+
+    def test_values_satisfy_protocol(self):
+        for loader in discover_loaders().values():
+            assert isinstance(loader, Loader)
+
+    def test_keys_are_strings(self):
+        for key in discover_loaders():
+            assert isinstance(key, str)
+
+    def test_no_loaders_when_entry_points_empty(self, monkeypatch):
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {},
+        )
+        result = discover_loaders()
+        assert result == {}
+
+    def test_loader_with_missing_deps_excluded(self, monkeypatch):
+        """If a loader's entry point raises ImportError, it is skipped."""
+        import fd5.ingest._base as base_mod
+
+        def _fake_load():
+            raise ImportError("numpy not installed")
+
+        def _fake_eps():
+            return {"broken": _fake_load}
+
+        monkeypatch.setattr(base_mod, "_load_loader_entry_points", _fake_eps)
+        result = discover_loaders()
+        assert "broken" not in result


### PR DESCRIPTION
## Summary

- Define `Loader` runtime-checkable `Protocol` in `fd5.ingest._base` with `supported_product_types` property and `ingest()` method
- Implement `hash_source_files()` — computes SHA-256 + size for source file provenance records (chunked reads for large files)
- Implement `discover_loaders()` — discovers loaders from `fd5.loaders` entry-point group, skipping those with missing dependencies
- Re-export public API from `fd5.ingest.__init__`
- 21 tests covering protocol conformance, happy paths, edge cases, error paths, and entry-point discovery — 100% coverage on ingest module

## Test plan

- [x] `Loader` protocol: valid implementors pass `isinstance`, incomplete classes fail
- [x] `hash_source_files`: single file, multiple files, empty input, large files, missing files
- [x] `discover_loaders`: empty entry points, valid loaders included, broken loaders excluded, non-Loader objects excluded
- [x] Full test suite (995 tests) passes with no regressions

Refs: #109

Made with [Cursor](https://cursor.com)