### PR TITLE
feat(ingest): add raw/numpy array loader (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Raw/numpy array ingest loader** ([#112](https://github.com/vig-os/fd5/issues/112))
+  - `ingest_array()` wraps data dicts into sealed fd5 files for any registered product type
+  - `ingest_binary()` reads raw binary files with specified dtype/shape and records SHA-256 provenance
+  - `RawLoader` class implementing the `Loader` protocol
+  - `Loader` protocol and `hash_source_files()` helper in `fd5.ingest._base`
+
 - **HDF5 dict round-trip helpers** ([#12](https://github.com/vig-os/fd5/issues/12))
   - `dict_to_h5(group, d)` writes nested Python dicts as HDF5 attrs/sub-groups
   - `h5_to_dict(group)` reads HDF5 attrs and sub-groups back to a Python dict

--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""fd5.ingest — data ingest loaders for creating fd5 files from raw data."""
+
+from fd5.ingest._base import Loader, hash_source_files
+
+__all__ = ["Loader", "hash_source_files"]

--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,5 +1,12 @@
 """fd5.ingest — data ingest loaders for creating fd5 files from raw data."""
 
 from fd5.ingest._base import Loader, hash_source_files
+from fd5.ingest.raw import RawLoader, ingest_array, ingest_binary
 
-__all__ = ["Loader", "hash_source_files"]
+__all__ = [
+    "Loader",
+    "RawLoader",
+    "hash_source_files",
+    "ingest_array",
+    "ingest_binary",
+]

--- a/src/fd5/ingest/_base.py
+++ b/src/fd5/ingest/_base.py
@@ -1,0 +1,66 @@
+"""fd5.ingest._base — Loader protocol and shared ingest helpers.
+
+Defines the structural interface all format-specific loaders must satisfy
+and provides utilities for source file hashing (provenance tracking).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from fd5._types import Fd5Path
+
+_HASH_BUF_SIZE = 1 << 16  # 64 KiB
+
+
+@runtime_checkable
+class Loader(Protocol):
+    """Protocol that all fd5 ingest loaders must satisfy."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        """Product types this loader can produce."""
+        ...
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: object,
+    ) -> Fd5Path:
+        """Read source data and produce a sealed fd5 file."""
+        ...
+
+
+def hash_source_files(paths: Iterable[Path]) -> list[dict[str, str | int]]:
+    """Compute SHA-256 and file size for each path.
+
+    Returns a list of dicts suitable for
+    :func:`fd5.provenance.write_original_files`.
+
+    Raises:
+        FileNotFoundError: If any path does not exist.
+    """
+    records: list[dict[str, str | int]] = []
+    for p in paths:
+        p = Path(p)
+        sha = hashlib.sha256()
+        with p.open("rb") as fh:
+            while chunk := fh.read(_HASH_BUF_SIZE):
+                sha.update(chunk)
+        records.append(
+            {
+                "path": str(p),
+                "sha256": sha.hexdigest(),
+                "size_bytes": p.stat().st_size,
+            }
+        )
+    return records

--- a/src/fd5/ingest/raw.py
+++ b/src/fd5/ingest/raw.py
@@ -1,0 +1,186 @@
+"""fd5.ingest.raw — raw/numpy array loader.
+
+Wraps raw numpy arrays or binary files into sealed fd5 files.
+Serves as the reference Loader implementation and fallback when
+no format-specific loader is needed.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fd5._types import Fd5Path
+from fd5.create import create
+from fd5.ingest._base import hash_source_files
+from fd5.registry import list_schemas
+
+__all__ = ["RawLoader", "ingest_array", "ingest_binary"]
+
+_INGEST_TOOL = "fd5.ingest.raw"
+
+
+def _fd5_version() -> str:
+    try:
+        return importlib.metadata.version("fd5")
+    except importlib.metadata.PackageNotFoundError:
+        return "0.0.0"
+
+
+def ingest_array(
+    data: dict[str, Any],
+    output_dir: Path,
+    *,
+    product: str,
+    name: str,
+    description: str,
+    timestamp: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    study_metadata: dict[str, Any] | None = None,
+    sources: list[dict[str, Any]] | None = None,
+) -> Fd5Path:
+    """Wrap a data dict into a sealed fd5 file.
+
+    The data dict is passed directly to the product schema's ``write()`` method.
+
+    Returns:
+        Path to the sealed fd5 file.
+
+    Raises:
+        ValueError: If *product* is not a registered product type.
+    """
+    if timestamp is None:
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
+
+    output_dir = Path(output_dir)
+
+    with create(
+        output_dir,
+        product=product,
+        name=name,
+        description=description,
+        timestamp=timestamp,
+    ) as builder:
+        builder.write_product(data)
+
+        if metadata is not None:
+            builder.write_metadata(metadata)
+
+        if sources is not None:
+            builder.write_sources(sources)
+
+        if study_metadata is not None:
+            builder.write_study(**study_metadata)
+
+    sealed_files = sorted(output_dir.glob("*.h5"))
+    return sealed_files[-1]
+
+
+def ingest_binary(
+    binary_path: Path,
+    output_dir: Path,
+    *,
+    dtype: str,
+    shape: tuple[int, ...],
+    product: str,
+    name: str,
+    description: str,
+    timestamp: str | None = None,
+    **kwargs: Any,
+) -> Fd5Path:
+    """Read a raw binary file, reshape, and produce a sealed fd5 file.
+
+    The binary data is read via ``numpy.fromfile`` and reshaped to *shape*.
+    Provenance records the source file's SHA-256.
+
+    Additional keyword arguments are merged into the data dict passed to
+    the product schema's ``write()`` method.
+
+    Returns:
+        Path to the sealed fd5 file.
+
+    Raises:
+        FileNotFoundError: If *binary_path* does not exist.
+        ValueError: If the file size does not match *dtype* × *shape*.
+    """
+    binary_path = Path(binary_path)
+    if not binary_path.exists():
+        raise FileNotFoundError(f"Binary file not found: {binary_path}")
+
+    raw = np.fromfile(binary_path, dtype=dtype)
+    expected_size = 1
+    for s in shape:
+        expected_size *= s
+    if raw.size != expected_size:
+        msg = f"cannot reshape array of size {raw.size} into shape {shape}"
+        raise ValueError(msg)
+
+    arr = raw.reshape(shape)
+
+    prov_records = hash_source_files([binary_path])
+
+    if timestamp is None:
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
+
+    data: dict[str, Any] = {"volume": arr, "description": description}
+    data.update(kwargs)
+
+    output_dir = Path(output_dir)
+
+    with create(
+        output_dir,
+        product=product,
+        name=name,
+        description=description,
+        timestamp=timestamp,
+    ) as builder:
+        builder.write_product(data)
+        builder.write_provenance(
+            original_files=prov_records,
+            ingest_tool=_INGEST_TOOL,
+            ingest_version=_fd5_version(),
+            ingest_timestamp=timestamp,
+        )
+
+    sealed_files = sorted(output_dir.glob("*.h5"))
+    return sealed_files[-1]
+
+
+class RawLoader:
+    """Loader implementation for raw numpy arrays and binary files.
+
+    Satisfies the :class:`~fd5.ingest._base.Loader` protocol.
+    """
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        return list_schemas()
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        """Read a binary source file and produce a sealed fd5 file.
+
+        Requires ``dtype`` and ``shape`` in *kwargs*.
+        """
+        return ingest_binary(
+            Path(source),
+            output_dir,
+            product=product,
+            name=name,
+            description=description,
+            timestamp=timestamp,
+            **kwargs,
+        )

--- a/tests/test_ingest_base.py
+++ b/tests/test_ingest_base.py
@@ -1,0 +1,96 @@
+"""Tests for fd5.ingest._base module."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from fd5.ingest._base import Loader, hash_source_files
+
+
+class TestLoaderProtocol:
+    """Loader is a runtime-checkable Protocol."""
+
+    def test_protocol_is_runtime_checkable(self):
+        assert hasattr(Loader, "__protocol_attrs__")
+
+    def test_conforming_class_is_instance(self):
+        class _Good:
+            @property
+            def supported_product_types(self) -> list[str]:
+                return ["recon"]
+
+            def ingest(
+                self,
+                source,
+                output_dir,
+                *,
+                product,
+                name,
+                description,
+                timestamp=None,
+                **kwargs,
+            ):
+                return Path("out.h5")
+
+        assert isinstance(_Good(), Loader)
+
+    def test_non_conforming_class_is_not_instance(self):
+        class _Bad:
+            pass
+
+        assert not isinstance(_Bad(), Loader)
+
+
+class TestHashSourceFiles:
+    """Tests for hash_source_files()."""
+
+    def test_single_file(self, tmp_path: Path):
+        f = tmp_path / "data.bin"
+        content = b"hello world"
+        f.write_bytes(content)
+
+        result = hash_source_files([f])
+        assert len(result) == 1
+        rec = result[0]
+        assert rec["path"] == str(f)
+        assert rec["sha256"] == hashlib.sha256(content).hexdigest()
+        assert rec["size_bytes"] == len(content)
+
+    def test_multiple_files(self, tmp_path: Path):
+        files = []
+        for i in range(3):
+            p = tmp_path / f"file_{i}.bin"
+            p.write_bytes(bytes([i]) * (i + 1))
+            files.append(p)
+
+        result = hash_source_files(files)
+        assert len(result) == 3
+        for i, rec in enumerate(result):
+            assert rec["size_bytes"] == i + 1
+
+    def test_empty_iterable(self):
+        assert hash_source_files([]) == []
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        missing = tmp_path / "no_such_file.bin"
+        with pytest.raises(FileNotFoundError):
+            hash_source_files([missing])
+
+    def test_empty_file(self, tmp_path: Path):
+        f = tmp_path / "empty.bin"
+        f.write_bytes(b"")
+
+        result = hash_source_files([f])
+        assert result[0]["size_bytes"] == 0
+        assert result[0]["sha256"] == hashlib.sha256(b"").hexdigest()
+
+    def test_large_file_crosses_buffer_boundary(self, tmp_path: Path):
+        f = tmp_path / "large.bin"
+        content = b"x" * (1 << 17)  # 128 KiB > 64 KiB buffer
+        f.write_bytes(content)
+
+        result = hash_source_files([f])
+        assert result[0]["sha256"] == hashlib.sha256(content).hexdigest()

--- a/tests/test_ingest_raw.py
+++ b/tests/test_ingest_raw.py
@@ -1,0 +1,328 @@
+"""Tests for fd5.ingest.raw module."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytest
+
+from fd5.imaging.recon import ReconSchema
+from fd5.imaging.sinogram import SinogramSchema
+from fd5.registry import register_schema
+
+
+@pytest.fixture(autouse=True)
+def _register_schemas():
+    register_schema("recon", ReconSchema())
+    register_schema("sinogram", SinogramSchema())
+
+
+def _recon_data(shape: tuple[int, ...] = (8, 16, 16)) -> dict[str, Any]:
+    return {
+        "volume": np.random.default_rng(42).random(shape, dtype=np.float32),
+        "affine": np.eye(4, dtype=np.float64),
+        "dimension_order": "ZYX",
+        "reference_frame": "LPS",
+        "description": "Test recon volume",
+    }
+
+
+def _sinogram_data() -> dict[str, Any]:
+    n_planes, n_angular, n_radial = 5, 12, 16
+    return {
+        "sinogram": np.random.default_rng(7).random(
+            (n_planes, n_angular, n_radial), dtype=np.float32
+        ),
+        "n_radial": n_radial,
+        "n_angular": n_angular,
+        "n_planes": n_planes,
+        "span": 3,
+        "max_ring_diff": 2,
+        "tof_bins": 0,
+    }
+
+
+class TestIngestArray:
+    """Tests for ingest_array()."""
+
+    def test_produces_sealed_recon_file(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        result = ingest_array(
+            _recon_data(),
+            tmp_path,
+            product="recon",
+            name="test-recon",
+            description="A test recon file",
+            timestamp="2025-01-01T00:00:00+00:00",
+        )
+
+        assert result.exists()
+        assert result.suffix == ".h5"
+        with h5py.File(result, "r") as f:
+            assert f.attrs["product"] == "recon"
+            assert f.attrs["name"] == "test-recon"
+            assert "content_hash" in f.attrs
+            assert "id" in f.attrs
+            assert "_schema" in f.attrs
+            assert "volume" in f
+
+    def test_writes_metadata(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        metadata = {"scanner": "test-scanner", "vendor_series_id": "S001"}
+        result = ingest_array(
+            _recon_data(),
+            tmp_path,
+            product="recon",
+            name="test-meta",
+            description="Metadata test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            metadata=metadata,
+        )
+
+        with h5py.File(result, "r") as f:
+            assert "metadata" in f
+            assert f["metadata"].attrs["scanner"] == "test-scanner"
+
+    def test_writes_sources(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        sources = [
+            {
+                "name": "src0",
+                "id": "abc",
+                "product": "raw",
+                "file": "source.h5",
+                "content_hash": "sha256:deadbeef",
+                "role": "input",
+                "description": "test source",
+            }
+        ]
+        result = ingest_array(
+            _recon_data(),
+            tmp_path,
+            product="recon",
+            name="test-src",
+            description="Sources test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            sources=sources,
+        )
+
+        with h5py.File(result, "r") as f:
+            assert "sources" in f
+
+    def test_writes_study_metadata(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        study = {
+            "study_type": "clinical",
+            "license": "CC-BY-4.0",
+            "description": "Test study",
+        }
+        result = ingest_array(
+            _recon_data(),
+            tmp_path,
+            product="recon",
+            name="test-study",
+            description="Study test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            study_metadata=study,
+        )
+
+        with h5py.File(result, "r") as f:
+            assert "study" in f
+            assert f["study"].attrs["study_type"] == "clinical"
+
+    def test_default_timestamp(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        result = ingest_array(
+            _recon_data(),
+            tmp_path,
+            product="recon",
+            name="test-ts",
+            description="Default timestamp test",
+        )
+
+        assert result.exists()
+        with h5py.File(result, "r") as f:
+            ts = f.attrs["timestamp"]
+            assert len(ts) > 0
+
+    def test_unknown_product_raises(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        with pytest.raises(ValueError, match="no-such-product"):
+            ingest_array(
+                {},
+                tmp_path,
+                product="no-such-product",
+                name="bad",
+                description="Should fail",
+            )
+
+    def test_sinogram_product(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_array
+
+        result = ingest_array(
+            _sinogram_data(),
+            tmp_path,
+            product="sinogram",
+            name="test-sino",
+            description="A test sinogram",
+            timestamp="2025-01-01T00:00:00+00:00",
+        )
+
+        assert result.exists()
+        with h5py.File(result, "r") as f:
+            assert f.attrs["product"] == "sinogram"
+            assert "sinogram" in f
+
+
+class TestIngestBinary:
+    """Tests for ingest_binary()."""
+
+    def _write_binary(self, path: Path, arr: np.ndarray) -> None:
+        arr.tofile(path)
+
+    def test_reads_binary_and_produces_fd5(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_binary
+
+        shape = (8, 16, 16)
+        arr = np.random.default_rng(99).random(shape, dtype=np.float32)
+        bin_path = tmp_path / "volume.bin"
+        self._write_binary(bin_path, arr)
+
+        out_dir = tmp_path / "output"
+        result = ingest_binary(
+            bin_path,
+            out_dir,
+            dtype="float32",
+            shape=shape,
+            product="recon",
+            name="test-binary",
+            description="Binary ingest test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            affine=np.eye(4, dtype=np.float64),
+            dimension_order="ZYX",
+            reference_frame="LPS",
+        )
+
+        assert result.exists()
+        with h5py.File(result, "r") as f:
+            assert f.attrs["product"] == "recon"
+            read_vol = f["volume"][:]
+            np.testing.assert_array_almost_equal(read_vol, arr)
+
+    def test_records_provenance_sha256(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_binary
+
+        shape = (4, 8, 8)
+        arr = np.ones(shape, dtype=np.float32)
+        bin_path = tmp_path / "ones.bin"
+        self._write_binary(bin_path, arr)
+
+        out_dir = tmp_path / "output"
+        result = ingest_binary(
+            bin_path,
+            out_dir,
+            dtype="float32",
+            shape=shape,
+            product="recon",
+            name="test-prov",
+            description="Provenance test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            affine=np.eye(4, dtype=np.float64),
+            dimension_order="ZYX",
+            reference_frame="LPS",
+        )
+
+        expected_sha = hashlib.sha256(bin_path.read_bytes()).hexdigest()
+        with h5py.File(result, "r") as f:
+            assert "provenance" in f
+            assert "original_files" in f["provenance"]
+            rec = f["provenance"]["original_files"][0]
+            assert rec["sha256"].decode() == expected_sha
+
+    def test_nonexistent_binary_raises(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_binary
+
+        with pytest.raises(FileNotFoundError):
+            ingest_binary(
+                tmp_path / "missing.bin",
+                tmp_path / "output",
+                dtype="float32",
+                shape=(4, 4, 4),
+                product="recon",
+                name="bad",
+                description="Should fail",
+            )
+
+    def test_shape_mismatch_raises(self, tmp_path: Path):
+        from fd5.ingest.raw import ingest_binary
+
+        arr = np.ones((4, 4, 4), dtype=np.float32)
+        bin_path = tmp_path / "small.bin"
+        self._write_binary(bin_path, arr)
+
+        with pytest.raises(ValueError, match="cannot reshape"):
+            ingest_binary(
+                bin_path,
+                tmp_path / "output",
+                dtype="float32",
+                shape=(100, 100, 100),
+                product="recon",
+                name="bad",
+                description="Should fail",
+            )
+
+
+class TestRawLoader:
+    """Tests for RawLoader protocol conformance."""
+
+    def test_satisfies_loader_protocol(self):
+        from fd5.ingest._base import Loader
+        from fd5.ingest.raw import RawLoader
+
+        loader = RawLoader()
+        assert isinstance(loader, Loader)
+
+    def test_supported_product_types(self):
+        from fd5.ingest.raw import RawLoader
+
+        loader = RawLoader()
+        types = loader.supported_product_types
+        assert isinstance(types, list)
+        assert "recon" in types
+
+    def test_ingest_produces_file(self, tmp_path: Path):
+        from fd5.ingest.raw import RawLoader
+
+        data_path = tmp_path / "data.bin"
+        arr = np.random.default_rng(1).random((4, 8, 8), dtype=np.float32)
+        arr.tofile(data_path)
+
+        out_dir = tmp_path / "output"
+        loader = RawLoader()
+        result = loader.ingest(
+            data_path,
+            out_dir,
+            product="recon",
+            name="loader-test",
+            description="RawLoader test",
+            timestamp="2025-01-01T00:00:00+00:00",
+            dtype="float32",
+            shape=(4, 8, 8),
+            affine=np.eye(4, dtype=np.float64),
+            dimension_order="ZYX",
+            reference_frame="LPS",
+        )
+
+        assert result.exists()
+        with h5py.File(result, "r") as f:
+            assert f.attrs["product"] == "recon"

--- a/tests/test_ingest_raw.py
+++ b/tests/test_ingest_raw.py
@@ -136,7 +136,7 @@ class TestIngestArray:
 
         with h5py.File(result, "r") as f:
             assert "study" in f
-            assert f["study"].attrs["study_type"] == "clinical"
+            assert f["study"].attrs["type"] == "clinical"
 
     def test_default_timestamp(self, tmp_path: Path):
         from fd5.ingest.raw import ingest_array


### PR DESCRIPTION
## Description

Implement `fd5.ingest.raw` — a loader that wraps raw numpy arrays or binary files into sealed fd5 files. This is the simplest loader and serves as the reference implementation of the `Loader` protocol. Also creates the `fd5.ingest` package with the `Loader` protocol and `hash_source_files()` helper (`_base.py`), which is a subset of #109.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `src/fd5/ingest/__init__.py` — New package init, re-exports public API (`Loader`, `RawLoader`, `ingest_array`, `ingest_binary`, `hash_source_files`)
- `src/fd5/ingest/_base.py` — `Loader` protocol (runtime_checkable) and `hash_source_files()` helper for provenance tracking
- `src/fd5/ingest/raw.py` — `ingest_array()` wraps data dicts into sealed fd5 files via `fd5.create()`, `ingest_binary()` reads raw binary files with dtype/shape and records SHA-256 provenance, `RawLoader` class implements the `Loader` protocol
- `tests/test_ingest_base.py` — 9 tests covering `Loader` protocol conformance and `hash_source_files()` edge cases
- `tests/test_ingest_raw.py` — 14 tests covering `ingest_array` (recon + sinogram), `ingest_binary` (provenance, errors), and `RawLoader` protocol
- `CHANGELOG.md` — Added entry under `## Unreleased`

## Changelog Entry

### Added

- **Raw/numpy array ingest loader** ([#112](https://github.com/vig-os/fd5/issues/112))
  - `ingest_array()` wraps data dicts into sealed fd5 files for any registered product type
  - `ingest_binary()` reads raw binary files with specified dtype/shape and records SHA-256 provenance
  - `RawLoader` class implementing the `Loader` protocol
  - `Loader` protocol and `hash_source_files()` helper in `fd5.ingest._base`

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR creates the `fd5.ingest` package which partially implements #109 (`_base.py` with `Loader` protocol and `hash_source_files`). The `discover_loaders()` helper from #109 is intentionally omitted — it will be added when #109 is fully implemented.

Refs: #112
