### PR TITLE
feat(ingest): add RO-Crate and DataCite metadata import

### DIFF
--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,5 +1,17 @@
-"""fd5.ingest — loader protocol and shared ingest helpers."""
+"""fd5.ingest — loader protocol, shared ingest helpers, and metadata import."""
 
 from fd5.ingest._base import Loader, discover_loaders, hash_source_files
+from fd5.ingest.metadata import (
+    load_datacite_metadata,
+    load_metadata,
+    load_rocrate_metadata,
+)
 
-__all__ = ["Loader", "discover_loaders", "hash_source_files"]
+__all__ = [
+    "Loader",
+    "discover_loaders",
+    "hash_source_files",
+    "load_datacite_metadata",
+    "load_metadata",
+    "load_rocrate_metadata",
+]

--- a/src/fd5/ingest/__init__.py
+++ b/src/fd5/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""fd5.ingest — loader protocol and shared ingest helpers."""
+
+from fd5.ingest._base import Loader, discover_loaders, hash_source_files
+
+__all__ = ["Loader", "discover_loaders", "hash_source_files"]

--- a/src/fd5/ingest/_base.py
+++ b/src/fd5/ingest/_base.py
@@ -1,0 +1,102 @@
+"""fd5.ingest._base — Loader protocol and shared ingest helpers.
+
+Defines the interface all format-specific loaders must implement and
+provides utility functions for source-file hashing and loader discovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from fd5._types import Fd5Path
+
+_READ_CHUNK = 1024 * 1024  # 1 MiB
+
+_EP_GROUP = "fd5.loaders"
+
+
+@runtime_checkable
+class Loader(Protocol):
+    """Protocol that all fd5 ingest loaders must satisfy."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        """Product types this loader can produce (e.g. ``['recon', 'listmode']``)."""
+        ...
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        """Read source data and produce a sealed fd5 file."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def hash_source_files(paths: Iterable[Path]) -> list[dict[str, Any]]:
+    """Hash source files for ``provenance/original_files`` records.
+
+    Returns a list of dicts with keys ``path``, ``sha256``, and
+    ``size_bytes`` — matching the schema expected by
+    :func:`fd5.provenance.write_original_files`.
+    """
+    records: list[dict[str, Any]] = []
+    for p in paths:
+        p = Path(p)
+        h = hashlib.sha256()
+        size = 0
+        with p.open("rb") as fh:
+            while chunk := fh.read(_READ_CHUNK):
+                h.update(chunk)
+                size += len(chunk)
+        records.append(
+            {
+                "path": str(p),
+                "sha256": f"sha256:{h.hexdigest()}",
+                "size_bytes": size,
+            }
+        )
+    return records
+
+
+def _load_loader_entry_points() -> dict[str, Any]:
+    """Load callables from the ``fd5.loaders`` entry-point group."""
+    factories: dict[str, Any] = {}
+    for ep in importlib.metadata.entry_points(group=_EP_GROUP):
+        factories[ep.name] = ep.load()
+    return factories
+
+
+def discover_loaders() -> dict[str, Loader]:
+    """Discover available loaders based on installed optional deps.
+
+    Iterates over entry points in the ``fd5.loaders`` group.  Each entry
+    point should be a callable returning a :class:`Loader` instance.
+    Loaders whose dependencies are missing (``ImportError``) are silently
+    skipped.
+    """
+    factories = _load_loader_entry_points()
+    loaders: dict[str, Loader] = {}
+    for name, factory in factories.items():
+        try:
+            loader = factory()
+        except ImportError:
+            continue
+        if isinstance(loader, Loader):
+            loaders[name] = loader
+    return loaders

--- a/src/fd5/ingest/metadata.py
+++ b/src/fd5/ingest/metadata.py
@@ -1,0 +1,151 @@
+"""fd5.ingest.metadata — RO-Crate and DataCite metadata import.
+
+Reads existing metadata files (RO-Crate JSON-LD, DataCite YAML, or
+generic structured metadata) and returns dicts suitable for
+:meth:`fd5.create.Fd5Builder.write_study`.
+
+This is the *inverse* of :mod:`fd5.rocrate` and :mod:`fd5.datacite`
+exports: instead of generating metadata from fd5 files, we consume
+external metadata to populate fd5 files during ingest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_rocrate_metadata(rocrate_path: Path) -> dict[str, Any]:
+    """Extract fd5-compatible study metadata from an RO-Crate JSON-LD file.
+
+    Returns a dict with possible keys: ``name``, ``license``,
+    ``description``, ``creators``.  Missing fields in the source are
+    omitted (no ``KeyError``).
+    """
+    rocrate_path = Path(rocrate_path)
+    crate = json.loads(rocrate_path.read_text(encoding="utf-8"))
+
+    dataset = _find_rocrate_dataset(crate)
+    if dataset is None:
+        return {}
+
+    result: dict[str, Any] = {}
+
+    if "name" in dataset:
+        result["name"] = dataset["name"]
+    if "license" in dataset:
+        result["license"] = dataset["license"]
+    if "description" in dataset:
+        result["description"] = dataset["description"]
+
+    creators = _extract_rocrate_creators(dataset)
+    if creators:
+        result["creators"] = creators
+
+    return result
+
+
+def load_datacite_metadata(datacite_path: Path) -> dict[str, Any]:
+    """Extract fd5-compatible study metadata from a DataCite YAML file.
+
+    Returns a dict with possible keys: ``name``, ``creators``,
+    ``dates``, ``subjects``.  Missing fields in the source are omitted.
+    """
+    datacite_path = Path(datacite_path)
+    data = yaml.safe_load(datacite_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return {}
+
+    result: dict[str, Any] = {}
+
+    if "title" in data:
+        result["name"] = data["title"]
+
+    creators = data.get("creators")
+    if creators:
+        result["creators"] = [_normalise_datacite_creator(c) for c in creators]
+
+    dates = data.get("dates")
+    if dates:
+        result["dates"] = dates
+
+    subjects = data.get("subjects")
+    if subjects:
+        result["subjects"] = subjects
+
+    return result
+
+
+def load_metadata(path: Path) -> dict[str, Any]:
+    """Auto-detect metadata format and extract fd5-compatible metadata.
+
+    Detection is filename-based:
+    - ``ro-crate-metadata.json`` → RO-Crate
+    - ``datacite.yml`` / ``datacite.yaml`` → DataCite
+    - other ``.json`` → generic JSON pass-through
+    - other ``.yml`` / ``.yaml`` → generic YAML pass-through
+
+    Raises :class:`ValueError` for unsupported extensions and
+    :class:`FileNotFoundError` for missing files.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    if path.name == "ro-crate-metadata.json":
+        return load_rocrate_metadata(path)
+
+    if path.name in {"datacite.yml", "datacite.yaml"}:
+        return load_datacite_metadata(path)
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(path.read_text(encoding="utf-8"))
+    if suffix in {".yml", ".yaml"}:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    msg = f"Unsupported metadata format: {path.name}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_rocrate_dataset(crate: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the root Dataset entity from an RO-Crate ``@graph``."""
+    for entity in crate.get("@graph", []):
+        if entity.get("@id") == "./" and entity.get("@type") == "Dataset":
+            return entity
+    return None
+
+
+def _extract_rocrate_creators(
+    dataset: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Convert RO-Crate ``author`` Person entities to fd5 creator dicts."""
+    authors = dataset.get("author")
+    if not authors:
+        return []
+
+    creators: list[dict[str, Any]] = []
+    for person in authors:
+        creator: dict[str, Any] = {"name": person["name"]}
+        if "affiliation" in person:
+            creator["affiliation"] = person["affiliation"]
+        if "@id" in person and person["@id"].startswith("https://orcid.org/"):
+            creator["orcid"] = person["@id"]
+        creators.append(creator)
+    return creators
+
+
+def _normalise_datacite_creator(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalise a single DataCite creator entry."""
+    result: dict[str, Any] = {"name": raw["name"]}
+    if "affiliation" in raw:
+        result["affiliation"] = raw["affiliation"]
+    return result

--- a/tests/test_ingest_base.py
+++ b/tests/test_ingest_base.py
@@ -1,0 +1,261 @@
+"""Tests for fd5.ingest._base — Loader protocol and shared helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fd5._types import Fd5Path
+from fd5.ingest._base import (
+    Loader,
+    _load_loader_entry_points,
+    discover_loaders,
+    hash_source_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ValidLoader:
+    """Minimal concrete class satisfying the Loader protocol."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        return ["recon"]
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        return output_dir / "out.h5"
+
+
+class _MissingIngest:
+    """Has supported_product_types but no ingest method."""
+
+    @property
+    def supported_product_types(self) -> list[str]:
+        return ["recon"]
+
+
+class _MissingProductTypes:
+    """Has ingest but no supported_product_types."""
+
+    def ingest(
+        self,
+        source: Path | str,
+        output_dir: Path,
+        *,
+        product: str,
+        name: str,
+        description: str,
+        timestamp: str | None = None,
+        **kwargs: Any,
+    ) -> Fd5Path:
+        return output_dir / "out.h5"
+
+
+# ---------------------------------------------------------------------------
+# Loader protocol
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderProtocol:
+    """Loader is a runtime_checkable Protocol."""
+
+    def test_valid_loader_is_instance(self):
+        assert isinstance(_ValidLoader(), Loader)
+
+    def test_missing_ingest_not_instance(self):
+        assert not isinstance(_MissingIngest(), Loader)
+
+    def test_missing_product_types_not_instance(self):
+        assert not isinstance(_MissingProductTypes(), Loader)
+
+    def test_protocol_requires_supported_product_types(self):
+        import inspect
+
+        members = {
+            name for name, _ in inspect.getmembers(Loader) if not name.startswith("_")
+        }
+        attrs = set(Loader.__protocol_attrs__)
+        assert (members | attrs) >= {"supported_product_types", "ingest"}
+
+    def test_plain_object_not_instance(self):
+        assert not isinstance(object(), Loader)
+
+
+# ---------------------------------------------------------------------------
+# hash_source_files
+# ---------------------------------------------------------------------------
+
+
+class TestHashSourceFiles:
+    """hash_source_files computes SHA-256 + size for provenance records."""
+
+    def test_single_file(self, tmp_path: Path):
+        p = tmp_path / "data.bin"
+        content = b"hello world"
+        p.write_bytes(content)
+
+        result = hash_source_files([p])
+
+        assert len(result) == 1
+        rec = result[0]
+        assert rec["path"] == str(p)
+        assert rec["sha256"] == f"sha256:{hashlib.sha256(content).hexdigest()}"
+        assert rec["size_bytes"] == len(content)
+
+    def test_multiple_files(self, tmp_path: Path):
+        paths = []
+        for i in range(3):
+            p = tmp_path / f"file_{i}.dat"
+            p.write_bytes(f"content-{i}".encode())
+            paths.append(p)
+
+        result = hash_source_files(paths)
+        assert len(result) == 3
+        assert all(r["sha256"].startswith("sha256:") for r in result)
+
+    def test_empty_iterable(self):
+        result = hash_source_files([])
+        assert result == []
+
+    def test_large_file_chunked(self, tmp_path: Path):
+        """Hash must be correct even for files larger than a typical read buffer."""
+        p = tmp_path / "large.bin"
+        data = b"x" * (2 * 1024 * 1024)
+        p.write_bytes(data)
+
+        result = hash_source_files([p])
+        expected = f"sha256:{hashlib.sha256(data).hexdigest()}"
+        assert result[0]["sha256"] == expected
+
+    def test_record_keys(self, tmp_path: Path):
+        p = tmp_path / "keys.bin"
+        p.write_bytes(b"abc")
+
+        rec = hash_source_files([p])[0]
+        assert set(rec.keys()) == {"path", "sha256", "size_bytes"}
+
+    def test_size_bytes_is_int(self, tmp_path: Path):
+        p = tmp_path / "sz.bin"
+        p.write_bytes(b"12345")
+
+        rec = hash_source_files([p])[0]
+        assert isinstance(rec["size_bytes"], int)
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        missing = tmp_path / "no_such_file.bin"
+        with pytest.raises((FileNotFoundError, OSError)):
+            hash_source_files([missing])
+
+
+# ---------------------------------------------------------------------------
+# discover_loaders
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverLoaders:
+    """discover_loaders returns loaders whose optional deps are installed."""
+
+    def test_returns_dict(self):
+        result = discover_loaders()
+        assert isinstance(result, dict)
+
+    def test_values_satisfy_protocol(self):
+        for loader in discover_loaders().values():
+            assert isinstance(loader, Loader)
+
+    def test_keys_are_strings(self):
+        for key in discover_loaders():
+            assert isinstance(key, str)
+
+    def test_no_loaders_when_entry_points_empty(self, monkeypatch):
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {},
+        )
+        result = discover_loaders()
+        assert result == {}
+
+    def test_loader_with_missing_deps_excluded(self, monkeypatch):
+        """If a loader's entry point raises ImportError, it is skipped."""
+        import fd5.ingest._base as base_mod
+
+        def _fake_load():
+            raise ImportError("numpy not installed")
+
+        def _fake_eps():
+            return {"broken": _fake_load}
+
+        monkeypatch.setattr(base_mod, "_load_loader_entry_points", _fake_eps)
+        result = discover_loaders()
+        assert "broken" not in result
+
+    def test_valid_loader_discovered(self, monkeypatch):
+        """A factory returning a valid Loader is included in the result."""
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {"good": _ValidLoader},
+        )
+        result = discover_loaders()
+        assert "good" in result
+        assert isinstance(result["good"], Loader)
+
+    def test_non_loader_object_excluded(self, monkeypatch):
+        """If a factory returns something that isn't a Loader, skip it."""
+        import fd5.ingest._base as base_mod
+
+        monkeypatch.setattr(
+            base_mod,
+            "_load_loader_entry_points",
+            lambda: {"bad": lambda: object()},
+        )
+        result = discover_loaders()
+        assert "bad" not in result
+
+
+class TestLoadLoaderEntryPoints:
+    """_load_loader_entry_points reads the fd5.loaders entry-point group."""
+
+    def test_returns_dict(self):
+        result = _load_loader_entry_points()
+        assert isinstance(result, dict)
+
+    def test_loads_entry_point_callables(self, monkeypatch):
+        """Each entry point's .load() result is stored by name."""
+        import importlib.metadata
+        from unittest.mock import MagicMock
+
+        ep = MagicMock()
+        ep.name = "mock_loader"
+        ep.load.return_value = _ValidLoader
+
+        monkeypatch.setattr(
+            importlib.metadata,
+            "entry_points",
+            lambda group: [ep] if group == "fd5.loaders" else [],
+        )
+        result = _load_loader_entry_points()
+        assert "mock_loader" in result
+        assert result["mock_loader"] is _ValidLoader

--- a/tests/test_ingest_metadata.py
+++ b/tests/test_ingest_metadata.py
@@ -1,0 +1,365 @@
+"""Tests for fd5.ingest.metadata — RO-Crate and DataCite metadata import."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from fd5.ingest.metadata import (
+    load_datacite_metadata,
+    load_metadata,
+    load_rocrate_metadata,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic RO-Crate fixtures
+# ---------------------------------------------------------------------------
+
+ROCRATE_FULL: dict[str, Any] = {
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {"@id": "./"},
+            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "DOGPLET DD01",
+            "license": "CC-BY-4.0",
+            "description": "Full PET dataset",
+            "author": [
+                {
+                    "@type": "Person",
+                    "name": "Jane Doe",
+                    "affiliation": "ETH Zurich",
+                    "@id": "https://orcid.org/0000-0002-1234-5678",
+                },
+                {
+                    "@type": "Person",
+                    "name": "John Smith",
+                    "affiliation": "MIT",
+                },
+            ],
+        },
+    ],
+}
+
+ROCRATE_MINIMAL: dict[str, Any] = {
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {"@id": "./"},
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "Minimal Dataset",
+        },
+    ],
+}
+
+ROCRATE_NO_DATASET: dict[str, Any] = {
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {"@id": "./"},
+        },
+    ],
+}
+
+
+def _write_rocrate(path: Path, data: dict[str, Any]) -> Path:
+    out = path / "ro-crate-metadata.json"
+    out.write_text(json.dumps(data, indent=2))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Synthetic DataCite fixtures
+# ---------------------------------------------------------------------------
+
+DATACITE_FULL: dict[str, Any] = {
+    "title": "DOGPLET DD01",
+    "creators": [
+        {"name": "Jane Doe", "affiliation": "ETH Zurich"},
+        {"name": "John Smith", "affiliation": "MIT"},
+    ],
+    "dates": [
+        {"date": "2024-07-24", "dateType": "Collected"},
+    ],
+    "subjects": [
+        {"subject": "FDG", "subjectScheme": "Radiotracer"},
+    ],
+    "resourceType": "Dataset",
+}
+
+DATACITE_MINIMAL: dict[str, Any] = {
+    "title": "Minimal",
+}
+
+
+def _write_datacite(path: Path, data: dict[str, Any]) -> Path:
+    out = path / "datacite.yml"
+    out.write_text(yaml.dump(data, default_flow_style=False))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# load_rocrate_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRocrateMetadata:
+    def test_extracts_name(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        assert result["name"] == "DOGPLET DD01"
+
+    def test_extracts_license(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        assert result["license"] == "CC-BY-4.0"
+
+    def test_extracts_description(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        assert result["description"] == "Full PET dataset"
+
+    def test_extracts_creators(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        creators = result["creators"]
+        assert len(creators) == 2
+        assert creators[0]["name"] == "Jane Doe"
+        assert creators[0]["affiliation"] == "ETH Zurich"
+        assert creators[0]["orcid"] == "https://orcid.org/0000-0002-1234-5678"
+
+    def test_creator_without_orcid(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        john = result["creators"][1]
+        assert john["name"] == "John Smith"
+        assert "orcid" not in john
+
+    def test_creator_without_affiliation(self, tmp_path: Path):
+        crate = {
+            "@context": "https://w3id.org/ro/crate/1.2/context",
+            "@graph": [
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Test",
+                    "author": [{"@type": "Person", "name": "Solo Dev"}],
+                },
+            ],
+        }
+        f = _write_rocrate(tmp_path, crate)
+        result = load_rocrate_metadata(f)
+        assert result["creators"][0]["name"] == "Solo Dev"
+        assert "affiliation" not in result["creators"][0]
+
+    def test_missing_license_absent_key(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_MINIMAL)
+        result = load_rocrate_metadata(f)
+        assert "license" not in result
+
+    def test_missing_description_absent_key(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_MINIMAL)
+        result = load_rocrate_metadata(f)
+        assert "description" not in result
+
+    def test_missing_authors_absent_creators(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_MINIMAL)
+        result = load_rocrate_metadata(f)
+        assert "creators" not in result
+
+    def test_no_dataset_entity_returns_empty(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_NO_DATASET)
+        result = load_rocrate_metadata(f)
+        assert result == {}
+
+    def test_returns_dict(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        assert isinstance(result, dict)
+
+    def test_result_usable_with_write_study(self, tmp_path: Path):
+        """Returned dict keys should match builder.write_study() parameters."""
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        allowed = {"study_type", "license", "name", "description", "creators"}
+        assert set(result.keys()) <= allowed
+
+    def test_study_type_not_set(self, tmp_path: Path):
+        """RO-Crate doesn't map to study_type, so key should be absent."""
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_rocrate_metadata(f)
+        assert "study_type" not in result
+
+    def test_empty_author_list(self, tmp_path: Path):
+        crate = {
+            "@context": "https://w3id.org/ro/crate/1.2/context",
+            "@graph": [
+                {"@id": "./", "@type": "Dataset", "name": "Test", "author": []},
+            ],
+        }
+        f = _write_rocrate(tmp_path, crate)
+        result = load_rocrate_metadata(f)
+        assert "creators" not in result
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_rocrate_metadata(tmp_path / "nonexistent.json")
+
+
+# ---------------------------------------------------------------------------
+# load_datacite_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataciteMetadata:
+    def test_extracts_name_from_title(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        assert result["name"] == "DOGPLET DD01"
+
+    def test_extracts_creators(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        creators = result["creators"]
+        assert len(creators) == 2
+        assert creators[0]["name"] == "Jane Doe"
+        assert creators[0]["affiliation"] == "ETH Zurich"
+
+    def test_extracts_dates(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        assert result["dates"] == [{"date": "2024-07-24", "dateType": "Collected"}]
+
+    def test_extracts_subjects(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        assert result["subjects"] == [
+            {"subject": "FDG", "subjectScheme": "Radiotracer"}
+        ]
+
+    def test_missing_creators_absent_key(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_MINIMAL)
+        result = load_datacite_metadata(f)
+        assert "creators" not in result
+
+    def test_missing_dates_absent_key(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_MINIMAL)
+        result = load_datacite_metadata(f)
+        assert "dates" not in result
+
+    def test_missing_subjects_absent_key(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_MINIMAL)
+        result = load_datacite_metadata(f)
+        assert "subjects" not in result
+
+    def test_missing_title_absent_name(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, {})
+        result = load_datacite_metadata(f)
+        assert "name" not in result
+
+    def test_returns_dict(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        assert isinstance(result, dict)
+
+    def test_result_keys_subset_of_study_params(self, tmp_path: Path):
+        """Keys must be compatible with builder.write_study() + extra metadata."""
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_datacite_metadata(f)
+        allowed = {
+            "study_type",
+            "license",
+            "name",
+            "description",
+            "creators",
+            "dates",
+            "subjects",
+        }
+        assert set(result.keys()) <= allowed
+
+    def test_empty_creators_list(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, {"title": "Test", "creators": []})
+        result = load_datacite_metadata(f)
+        assert "creators" not in result
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_datacite_metadata(tmp_path / "nonexistent.yml")
+
+
+# ---------------------------------------------------------------------------
+# load_metadata (auto-detect)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMetadata:
+    def test_detects_rocrate(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_metadata(f)
+        assert result["name"] == "DOGPLET DD01"
+        assert result["license"] == "CC-BY-4.0"
+
+    def test_detects_datacite_yml(self, tmp_path: Path):
+        f = _write_datacite(tmp_path, DATACITE_FULL)
+        result = load_metadata(f)
+        assert result["name"] == "DOGPLET DD01"
+
+    def test_detects_datacite_yaml(self, tmp_path: Path):
+        out = tmp_path / "datacite.yaml"
+        out.write_text(yaml.dump(DATACITE_FULL, default_flow_style=False))
+        result = load_metadata(out)
+        assert result["name"] == "DOGPLET DD01"
+
+    def test_generic_json(self, tmp_path: Path):
+        data = {"name": "Generic Study", "license": "MIT"}
+        f = tmp_path / "meta.json"
+        f.write_text(json.dumps(data))
+        result = load_metadata(f)
+        assert result == data
+
+    def test_generic_yaml(self, tmp_path: Path):
+        data = {"name": "YAML Study", "description": "A study from YAML"}
+        f = tmp_path / "meta.yml"
+        f.write_text(yaml.dump(data))
+        result = load_metadata(f)
+        assert result == data
+
+    def test_generic_yaml_extension(self, tmp_path: Path):
+        data = {"name": "YAML Study"}
+        f = tmp_path / "meta.yaml"
+        f.write_text(yaml.dump(data))
+        result = load_metadata(f)
+        assert result == data
+
+    def test_unsupported_extension_raises(self, tmp_path: Path):
+        f = tmp_path / "meta.txt"
+        f.write_text("hello")
+        with pytest.raises(ValueError, match="Unsupported"):
+            load_metadata(f)
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            load_metadata(tmp_path / "nonexistent.json")
+
+    def test_returns_dict(self, tmp_path: Path):
+        f = _write_rocrate(tmp_path, ROCRATE_FULL)
+        result = load_metadata(f)
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

- Adds `fd5.ingest.metadata` module with `load_rocrate_metadata()`, `load_datacite_metadata()`, and `load_metadata()` auto-detection
- RO-Crate import extracts `name`, `license`, `description`, and `creators` from JSON-LD `@graph` Dataset entity
- DataCite import extracts `name`, `creators`, `dates`, and `subjects` from YAML
- `load_metadata()` auto-detects format by filename, with generic JSON/YAML fallback
- Returned dicts are directly usable with `builder.write_study()`
- Missing fields in source metadata produce absent keys (no errors)
- Includes ingest base module (`Loader` protocol and `hash_source_files`) from #109 as dependency
- 36 metadata tests + 21 base tests, all passing (1031 total, no regressions)

## Test plan

- [x] `load_rocrate_metadata()` extracts license, name, description, creators
- [x] `load_datacite_metadata()` extracts creators, dates, subjects
- [x] `load_metadata()` auto-detects by filename (ro-crate-metadata.json, datacite.yml/yaml, generic)
- [x] Creator edge cases: missing orcid, missing affiliation, empty author list
- [x] Missing fields → absent keys (no KeyError)
- [x] Unsupported format raises ValueError, missing file raises FileNotFoundError
- [x] Result dict keys are compatible with `builder.write_study()` parameters
- [x] Full test suite passes (1031 tests)

Closes #119

Made with [Cursor](https://cursor.com)