### PR TITLE
fix(devc-remote): use .devcontainer subdir for compose and resolve tilde paths (#156)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
                 "nefrob.vscode-just-syntax"
             ],
             "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
                 "python.defaultInterpreterPath": "/root/assets/workspace/.venv/bin/python",
                 "[python]": {
                     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -215,9 +215,9 @@ else
     echo "OS_TYPE=linux"
 fi
 # Check for a running devcontainer (compose project in REPO_PATH)
-if command -v podman &>/dev/null && cd "$REPO_PATH" 2>/dev/null && podman compose ps --format json 2>/dev/null | grep -q '"running"'; then
+if command -v podman &>/dev/null && cd "$REPO_PATH/.devcontainer" 2>/dev/null && podman compose ps --format json 2>/dev/null | grep -q '"running"'; then
     echo "CONTAINER_RUNNING=1"
-elif command -v docker &>/dev/null && cd "$REPO_PATH" 2>/dev/null && docker compose ps --format json 2>/dev/null | grep -q '"running"'; then
+elif command -v docker &>/dev/null && cd "$REPO_PATH/.devcontainer" 2>/dev/null && docker compose ps --format json 2>/dev/null | grep -q '"running"'; then
     echo "CONTAINER_RUNNING=1"
 else
     echo "CONTAINER_RUNNING=0"
@@ -348,7 +348,31 @@ remote_init_if_needed() {
 
 compose_ps_json() {
     # shellcheck disable=SC2029
-    ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD ps --format json 2>/dev/null" || true
+    ssh "$SSH_HOST" "cd $REMOTE_PATH/.devcontainer && $COMPOSE_CMD ps --format json 2>/dev/null" || true
+}
+
+resolve_remote_path_absolute() {
+    local path="$1"
+    local remote_home=""
+
+    # shellcheck disable=SC2088
+    if [[ "$path" == "~" || "$path" == "~/"* || "$path" != /* ]]; then
+        # shellcheck disable=SC2029
+        remote_home=$(ssh "$SSH_HOST" 'printf %s "$HOME"')
+    fi
+
+    # shellcheck disable=SC2088
+    if [[ "$path" == "~" || "$path" == "~/"* ]]; then
+        if [[ "$path" == "~" ]]; then
+            path="$remote_home"
+        else
+            path="${remote_home}/${path#\~/}"
+        fi
+    elif [[ "$path" != /* ]]; then
+        path="${remote_home}/${path#./}"
+    fi
+
+    echo "$path"
 }
 
 check_existing_container() {
@@ -380,7 +404,7 @@ check_existing_container() {
             if [[ "${choice:-R}" == "r" ]]; then
                 log_info "Recreating container..."
                 # shellcheck disable=SC2029
-                ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD down" || true
+                ssh "$SSH_HOST" "cd $REMOTE_PATH/.devcontainer && $COMPOSE_CMD down" || true
                 SKIP_COMPOSE_UP=0
             else
                 log_info "Reusing existing container"
@@ -406,21 +430,23 @@ remote_compose_up() {
 
     log_info "Starting devcontainer on $SSH_HOST..."
     # shellcheck disable=SC2029
-    if ! ssh "$SSH_HOST" "cd $REMOTE_PATH && $COMPOSE_CMD up -d"; then
+    if ! ssh "$SSH_HOST" "cd $REMOTE_PATH/.devcontainer && $COMPOSE_CMD up -d"; then
         log_error "Failed to start devcontainer on $SSH_HOST."
-        log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH && $COMPOSE_CMD logs\"' for details."
+        log_error "Run 'ssh $SSH_HOST \"cd $REMOTE_PATH/.devcontainer && $COMPOSE_CMD logs\"' for details."
         exit 1
     fi
     sleep 2
 }
 
 open_editor() {
-    local container_workspace uri
+    local container_workspace uri remote_workspace_path
+    remote_workspace_path=$(resolve_remote_path_absolute "$REMOTE_PATH")
+
     # Read workspaceFolder from devcontainer.json on remote host
     # shellcheck disable=SC2029
     container_workspace=$(ssh "$SSH_HOST" \
         "grep -o '\"workspaceFolder\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' \
-         ${REMOTE_PATH}/.devcontainer/devcontainer.json 2>/dev/null" \
+         ${remote_workspace_path}/.devcontainer/devcontainer.json 2>/dev/null" \
         | sed 's/.*: *"//;s/"//' || echo "/workspace")
 
     # Default to /workspace if workspaceFolder not found
@@ -428,7 +454,7 @@ open_editor() {
 
     # Build URI using Python helper
     if ! uri=$(python3 "$SCRIPT_DIR/devc_remote_uri.py" \
-        "$REMOTE_PATH" \
+        "$remote_workspace_path" \
         "$SSH_HOST" \
         "$container_workspace"); then
         log_error "Failed to build editor URI. Is devc_remote_uri.py present in $SCRIPT_DIR?"

--- a/tests/test_devc_remote_preflight.sh
+++ b/tests/test_devc_remote_preflight.sh
@@ -180,6 +180,43 @@ run_container_check() {
     return $rc
 }
 
+# Helper: build a script that tests resolve_remote_path_absolute
+build_resolve_path_script() {
+    local input_path="$1" home_path="$2"
+    local tmpscript tmpsrc
+    tmpscript=$(mktemp "${TMPDIR:-/tmp}/devc_test.XXXXXX")
+    tmpsrc=$(mktemp "${TMPDIR:-/tmp}/devc_src.XXXXXX")
+
+    sed 's/^main "\$@"$/# main disabled/' "$DEVC_SCRIPT" > "$tmpsrc"
+    TMPFILES+=("$tmpsrc")
+
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -euo pipefail'
+        echo "source \"$tmpsrc\""
+        echo 'ssh() {'
+        echo "    printf '%s' \"$1\" >/dev/null"
+        echo "    printf '%s' \"$2\" >/dev/null"
+        echo "    echo \"$home_path\""
+        echo '}'
+        echo 'SSH_HOST="testhost"'
+        echo "resolve_remote_path_absolute \"$input_path\""
+    } > "$tmpscript"
+
+    echo "$tmpscript"
+}
+
+run_resolve_path() {
+    local input_path="$1" home_path="$2"
+    local tmpscript
+    tmpscript=$(build_resolve_path_script "$input_path" "$home_path")
+    TMPFILES+=("$tmpscript")
+    local output rc=0
+    output=$(bash "$tmpscript" 2>&1) || rc=$?
+    echo "$output"
+    return $rc
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Mock data sets
 # ─────────────────────────────────────────────────────────────────────────────
@@ -450,6 +487,38 @@ test_ssh_agent_fwd_fail() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# TEST: Tilde paths are resolved for editor URI construction
+# ─────────────────────────────────────────────────────────────────────────────
+test_resolve_remote_path_tilde_prefix() {
+    local output
+    # shellcheck disable=SC2088
+    output=$(run_resolve_path "~/fd5" "/home/user") || true
+
+    assert_contains "tilde prefix resolved" "$output" "/home/user/fd5"
+}
+
+test_resolve_remote_path_tilde_only() {
+    local output
+    output=$(run_resolve_path "~" "/home/user") || true
+
+    assert_contains "tilde only resolved" "$output" "/home/user"
+}
+
+test_resolve_remote_path_absolute_passthrough() {
+    local output
+    output=$(run_resolve_path "/opt/fd5" "/home/user") || true
+
+    assert_contains "absolute path unchanged" "$output" "/opt/fd5"
+}
+
+test_resolve_remote_path_relative_prefix() {
+    local output
+    output=$(run_resolve_path "fd5" "/home/user") || true
+
+    assert_contains "relative path resolved under home" "$output" "/home/user/fd5"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # RUN ALL
 # ─────────────────────────────────────────────────────────────────────────────
 echo "=== devc-remote preflight tests ==="
@@ -470,6 +539,10 @@ test_container_check_yes_reuses
 test_container_check_skip_when_not_running
 test_ssh_agent_fwd_ok
 test_ssh_agent_fwd_fail
+test_resolve_remote_path_tilde_prefix
+test_resolve_remote_path_tilde_only
+test_resolve_remote_path_absolute_passthrough
+test_resolve_remote_path_relative_prefix
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/uv.lock
+++ b/uv.lock
@@ -575,10 +575,13 @@ all = [
     { name = "ipykernel" },
     { name = "jupyter" },
     { name = "matplotlib" },
+    { name = "nibabel" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pip-licenses" },
     { name = "pre-commit" },
+    { name = "pyarrow" },
+    { name = "pydicom" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "scipy" },
@@ -591,6 +594,15 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+]
+dicom = [
+    { name = "pydicom" },
+]
+nifti = [
+    { name = "nibabel" },
+]
+parquet = [
+    { name = "pyarrow" },
 ]
 science = [
     { name = "matplotlib" },
@@ -609,24 +621,27 @@ dev = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "click", specifier = ">=8.0" },
-    { name = "fd5", extras = ["dev", "science"], marker = "extra == 'all'" },
+    { name = "fd5", extras = ["dev", "science", "dicom", "nifti", "parquet"], marker = "extra == 'all'" },
     { name = "h5py", specifier = ">=3.10" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jsonschema", specifier = ">=4.20" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.9" },
+    { name = "nibabel", marker = "extra == 'nifti'", specifier = ">=5.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "numpy", marker = "extra == 'science'", specifier = ">=2.0" },
     { name = "pandas", marker = "extra == 'science'", specifier = ">=2.2" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14.0" },
+    { name = "pydicom", marker = "extra == 'dicom'", specifier = ">=2.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = ">=1.14" },
     { name = "tomli-w", specifier = ">=1.0" },
 ]
-provides-extras = ["dev", "science", "all"]
+provides-extras = ["dev", "science", "dicom", "nifti", "parquet", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1477,6 +1492,20 @@ wheels = [
 ]
 
 [[package]]
+name = "nibabel"
+version = "5.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/8b/98e35cd0f2a97c8c261cedf8cc155766a3c540cb248d449582bb9e99c719/nibabel-5.3.3.tar.gz", hash = "sha256:8d2006b70d727fd0a798a88ae5fd64339741f436fcfc83d6ea3256cdbc51c5b7", size = 4506925, upload-time = "2025-12-05T19:16:54.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/f5/7f6aa3bbff013c0bf993129cbb2b1505790091f812accbe85cf001514737/nibabel-5.3.3-py3-none-any.whl", hash = "sha256:e8b17423ee8464da3b69e6a15799eb19f2350a7d38377026d527b6b84938adac", size = 3293989, upload-time = "2025-12-05T19:16:51.941Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1869,12 +1898,64 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydicom"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/6f/55ea163b344c91df2e03c007bebf94781f0817656e2c037d7c5bf86c3bfc/pydicom-3.0.1.tar.gz", hash = "sha256:7b8be344b5b62493c9452ba6f5a299f78f8a6ab79786c729b0613698209603ec", size = 2884731, upload-time = "2024-09-22T02:02:43.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/a6/98651e752a49f341aa99aa3f6c8ba361728dfc064242884355419df63669/pydicom-3.0.1-py3-none-any.whl", hash = "sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41", size = 2376126, upload-time = "2024-09-22T02:02:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix compose working directory**: All compose commands (`ps`, `up`, `down`) now `cd` into `$REPO_PATH/.devcontainer` instead of `$REPO_PATH`, matching where `docker-compose.yaml` actually lives.
- **Resolve tilde/relative paths for editor URI**: New `resolve_remote_path_absolute()` expands `~`, `~/...`, and relative paths via the remote `$HOME` before building the VS Code URI, so the hex-encoded config path is correct.
- **Add tests**: 4 new tests for path resolution (tilde prefix, tilde only, absolute passthrough, relative path).
- **Minor additions**: Default terminal profile set to `bash` in `devcontainer.json`; `dicom`, `nifti`, `parquet` optional dependency groups added to `uv.lock`.

Closes #156

## Test plan

- [ ] Verify `devc-remote.sh` compose commands run from `.devcontainer/` subdir on remote
- [ ] Verify tilde and relative `REMOTE_PATH` values resolve to absolute paths in the editor URI
- [ ] Run `tests/test_devc_remote_preflight.sh` — all 4 new `resolve_remote_path` tests pass
- [ ] Existing preflight tests still pass