### PR TITLE
chore(ci): add Rust and C/C++ test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@
 # Jobs:
 #   1. lint              — Pre-commit hooks (Ruff, yamllint, pymarkdown, shellcheck, etc.)
 #   2. test              — Pytest with coverage
-#   3. security          — Python security scanning (Bandit)
-#   4. dependency-review — Dependency vulnerability check (PRs only)
-#   5. summary           — Aggregate results for branch protection
+#   3. rust-test         — Rust formatting, linting (clippy), and tests
+#   4. c-build           — C library build and CTest
+#   5. security          — Python security scanning (Bandit)
+#   6. dependency-review — Dependency vulnerability check (PRs only)
+#   7. summary           — Aggregate results for branch protection
 #
 # Triggers:
 #   - Pull requests to dev, release/**, and main (runs all checks)
@@ -93,6 +95,66 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+  rust-test:
+    name: Rust Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all
+
+  c-build:
+    name: C Library Build & Test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libhdf5-dev
+
+      - name: Build
+        run: |
+          cd lib/c
+          mkdir -p build
+          cd build
+          cmake ..
+          make
+
+      - name: Test
+        run: |
+          cd lib/c/build
+          ctest --output-on-failure
+
   security:
     name: Security Scan
     runs-on: ubuntu-22.04
@@ -167,7 +229,7 @@ jobs:
     name: CI Summary
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [lint, test, security, dependency-review]
+    needs: [lint, test, rust-test, c-build, security, dependency-review]
     if: always()
 
     steps:
@@ -178,6 +240,8 @@ jobs:
           echo ""
           echo "Lint:              ${{ needs.lint.result }}"
           echo "Test:              ${{ needs.test.result }}"
+          echo "Rust Test:         ${{ needs.rust-test.result }}"
+          echo "C Build:           ${{ needs.c-build.result }}"
           echo "Security:          ${{ needs.security.result }}"
           echo "Dependency Review: ${{ needs.dependency-review.result }}"
           echo ""
@@ -191,6 +255,16 @@ jobs:
 
           if [ "${{ needs.test.result }}" = "failure" ]; then
             echo "ERROR: Tests failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.rust-test.result }}" = "failure" ]; then
+            echo "ERROR: Rust tests failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.c-build.result }}" = "failure" ]; then
+            echo "ERROR: C build/test failed"
             FAILED=true
           fi
 


### PR DESCRIPTION
## Summary
- Add `rust-test` job: checks formatting (`cargo fmt`), runs clippy lints, and executes `cargo test`
- Add `c-build` job: installs cmake/libhdf5-dev, builds the C library via cmake, and runs CTest
- Update `summary` job to aggregate results from all 7 jobs (was 5)

All new actions are SHA-pinned to match the repo's existing convention. New jobs use `ubuntu-22.04` consistent with existing jobs.

## Test plan
- [ ] CI runs successfully on this PR (rust-test and c-build jobs appear and pass)
- [ ] Summary job correctly reports results for all 7 jobs
- [ ] Existing lint, test, security, and dependency-review jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)