### PR TITLE
feat(devc-remote): improve preflight feedback and add missing checks (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight feedback and status dashboard for devc-remote** ([#149](https://github.com/vig-os/fd5/issues/149))
+  - Each preflight check now prints a success/warning/error status line as it completes
+  - New checks: container-already-running, runtime version, compose version, SSH agent forwarding
+  - Summary dashboard printed before proceeding to compose up
+
 - **HDF5 dict round-trip helpers** ([#12](https://github.com/vig-os/fd5/issues/12))
   - `dict_to_h5(group, d)` writes nested Python dicts as HDF5 attrs/sub-groups
   - `h5_to_dict(group)` reads HDF5 attrs and sub-groups back to a Python dict

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -158,16 +158,25 @@ remote_preflight() {
 REPO_PATH="${1:-$HOME}"
 if command -v podman &>/dev/null; then
     echo "RUNTIME=podman"
+    VER=$(podman --version 2>/dev/null | awk '{print $NF}')
+    echo "RUNTIME_VERSION=${VER:-unknown}"
 elif command -v docker &>/dev/null; then
     echo "RUNTIME=docker"
+    VER=$(docker --version 2>/dev/null | sed 's/.*version \([^,]*\).*/\1/')
+    echo "RUNTIME_VERSION=${VER:-unknown}"
 else
     echo "RUNTIME="
+    echo "RUNTIME_VERSION="
 fi
 if (command -v podman &>/dev/null && podman compose version &>/dev/null) || \
    (command -v docker &>/dev/null && docker compose version &>/dev/null); then
     echo "COMPOSE_AVAILABLE=1"
+    CVER=$(podman compose version 2>/dev/null || docker compose version 2>/dev/null)
+    CVER=$(echo "$CVER" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    echo "COMPOSE_VERSION=${CVER:-unknown}"
 else
     echo "COMPOSE_AVAILABLE=0"
+    echo "COMPOSE_VERSION="
 fi
 if command -v git &>/dev/null; then
     echo "GIT_AVAILABLE=1"
@@ -191,27 +200,52 @@ if [ "$(uname -s)" = "Darwin" ]; then
 else
     echo "OS_TYPE=linux"
 fi
+# Check for a running devcontainer (compose project in REPO_PATH)
+if command -v podman &>/dev/null && cd "$REPO_PATH" 2>/dev/null && podman compose ps --format json 2>/dev/null | grep -q '"running"'; then
+    echo "CONTAINER_RUNNING=1"
+elif command -v docker &>/dev/null && cd "$REPO_PATH" 2>/dev/null && docker compose ps --format json 2>/dev/null | grep -q '"running"'; then
+    echo "CONTAINER_RUNNING=1"
+else
+    echo "CONTAINER_RUNNING=0"
+fi
+# Check SSH agent socket forwarding
+if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+    echo "SSH_AUTH_SOCK_FORWARDED=1"
+else
+    echo "SSH_AUTH_SOCK_FORWARDED=0"
+fi
 REMOTEEOF
     )
 
     while IFS= read -r line; do
         [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
         case "${BASH_REMATCH[1]}" in
-            RUNTIME) RUNTIME="${BASH_REMATCH[2]}" ;;
-            COMPOSE_AVAILABLE) COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
-            GIT_AVAILABLE) GIT_AVAILABLE="${BASH_REMATCH[2]}" ;;
-            REPO_PATH_EXISTS) REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
-            DEVCONTAINER_EXISTS) DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
-            DISK_AVAILABLE_GB) DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
-            OS_TYPE) OS_TYPE="${BASH_REMATCH[2]}" ;;
+            RUNTIME)                 RUNTIME="${BASH_REMATCH[2]}" ;;
+            RUNTIME_VERSION)         RUNTIME_VERSION="${BASH_REMATCH[2]}" ;;
+            COMPOSE_AVAILABLE)       COMPOSE_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            COMPOSE_VERSION)         COMPOSE_VERSION="${BASH_REMATCH[2]}" ;;
+            GIT_AVAILABLE)           GIT_AVAILABLE="${BASH_REMATCH[2]}" ;;
+            REPO_PATH_EXISTS)        REPO_PATH_EXISTS="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_EXISTS)     DEVCONTAINER_EXISTS="${BASH_REMATCH[2]}" ;;
+            DISK_AVAILABLE_GB)       DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
+            OS_TYPE)                 OS_TYPE="${BASH_REMATCH[2]}" ;;
+            CONTAINER_RUNNING)       CONTAINER_RUNNING="${BASH_REMATCH[2]}" ;;
+            SSH_AUTH_SOCK_FORWARDED) SSH_AUTH_SOCK_FORWARDED="${BASH_REMATCH[2]}" ;;
         esac
     done <<< "$preflight_output"
+
+    # ── Per-check status lines ──────────────────────────────────────────
+    local repo_status="missing"
+    [[ "${REPO_PATH_EXISTS:-0}" == "1" ]] && repo_status="found"
+    log_info "Repo path: $REMOTE_PATH ($repo_status)"
 
     # Hard errors: runtime and compose are always required
     if [[ -z "${RUNTIME:-}" ]]; then
         log_error "No container runtime found on $SSH_HOST. Install podman or docker."
         exit 1
     fi
+    log_success "Container runtime: $RUNTIME ${RUNTIME_VERSION:-}"
+
     if [[ "$RUNTIME" == "podman" ]]; then
         COMPOSE_CMD="podman compose"
     else
@@ -221,14 +255,37 @@ REMOTEEOF
         log_error "Compose not available on $SSH_HOST. Install docker-compose or podman-compose."
         exit 1
     fi
+    log_success "Compose: ${COMPOSE_VERSION:-available}"
 
-    # Soft checks: repo and devcontainer are handled by clone/init steps
+    if [[ "${CONTAINER_RUNNING:-0}" == "1" ]]; then
+        log_warning "A container already running in $REMOTE_PATH"
+    else
+        log_success "No existing container running"
+    fi
+
+    if [[ "${SSH_AUTH_SOCK_FORWARDED:-0}" == "1" ]]; then
+        log_success "SSH agent forwarding detected"
+    else
+        log_warning "SSH agent not forwarded — git operations inside the container may fail"
+    fi
+
     if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
         log_warning "Low disk space on $SSH_HOST (${DISK_AVAILABLE_GB:-0}GB). At least 2GB recommended."
     fi
     if [[ "${OS_TYPE:-}" == "macos" ]]; then
         log_warning "Remote host is macOS. Devcontainer support may be limited."
     fi
+
+    # ── Summary dashboard ───────────────────────────────────────────────
+    echo ""
+    echo -e "${BLUE}═══ Preflight Summary ═══${NC}"
+    echo -e "  Host:      $SSH_HOST"
+    echo -e "  Repo:      $REMOTE_PATH"
+    echo -e "  Runtime:   $RUNTIME ${RUNTIME_VERSION:-}"
+    echo -e "  Compose:   ${COMPOSE_VERSION:-available}"
+    echo -e "  Disk:      ${DISK_AVAILABLE_GB:-?}GB available"
+    echo -e "${BLUE}═════════════════════════${NC}"
+    echo ""
 }
 
 remote_clone_if_needed() {

--- a/tests/test_devc_remote_preflight.sh
+++ b/tests/test_devc_remote_preflight.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+###############################################################################
+# test_devc_remote_preflight.sh — Tests for devc-remote.sh preflight feedback
+#
+# Validates that remote_preflight() prints per-check status lines, collects
+# runtime/compose versions, detects running containers, checks SSH agent
+# forwarding, and emits a summary dashboard.
+#
+# Run:  bash tests/test_devc_remote_preflight.sh
+#
+# Refs: #149
+###############################################################################
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEVC_SCRIPT="$PROJECT_ROOT/scripts/devc-remote.sh"
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $label"
+        echo "  expected to contain: $needle"
+        echo "  got output (first 500 chars): ${haystack:0:500}"
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $label"
+        echo "  expected NOT to contain: $needle"
+    fi
+}
+
+assert_exit_code() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $label"
+        echo "  expected exit code: $expected, got: $actual"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: build a temp script that sources devc-remote.sh (with main disabled),
+# overrides ssh() to echo canned data, then calls remote_preflight.
+# ─────────────────────────────────────────────────────────────────────────────
+build_test_script() {
+    local mock_data="$1"
+    local tmpscript tmpsrc
+    tmpscript=$(mktemp "${TMPDIR:-/tmp}/devc_test.XXXXXX")
+    tmpsrc=$(mktemp "${TMPDIR:-/tmp}/devc_src.XXXXXX")
+
+    sed 's/^main "\$@"$/# main disabled/' "$DEVC_SCRIPT" > "$tmpsrc"
+    TMPFILES+=("$tmpsrc")
+
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "source \"$tmpsrc\""
+        echo 'ssh() {'
+        echo "    cat <<'MOCKEOF'"
+        echo "$mock_data"
+        echo 'MOCKEOF'
+        echo '}'
+        echo 'SSH_HOST="testhost"'
+        echo 'REMOTE_PATH="/home/user/repo"'
+        echo 'remote_preflight'
+    } > "$tmpscript"
+
+    echo "$tmpscript"
+}
+
+TMPFILES=()
+cleanup_tmpfiles() { rm -f "${TMPFILES[@]+"${TMPFILES[@]}"}"; }
+trap cleanup_tmpfiles EXIT
+
+run_preflight() {
+    local mock_data="$1"
+    local tmpscript
+    tmpscript=$(build_test_script "$mock_data")
+    TMPFILES+=("$tmpscript")
+    local output rc=0
+    output=$(bash "$tmpscript" 2>&1) || rc=$?
+    echo "$output"
+    return $rc
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mock data sets
+# ─────────────────────────────────────────────────────────────────────────────
+MOCK_HAPPY="RUNTIME=podman
+RUNTIME_VERSION=4.9.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=42
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AUTH_SOCK_FORWARDED=1"
+
+MOCK_CONTAINER_RUNNING="RUNTIME=docker
+RUNTIME_VERSION=25.0.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=42
+OS_TYPE=linux
+CONTAINER_RUNNING=1
+SSH_AUTH_SOCK_FORWARDED=1"
+
+MOCK_NO_RUNTIME="RUNTIME=
+RUNTIME_VERSION=
+COMPOSE_AVAILABLE=0
+COMPOSE_VERSION=
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=0
+DISK_AVAILABLE_GB=10
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AUTH_SOCK_FORWARDED=0"
+
+MOCK_NO_SSH_AGENT="RUNTIME=podman
+RUNTIME_VERSION=4.9.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=42
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AUTH_SOCK_FORWARDED=0"
+
+MOCK_LOW_DISK="RUNTIME=docker
+RUNTIME_VERSION=25.0.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=1
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AUTH_SOCK_FORWARDED=1"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Happy path — each check prints a status line
+# ─────────────────────────────────────────────────────────────────────────────
+test_happy_path_prints_status_lines() {
+    local output
+    output=$(run_preflight "$MOCK_HAPPY") || true
+
+    assert_contains "repo path reported" "$output" "/home/user/repo"
+    assert_contains "runtime detected" "$output" "podman"
+    assert_contains "runtime version shown" "$output" "4.9.3"
+    assert_contains "compose version shown" "$output" "2.24.5"
+    assert_contains "no container running" "$output" "no existing container"
+    assert_contains "ssh agent OK" "$output" "SSH agent"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Container already running is detected
+# ─────────────────────────────────────────────────────────────────────────────
+test_container_running_detected() {
+    local output
+    output=$(run_preflight "$MOCK_CONTAINER_RUNNING") || true
+
+    assert_contains "container running warning" "$output" "container already running"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: No runtime produces error and exits non-zero
+# ─────────────────────────────────────────────────────────────────────────────
+test_no_runtime_errors() {
+    local output rc=0
+    output=$(run_preflight "$MOCK_NO_RUNTIME") || rc=$?
+
+    assert_exit_code "exits non-zero without runtime" "1" "$rc"
+    assert_contains "runtime error" "$output" "No container runtime"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Missing SSH agent forwarding produces warning
+# ─────────────────────────────────────────────────────────────────────────────
+test_no_ssh_agent_warns() {
+    local output
+    output=$(run_preflight "$MOCK_NO_SSH_AGENT") || true
+
+    assert_contains "ssh agent warning" "$output" "SSH agent"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Summary dashboard is printed
+# ─────────────────────────────────────────────────────────────────────────────
+test_summary_dashboard() {
+    local output
+    output=$(run_preflight "$MOCK_HAPPY") || true
+
+    assert_contains "summary header" "$output" "Preflight Summary"
+    assert_contains "summary runtime" "$output" "podman"
+    assert_contains "summary compose" "$output" "2.24.5"
+    assert_contains "summary repo path" "$output" "/home/user/repo"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Low disk triggers warning
+# ─────────────────────────────────────────────────────────────────────────────
+test_low_disk_warns() {
+    local output
+    output=$(run_preflight "$MOCK_LOW_DISK") || true
+
+    assert_contains "low disk warning" "$output" "Low disk"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RUN ALL
+# ─────────────────────────────────────────────────────────────────────────────
+echo "=== devc-remote preflight tests ==="
+test_happy_path_prints_status_lines
+test_container_running_detected
+test_no_runtime_errors
+test_no_ssh_agent_warns
+test_summary_dashboard
+test_low_disk_warns
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+else
+    echo "All tests passed."
+fi

--- a/tests/test_devc_remote_preflight.sh
+++ b/tests/test_devc_remote_preflight.sh
@@ -171,7 +171,7 @@ test_happy_path_prints_status_lines() {
     assert_contains "runtime detected" "$output" "podman"
     assert_contains "runtime version shown" "$output" "4.9.3"
     assert_contains "compose version shown" "$output" "2.24.5"
-    assert_contains "no container running" "$output" "no existing container"
+    assert_contains "no container running" "$output" "No existing container"
     assert_contains "ssh agent OK" "$output" "SSH agent"
 }
 


### PR DESCRIPTION
## Summary

- Enhanced `remote_preflight()` in `scripts/devc-remote.sh` to print a success/warning/error status line for each check as it completes
- Added new checks: container-already-running, runtime version, compose version, SSH agent forwarding
- Added a summary dashboard printed before proceeding to compose up

## Test plan

- [x] `bash tests/test_devc_remote_preflight.sh` — 15 tests covering happy path, container-running detection, no-runtime error, SSH agent warning, summary dashboard, low disk warning
- [ ] Manual: run `./scripts/devc-remote.sh <host>` against a real remote and verify status lines and summary appear

Refs: #149