### PR TITLE
feat(devc-remote): add --yes flag, container prompt, and SSH agent improvements (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each preflight check now prints a success/warning/error status line as it completes
   - New checks: container-already-running, runtime version, compose version, SSH agent forwarding
   - Summary dashboard printed before proceeding to compose up
+  - `--yes`/`-y` flag to auto-accept interactive prompts
+  - Path and repo URL feedback with auto-derived annotation
+  - Interactive Reuse/Recreate/Abort prompt when a container is already running
+  - SSH agent forwarding check improved to use `ssh-add -l`
 
 - **HDF5 dict round-trip helpers** ([#12](https://github.com/vig-os/fd5/issues/12))
   - `dict_to_h5(group, d)` writes nested Python dicts as HDF5 attrs/sub-groups

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -11,14 +11,19 @@
 # .devcontainer/ is missing, runs init-workspace via the container image.
 #
 # USAGE:
-#   ./scripts/devc-remote.sh [--repo <url>] <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh [--yes|-y] [--repo <url>] <ssh-host>[:<remote-path>]
 #   ./scripts/devc-remote.sh --help
+#
+# Options:
+#   --yes, -y    Auto-accept all interactive prompts (reuse running containers)
+#   --repo URL   Specify the git remote URL for cloning
 #
 # Examples:
 #   ./scripts/devc-remote.sh myserver
 #   ./scripts/devc-remote.sh user@host:/opt/projects/myrepo
 #   ./scripts/devc-remote.sh myserver:/home/user/repo
 #   ./scripts/devc-remote.sh --repo git@github.com:org/repo.git myserver
+#   ./scripts/devc-remote.sh --yes myserver
 #
 # Part of #70. See issue #152 for design.
 ###############################################################################
@@ -68,11 +73,18 @@ parse_args() {
     SSH_HOST=""
     REMOTE_PATH=""
     REPO_URL=""
+    YES_MODE=0
+    PATH_AUTO_DERIVED=0
+    REPO_URL_SOURCE=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --help|-h)
                 show_help
+                ;;
+            --yes|-y)
+                YES_MODE=1
+                shift
                 ;;
             --repo)
                 shift
@@ -81,6 +93,7 @@ parse_args() {
                     log_error "--repo requires a URL argument"
                     exit 1
                 fi
+                REPO_URL_SOURCE="flag"
                 shift
                 ;;
             -*)
@@ -93,7 +106,6 @@ parse_args() {
                     log_error "Unexpected argument: $1"
                     exit 1
                 fi
-                # Parse SSH-style format: user@host:path or host:path
                 if [[ "$1" =~ ^([^:]+):(.+)$ ]]; then
                     SSH_HOST="${BASH_REMATCH[1]}"
                     REMOTE_PATH="${BASH_REMATCH[2]}"
@@ -111,7 +123,6 @@ parse_args() {
         exit 1
     fi
 
-    # Auto-derive REMOTE_PATH from local repo name when not explicitly given
     if [[ -z "$REMOTE_PATH" ]]; then
         local local_repo_name
         local_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
@@ -119,15 +130,18 @@ parse_args() {
             # Tilde is intentional; expanded by the remote shell
             # shellcheck disable=SC2088
             REMOTE_PATH="~/${local_repo_name}"
+            PATH_AUTO_DERIVED=1
         else
             log_error "No remote path given and not inside a git repository."
             exit 1
         fi
     fi
 
-    # Auto-derive REPO_URL from local git remote when not explicitly given
     if [[ -z "$REPO_URL" ]]; then
         REPO_URL=$(git remote get-url origin 2>/dev/null || echo "")
+        if [[ -n "$REPO_URL" ]]; then
+            REPO_URL_SOURCE="local"
+        fi
     fi
 }
 
@@ -208,11 +222,11 @@ elif command -v docker &>/dev/null && cd "$REPO_PATH" 2>/dev/null && docker comp
 else
     echo "CONTAINER_RUNNING=0"
 fi
-# Check SSH agent socket forwarding
-if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "$SSH_AUTH_SOCK" ]; then
-    echo "SSH_AUTH_SOCK_FORWARDED=1"
+# Check SSH agent forwarding via ssh-add
+if ssh-add -l &>/dev/null; then
+    echo "SSH_AGENT_FWD=1"
 else
-    echo "SSH_AUTH_SOCK_FORWARDED=0"
+    echo "SSH_AGENT_FWD=0"
 fi
 REMOTEEOF
     )
@@ -230,7 +244,7 @@ REMOTEEOF
             DISK_AVAILABLE_GB)       DISK_AVAILABLE_GB="${BASH_REMATCH[2]}" ;;
             OS_TYPE)                 OS_TYPE="${BASH_REMATCH[2]}" ;;
             CONTAINER_RUNNING)       CONTAINER_RUNNING="${BASH_REMATCH[2]}" ;;
-            SSH_AUTH_SOCK_FORWARDED) SSH_AUTH_SOCK_FORWARDED="${BASH_REMATCH[2]}" ;;
+            SSH_AGENT_FWD)          SSH_AGENT_FWD="${BASH_REMATCH[2]}" ;;
         esac
     done <<< "$preflight_output"
 
@@ -263,10 +277,10 @@ REMOTEEOF
         log_success "No existing container running"
     fi
 
-    if [[ "${SSH_AUTH_SOCK_FORWARDED:-0}" == "1" ]]; then
-        log_success "SSH agent forwarding detected"
+    if [[ "${SSH_AGENT_FWD:-0}" == "1" ]]; then
+        log_success "SSH agent forwarding: working"
     else
-        log_warning "SSH agent not forwarded — git operations inside the container may fail"
+        log_warning "SSH agent forwarding: not available (git signing may fail inside container)"
     fi
 
     if [[ "${DISK_AVAILABLE_GB:-0}" -lt 2 ]] 2>/dev/null; then
@@ -332,25 +346,72 @@ remote_init_if_needed() {
     DEVCONTAINER_EXISTS=1
 }
 
-remote_compose_up() {
-    local ps_output state health
+compose_ps_json() {
     # shellcheck disable=SC2029
-    ps_output=$(ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD ps --format json 2>/dev/null" || true)
-    state=$(echo "$ps_output" | grep -o '"State":"[^"]*"' | head -1 | cut -d'"' -f4)
-    health=$(echo "$ps_output" | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+    ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD ps --format json 2>/dev/null" || true
+}
 
-    if [[ "$state" == "running" && "${health:-}" == "healthy" ]]; then
-        log_success "Devcontainer already running on $SSH_HOST. Opening..."
-    else
-        log_info "Starting devcontainer on $SSH_HOST..."
-        # shellcheck disable=SC2029
-        if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
-            log_error "Failed to start devcontainer on $SSH_HOST."
-            log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH && $COMPOSE_CMD logs\"' for details."
-            exit 1
-        fi
-        sleep 2
+check_existing_container() {
+    [[ "${CONTAINER_RUNNING:-0}" != "1" ]] && return 0
+
+    local ps_output state
+    ps_output=$(compose_ps_json)
+    state=$(echo "$ps_output" | grep -o '"State":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+    if [[ "$state" != "running" ]]; then
+        return 0
     fi
+
+    if [[ "${YES_MODE:-0}" == "1" ]]; then
+        log_info "Reusing existing container (--yes)"
+        SKIP_COMPOSE_UP=1
+        return 0
+    fi
+
+    echo ""
+    log_info "Container for $REMOTE_PATH is already running on $SSH_HOST."
+    echo "  [R]euse (default)  [r]ecreate  [a]bort"
+    local choice
+    read -r -n 1 -p "  > " choice </dev/tty || choice="R"
+    echo ""
+
+    case "${choice:-R}" in
+        R|r)
+            if [[ "${choice:-R}" == "r" ]]; then
+                log_info "Recreating container..."
+                # shellcheck disable=SC2029
+                ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD down" || true
+                SKIP_COMPOSE_UP=0
+            else
+                log_info "Reusing existing container"
+                SKIP_COMPOSE_UP=1
+            fi
+            ;;
+        a|A)
+            log_info "Aborted by user."
+            exit 0
+            ;;
+        *)
+            log_info "Reusing existing container"
+            SKIP_COMPOSE_UP=1
+            ;;
+    esac
+}
+
+remote_compose_up() {
+    if [[ "${SKIP_COMPOSE_UP:-0}" == "1" ]]; then
+        log_success "Devcontainer already running on $SSH_HOST. Opening..."
+        return 0
+    fi
+
+    log_info "Starting devcontainer on $SSH_HOST..."
+    # shellcheck disable=SC2029
+    if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+        log_error "Failed to start devcontainer on $SSH_HOST."
+        log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH && $COMPOSE_CMD logs\"' for details."
+        exit 1
+    fi
+    sleep 2
 }
 
 open_editor() {
@@ -387,6 +448,16 @@ open_editor() {
 main() {
     parse_args "$@"
 
+    local path_annotation="explicit"
+    [[ "${PATH_AUTO_DERIVED:-0}" == "1" ]] && path_annotation="auto-derived from local repo"
+    log_success "Remote path: $REMOTE_PATH ($path_annotation)"
+
+    if [[ -n "${REPO_URL:-}" ]]; then
+        log_success "Repo URL: $REPO_URL (from ${REPO_URL_SOURCE:-unknown})"
+    else
+        log_warning "Repo URL: not available (clone will fail if repo missing on remote)"
+    fi
+
     log_info "Detecting local editor CLI..."
     detect_editor_cli
     log_success "Using $EDITOR_CLI"
@@ -401,6 +472,8 @@ main() {
 
     remote_clone_if_needed
     remote_init_if_needed
+    SKIP_COMPOSE_UP=0
+    check_existing_container
     remote_compose_up
     open_editor
 

--- a/tests/test_devc_remote_preflight.sh
+++ b/tests/test_devc_remote_preflight.sh
@@ -193,7 +193,7 @@ DEVCONTAINER_EXISTS=1
 DISK_AVAILABLE_GB=42
 OS_TYPE=linux
 CONTAINER_RUNNING=0
-SSH_AUTH_SOCK_FORWARDED=1"
+SSH_AGENT_FWD=1"
 
 MOCK_CONTAINER_RUNNING="RUNTIME=docker
 RUNTIME_VERSION=25.0.3
@@ -205,7 +205,7 @@ DEVCONTAINER_EXISTS=1
 DISK_AVAILABLE_GB=42
 OS_TYPE=linux
 CONTAINER_RUNNING=1
-SSH_AUTH_SOCK_FORWARDED=1"
+SSH_AGENT_FWD=1"
 
 MOCK_NO_RUNTIME="RUNTIME=
 RUNTIME_VERSION=
@@ -217,7 +217,7 @@ DEVCONTAINER_EXISTS=0
 DISK_AVAILABLE_GB=10
 OS_TYPE=linux
 CONTAINER_RUNNING=0
-SSH_AUTH_SOCK_FORWARDED=0"
+SSH_AGENT_FWD=0"
 
 MOCK_NO_SSH_AGENT="RUNTIME=podman
 RUNTIME_VERSION=4.9.3
@@ -229,7 +229,7 @@ DEVCONTAINER_EXISTS=1
 DISK_AVAILABLE_GB=42
 OS_TYPE=linux
 CONTAINER_RUNNING=0
-SSH_AUTH_SOCK_FORWARDED=0"
+SSH_AGENT_FWD=0"
 
 MOCK_LOW_DISK="RUNTIME=docker
 RUNTIME_VERSION=25.0.3
@@ -241,7 +241,7 @@ DEVCONTAINER_EXISTS=1
 DISK_AVAILABLE_GB=1
 OS_TYPE=linux
 CONTAINER_RUNNING=0
-SSH_AUTH_SOCK_FORWARDED=1"
+SSH_AGENT_FWD=1"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TEST: Happy path — each check prints a status line
@@ -255,7 +255,7 @@ test_happy_path_prints_status_lines() {
     assert_contains "runtime version shown" "$output" "4.9.3"
     assert_contains "compose version shown" "$output" "2.24.5"
     assert_contains "no container running" "$output" "No existing container"
-    assert_contains "ssh agent OK" "$output" "SSH agent"
+    assert_contains "ssh agent OK" "$output" "SSH agent forwarding: working"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -286,7 +286,7 @@ test_no_ssh_agent_warns() {
     local output
     output=$(run_preflight "$MOCK_NO_SSH_AGENT") || true
 
-    assert_contains "ssh agent warning" "$output" "SSH agent"
+    assert_contains "ssh agent warning" "$output" "SSH agent forwarding: not available"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_devc_remote_preflight.sh
+++ b/tests/test_devc_remote_preflight.sh
@@ -97,6 +97,89 @@ run_preflight() {
     return $rc
 }
 
+# Helper: build a temp script that tests parse_args and globals set by it
+build_parse_args_script() {
+    local args="$1"
+    local tmpscript tmpsrc
+    tmpscript=$(mktemp "${TMPDIR:-/tmp}/devc_test.XXXXXX")
+    tmpsrc=$(mktemp "${TMPDIR:-/tmp}/devc_src.XXXXXX")
+
+    sed 's/^main "\$@"$/# main disabled/' "$DEVC_SCRIPT" > "$tmpsrc"
+    TMPFILES+=("$tmpsrc")
+
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "source \"$tmpsrc\""
+        echo "git() { echo /fake/repo; }"
+        echo "parse_args $args"
+        # shellcheck disable=SC2016
+        echo 'echo "YES_MODE=${YES_MODE:-0}"'
+        # shellcheck disable=SC2016
+        echo 'echo "SSH_HOST=${SSH_HOST:-}"'
+        # shellcheck disable=SC2016
+        echo 'echo "REMOTE_PATH=${REMOTE_PATH:-}"'
+        # shellcheck disable=SC2016
+        echo 'echo "PATH_AUTO_DERIVED=${PATH_AUTO_DERIVED:-0}"'
+        # shellcheck disable=SC2016
+        echo 'echo "REPO_URL_SOURCE=${REPO_URL_SOURCE:-}"'
+    } > "$tmpscript"
+
+    echo "$tmpscript"
+}
+
+run_parse_args() {
+    local args="$1"
+    local tmpscript
+    tmpscript=$(build_parse_args_script "$args")
+    TMPFILES+=("$tmpscript")
+    local output rc=0
+    output=$(bash "$tmpscript" 2>&1) || rc=$?
+    echo "$output"
+    return $rc
+}
+
+# Helper: build a script that tests check_existing_container
+build_container_check_script() {
+    local mock_data="$1" yes_mode="${2:-0}"
+    local tmpscript tmpsrc
+    tmpscript=$(mktemp "${TMPDIR:-/tmp}/devc_test.XXXXXX")
+    tmpsrc=$(mktemp "${TMPDIR:-/tmp}/devc_src.XXXXXX")
+
+    sed 's/^main "\$@"$/# main disabled/' "$DEVC_SCRIPT" > "$tmpsrc"
+    TMPFILES+=("$tmpsrc")
+
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "source \"$tmpsrc\""
+        echo 'ssh() {'
+        echo "    cat <<'MOCKEOF'"
+        echo "$mock_data"
+        echo 'MOCKEOF'
+        echo '}'
+        echo "YES_MODE=$yes_mode"
+        echo 'SSH_HOST="testhost"'
+        echo 'REMOTE_PATH="/home/user/repo"'
+        echo 'COMPOSE_CMD="podman compose"'
+        echo 'CONTAINER_RUNNING=1'
+        echo 'check_existing_container'
+    } > "$tmpscript"
+
+    echo "$tmpscript"
+}
+
+run_container_check() {
+    local mock_data="$1" yes_mode="${2:-0}"
+    local tmpscript
+    tmpscript=$(build_container_check_script "$mock_data" "$yes_mode")
+    TMPFILES+=("$tmpscript")
+    local output rc=0
+    output=$(bash "$tmpscript" 2>&1) || rc=$?
+    echo "$output"
+    return $rc
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Mock data sets
 # ─────────────────────────────────────────────────────────────────────────────
@@ -230,6 +313,143 @@ test_low_disk_warns() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# TEST: --yes flag is parsed and sets YES_MODE=1
+# ─────────────────────────────────────────────────────────────────────────────
+test_yes_flag_long() {
+    local output
+    output=$(run_parse_args "--yes myhost") || true
+
+    assert_contains "YES_MODE set to 1" "$output" "YES_MODE=1"
+    assert_contains "SSH_HOST set" "$output" "SSH_HOST=myhost"
+}
+
+test_yes_flag_short() {
+    local output
+    output=$(run_parse_args "-y myhost") || true
+
+    assert_contains "YES_MODE set to 1 (short)" "$output" "YES_MODE=1"
+}
+
+test_yes_flag_default() {
+    local output
+    output=$(run_parse_args "myhost") || true
+
+    assert_contains "YES_MODE default 0" "$output" "YES_MODE=0"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Path and repo URL feedback with auto-derived annotation
+# ─────────────────────────────────────────────────────────────────────────────
+test_path_auto_derived_annotation() {
+    local output
+    output=$(run_parse_args "myhost") || true
+
+    assert_contains "path auto-derived" "$output" "PATH_AUTO_DERIVED=1"
+}
+
+test_path_explicit_annotation() {
+    local output
+    output=$(run_parse_args "myhost:/opt/proj") || true
+
+    assert_contains "path explicit" "$output" "PATH_AUTO_DERIVED=0"
+}
+
+test_repo_url_source_local() {
+    local output
+    output=$(run_parse_args "myhost") || true
+
+    assert_contains "repo url source local" "$output" "REPO_URL_SOURCE=local"
+}
+
+test_repo_url_source_flag() {
+    local output
+    output=$(run_parse_args "--repo git@github.com:o/r.git myhost") || true
+
+    assert_contains "repo url source flag" "$output" "REPO_URL_SOURCE=flag"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: Container-already-running with --yes auto-reuses
+# ─────────────────────────────────────────────────────────────────────────────
+MOCK_COMPOSE_PS_RUNNING='[{"State":"running","Health":"healthy"}]'
+# shellcheck disable=SC2034
+MOCK_COMPOSE_PS_EMPTY='[]'
+
+test_container_check_yes_reuses() {
+    local output
+    output=$(run_container_check "$MOCK_COMPOSE_PS_RUNNING" 1) || true
+
+    assert_contains "reuse msg" "$output" "Reusing existing container"
+}
+
+test_container_check_skip_when_not_running() {
+    local tmpscript tmpsrc
+    tmpscript=$(mktemp "${TMPDIR:-/tmp}/devc_test.XXXXXX")
+    tmpsrc=$(mktemp "${TMPDIR:-/tmp}/devc_src.XXXXXX")
+    sed 's/^main "\$@"$/# main disabled/' "$DEVC_SCRIPT" > "$tmpsrc"
+    TMPFILES+=("$tmpsrc" "$tmpscript")
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "source \"$tmpsrc\""
+        echo 'ssh() { echo "[]"; }'
+        echo 'YES_MODE=0'
+        echo 'SSH_HOST="testhost"'
+        echo 'REMOTE_PATH="/home/user/repo"'
+        echo 'COMPOSE_CMD="podman compose"'
+        echo 'CONTAINER_RUNNING=0'
+        echo 'check_existing_container'
+    } > "$tmpscript"
+
+    local output rc=0
+    output=$(bash "$tmpscript" 2>&1) || rc=$?
+
+    assert_not_contains "no reuse when not running" "$output" "Reusing"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: SSH agent check uses ssh-add -l output
+# ─────────────────────────────────────────────────────────────────────────────
+MOCK_SSH_ADD_OK="RUNTIME=podman
+RUNTIME_VERSION=4.9.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=42
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AGENT_FWD=1"
+
+MOCK_SSH_ADD_FAIL="RUNTIME=podman
+RUNTIME_VERSION=4.9.3
+COMPOSE_AVAILABLE=1
+COMPOSE_VERSION=2.24.5
+GIT_AVAILABLE=1
+REPO_PATH_EXISTS=1
+DEVCONTAINER_EXISTS=1
+DISK_AVAILABLE_GB=42
+OS_TYPE=linux
+CONTAINER_RUNNING=0
+SSH_AGENT_FWD=0"
+
+test_ssh_agent_fwd_ok() {
+    local output
+    output=$(run_preflight "$MOCK_SSH_ADD_OK") || true
+
+    assert_contains "ssh agent working" "$output" "SSH agent forwarding"
+}
+
+test_ssh_agent_fwd_fail() {
+    local output
+    output=$(run_preflight "$MOCK_SSH_ADD_FAIL") || true
+
+    assert_contains "ssh agent warning" "$output" "SSH agent"
+    assert_contains "ssh agent not available" "$output" "not available"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # RUN ALL
 # ─────────────────────────────────────────────────────────────────────────────
 echo "=== devc-remote preflight tests ==="
@@ -239,6 +459,17 @@ test_no_runtime_errors
 test_no_ssh_agent_warns
 test_summary_dashboard
 test_low_disk_warns
+test_yes_flag_long
+test_yes_flag_short
+test_yes_flag_default
+test_path_auto_derived_annotation
+test_path_explicit_annotation
+test_repo_url_source_local
+test_repo_url_source_flag
+test_container_check_yes_reuses
+test_container_check_skip_when_not_running
+test_ssh_agent_fwd_ok
+test_ssh_agent_fwd_fail
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Description

Complete the remaining features from the Design for issue #149: add a `--yes`/`-y` flag for non-interactive use, annotate path and repo URL feedback with auto-derived vs explicit source, add an interactive Reuse/Recreate/Abort prompt when a container is already running, and improve the SSH agent forwarding check to use `ssh-add -l`.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/devc-remote.sh` — 92 insertions, 33 deletions
  - `parse_args`: added `--yes`/`-y` flag, `YES_MODE`, `PATH_AUTO_DERIVED`, `REPO_URL_SOURCE` globals
  - `main`: added path and repo URL feedback lines with auto-derived annotation
  - `check_existing_container()`: new function with interactive Reuse/Recreate/Abort prompt; auto-reuses with `--yes`
  - `compose_ps_json()`: extracted shared helper (DRY with old `remote_compose_up`)
  - `remote_compose_up`: simplified to honor `SKIP_COMPOSE_UP` from container check
  - SSH heredoc: changed from `SSH_AUTH_SOCK` check to `ssh-add -l` for `SSH_AGENT_FWD`
  - Status line messages updated to match Design format
- `tests/test_devc_remote_preflight.sh` — 245 insertions, 6 deletions
  - New helpers: `build_parse_args_script`, `run_parse_args`, `build_container_check_script`, `run_container_check`
  - 13 new tests covering `--yes` flag, path annotation, repo URL source, container check, SSH agent forwarding
  - Updated mock data from `SSH_AUTH_SOCK_FORWARDED` to `SSH_AGENT_FWD`
- `CHANGELOG.md` — 4 new sub-bullets under existing #149 entry

## Changelog Entry

### Added

- **Preflight feedback and status dashboard for devc-remote** ([#149](https://github.com/vig-os/fd5/issues/149))
  - `--yes`/`-y` flag to auto-accept interactive prompts
  - Path and repo URL feedback with auto-derived annotation
  - Interactive Reuse/Recreate/Abort prompt when a container is already running
  - SSH agent forwarding check improved to use `ssh-add -l`

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

Shell tests only — `bash tests/test_devc_remote_preflight.sh` passes all 28 tests (15 existing + 13 new). Python test suite has pre-existing collection errors due to missing `h5py` in the worktree environment (unrelated to this change). Shellcheck passes on all modified files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This is a follow-up to PR #151 which implemented the initial preflight feedback (status lines, dashboard, basic checks). This PR completes the remaining items from the [Design comment](https://github.com/vig-os/fd5/issues/149#issuecomment-3962965856): `--yes` flag, path annotations, container-already-running prompt, and improved SSH agent check.

Refs: #149
