### PR TITLE
feat(blob): bounded-memory streaming ingest + extract (closes #231)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -624,13 +624,30 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
             Ok(())
         }
         Cmd::Extract { file, block, out } => {
-            // Stream the block to disk in bounded memory (no whole-block Vec) — a multi-GB blob
-            // extracts without buffering, and over a cloud source the zip read range-GETs just it.
+            // Stream the block in bounded memory (no whole-block Vec) — a multi-GB blob extracts
+            // without buffering, and over a cloud source the zip read range-GETs just it. Stage to a
+            // sibling `.part` and atomically rename only AFTER the digest verifies, so a corrupt
+            // block never leaves unverified bytes at the destination path.
             let mut r = Reader::open(&file)?;
-            let f = std::fs::File::create(&out).map_err(tessera_core::Error::from)?;
-            let mut w = std::io::BufWriter::new(f);
-            let n = r.stream_block(&block, &mut w)?;
-            std::io::Write::flush(&mut w).map_err(tessera_core::Error::from)?;
+            let mut tmp = out.clone().into_os_string();
+            tmp.push(".part");
+            let tmp = PathBuf::from(tmp);
+            let n = {
+                let f = std::fs::File::create(&tmp).map_err(tessera_core::Error::from)?;
+                let mut w = std::io::BufWriter::new(f);
+                match r.stream_block(&block, &mut w).and_then(|n| {
+                    std::io::Write::flush(&mut w)
+                        .map(|()| n)
+                        .map_err(Into::into)
+                }) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        let _ = std::fs::remove_file(&tmp);
+                        return Err(e);
+                    }
+                }
+            };
+            std::fs::rename(&tmp, &out).map_err(tessera_core::Error::from)?;
             println!("extracted {block} ({n} bytes) -> {}", out.display());
             Ok(())
         }

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -624,14 +624,14 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
             Ok(())
         }
         Cmd::Extract { file, block, out } => {
+            // Stream the block to disk in bounded memory (no whole-block Vec) — a multi-GB blob
+            // extracts without buffering, and over a cloud source the zip read range-GETs just it.
             let mut r = Reader::open(&file)?;
-            let bytes = r.read_block(&block)?;
-            std::fs::write(&out, &bytes).map_err(tessera_core::Error::from)?;
-            println!(
-                "extracted {block} ({} bytes) -> {}",
-                bytes.len(),
-                out.display()
-            );
+            let f = std::fs::File::create(&out).map_err(tessera_core::Error::from)?;
+            let mut w = std::io::BufWriter::new(f);
+            let n = r.stream_block(&block, &mut w)?;
+            std::io::Write::flush(&mut w).map_err(tessera_core::Error::from)?;
+            println!("extracted {block} ({n} bytes) -> {}", out.display());
             Ok(())
         }
         Cmd::Schema { file } => {

--- a/tessera/crates/tessera-core/src/hash.rs
+++ b/tessera/crates/tessera-core/src/hash.rs
@@ -16,6 +16,40 @@ pub fn digest(bytes: &[u8]) -> String {
     format!("blake3:{}", blake3::hash(bytes).to_hex())
 }
 
+/// Stream a reader through blake3 in bounded memory → the same `"blake3:<hex>"` digest as [`digest`]
+/// over the full bytes (blake3 is incremental, so a streamed hash is bit-identical to the one-shot
+/// hash). The bounded-memory path for hashing a multi-GB blob without holding it in RAM.
+pub fn digest_reader(mut r: impl std::io::Read) -> std::io::Result<String> {
+    let mut h = StreamHasher::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = r.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(h.finalize())
+}
+
+/// Incremental blake3 hasher — `update` chunks then `finalize` to the `"blake3:<hex>"` digest. Lets a
+/// caller hash a block **while** copying it (one pass, bounded memory) without re-buffering the bytes,
+/// keeping the `blake3` dependency inside the core. Equivalent to [`digest`] over the concatenated chunks.
+#[derive(Default)]
+pub struct StreamHasher(blake3::Hasher);
+
+impl StreamHasher {
+    pub fn new() -> Self {
+        Self(blake3::Hasher::new())
+    }
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+    pub fn finalize(&self) -> String {
+        format!("blake3:{}", self.0.finalize().to_hex())
+    }
+}
+
 /// Domain-separated **leaf** hash of a block digest string (`0x00` prefix).
 fn leaf_hash(block_digest: &str) -> [u8; 32] {
     let mut h = blake3::Hasher::new();

--- a/tessera/crates/tessera-ingest/src/blob.rs
+++ b/tessera/crates/tessera-ingest/src/blob.rs
@@ -101,7 +101,8 @@ mod tests {
             .collect();
         std::fs::write(&src, &bytes).unwrap();
 
-        let (in_ram, _) = to_blob_product(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+        let (in_ram, payloads) =
+            to_blob_product(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
         let streamed =
             to_blob_product_streaming(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
         // bounded-memory streaming yields the SAME identity, content hash, and seal as the in-RAM path.
@@ -109,5 +110,22 @@ mod tests {
         assert_eq!(in_ram.content_hash, streamed.content_hash);
         assert_eq!(in_ram.manifest_hash, streamed.manifest_hash);
         assert_eq!(in_ram.blocks[0].digest, streamed.blocks[0].digest);
+
+        // …and the packed `.tsra` is byte-identical end to end: in-RAM `pack` vs `pack_streaming` with
+        // the source file as the `data` fragment (closes the inductive gap to the container layer).
+        let ram_tsra = dir.path().join("ram.tsra");
+        let stream_tsra = dir.path().join("stream.tsra");
+        tessera_io::pack(&in_ram, &payloads, &ram_tsra).unwrap();
+        tessera_io::pack_streaming(
+            &streamed,
+            &[("data".to_string(), src.as_path())],
+            &stream_tsra,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read(&ram_tsra).unwrap(),
+            std::fs::read(&stream_tsra).unwrap(),
+            "streamed .tsra must be byte-identical to the in-RAM packed .tsra"
+        );
     }
 }

--- a/tessera/crates/tessera-ingest/src/blob.rs
+++ b/tessera/crates/tessera-ingest/src/blob.rs
@@ -14,9 +14,9 @@ use tessera_io::BlockPayload;
 /// basename is preserved in the descriptor (the default `tessera extract` name). `extra_sources` flow in
 /// after the `ingested_from` edge (the declarative engine threads `derived_from` / `ingested_via_spec`).
 ///
-/// **Memory:** reads the whole file into RAM (peak RSS ≈ file size) — fine for the common cases;
-/// bounded-memory streaming for multi-GB `.l64` is the tracked follow-up (#231). The sealed bytes +
-/// digest are identical either way.
+/// **Memory:** reads the whole file into RAM (peak RSS ≈ file size). The in-memory convenience for when
+/// you already hold/produce the bytes; for a large file on disk prefer [`to_blob_product_streaming`]
+/// (what the ingest engine uses) — bounded memory, byte-identical sealed result.
 pub fn to_blob_product(
     path: &Path,
     name: &str,
@@ -38,6 +38,31 @@ pub fn to_blob_product(
     }
     let sealed = b.seal()?;
     Ok((sealed, vec![payload]))
+}
+
+/// Like [`to_blob_product`] but **bounded-memory**: streams the file through blake3 (no whole-file
+/// `Vec`) and returns only the sealed manifest — the caller seals it with [`tessera_io::pack_streaming`]
+/// handing the **same `path`** as the `data` block's fragment, so a multi-GB file never enters RAM. The
+/// sealed bytes + digest are identical to [`to_blob_product`] (blake3 + `pack_streaming` are exact).
+pub fn to_blob_product_streaming(
+    path: &Path,
+    name: &str,
+    timestamp: &str,
+    media_type: Option<&str>,
+    extra_sources: &[tessera_core::provenance::Source],
+) -> Result<Manifest> {
+    let filename = path.file_name().and_then(|s| s.to_str()).unwrap_or("blob");
+    let block_ref = tessera_io::blob::blob_ref_streaming("data", filename, media_type, path)?;
+    let mut b = ProductBuilder::new("blob", name, "opaque preserved file", timestamp);
+    b.add_block_ref(block_ref);
+    b.add_source(tessera_core::provenance::Source::new(
+        "ingested_from",
+        path.display().to_string(),
+    ));
+    for s in extra_sources {
+        b.add_source(s.clone());
+    }
+    b.seal()
 }
 
 #[cfg(test)]
@@ -65,5 +90,24 @@ mod tests {
             .sources
             .iter()
             .any(|s| s.reference.contains("testscan.l64")));
+    }
+
+    #[test]
+    fn streaming_seal_is_identical_to_in_ram() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("scan.l64");
+        let bytes: Vec<u8> = (0..70_000u32)
+            .map(|k| (k.wrapping_mul(2_654_435_761) >> 9) as u8)
+            .collect();
+        std::fs::write(&src, &bytes).unwrap();
+
+        let (in_ram, _) = to_blob_product(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+        let streamed =
+            to_blob_product_streaming(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+        // bounded-memory streaming yields the SAME identity, content hash, and seal as the in-RAM path.
+        assert_eq!(in_ram.id, streamed.id);
+        assert_eq!(in_ram.content_hash, streamed.content_hash);
+        assert_eq!(in_ram.manifest_hash, streamed.manifest_hash);
+        assert_eq!(in_ram.blocks[0].digest, streamed.blocks[0].digest);
     }
 }

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -35,7 +35,7 @@ use tessera_core::collection::CollectionBuilder;
 use tessera_core::manifest::Manifest;
 use tessera_core::provenance::Source;
 use tessera_core::{Error, Result};
-use tessera_io::pack;
+use tessera_io::{pack, pack_streaming};
 
 use crate::spec::{spec_hash, validate, FormatOptions, IngestSpec, StreamingMode};
 
@@ -201,14 +201,17 @@ fn dispatch(
     let timestamp = timestamp.to_string();
     match &p.options {
         FormatOptions::Blob { input, media_type } => {
-            let (m, payloads) = crate::blob::to_blob_product(
+            // Bounded-memory: stream the file's blake3, then pack_streaming with the source file as the
+            // `data` block's fragment — a multi-GB blob never enters RAM (#231).
+            let m = crate::blob::to_blob_product_streaming(
                 input,
                 name,
                 &timestamp,
                 media_type.as_deref(),
                 extra_sources,
             )?;
-            let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
+            let m =
+                seal_streaming_to_tsra(m, &[("data".to_string(), input.as_path())], out_dir, p)?;
             Ok((m, ()))
         }
         FormatOptions::Dicom { input, deidentify } => {
@@ -400,6 +403,21 @@ fn seal_to_tsra(
     let m = apply_spec_metadata(m, &p.metadata)?;
     let path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
     pack(&m, payloads, &path)?;
+    Ok(m)
+}
+
+/// Bounded-memory counterpart of [`seal_to_tsra`]: identical metadata + naming, but the block payloads
+/// are **fragment files on disk** copied straight into the `.tsra` by `pack_streaming` (no in-RAM
+/// `BlockPayload`). Used by the blob backend, whose fragment is the un-parsed source file itself.
+fn seal_streaming_to_tsra(
+    m: Manifest,
+    sources: &[(String, &Path)],
+    out_dir: &Path,
+    p: &crate::spec::ProductSpec,
+) -> Result<Manifest> {
+    let m = apply_spec_metadata(m, &p.metadata)?;
+    let path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
+    pack_streaming(&m, sources, &path)?;
     Ok(m)
 }
 

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -37,6 +37,32 @@ pub fn blob_block(
     Ok((block_ref, BlockPayload::new(name, bytes)))
 }
 
+/// Build a blob [`BlockRef`] by **streaming** the file at `path` through blake3 in bounded memory — the
+/// bytes are never loaded into a `Vec`. Pair it with [`crate::pack_streaming`] handing the **same `path`**
+/// as the block's fragment (`(name, path)`), so a multi-GB file seals with bounded RSS. The resulting
+/// `BlockRef` + digest are byte-identical to [`blob_block`] over the same bytes (blake3 is incremental).
+pub fn blob_ref_streaming(
+    name: &str,
+    filename: &str,
+    media_type: Option<&str>,
+    path: &std::path::Path,
+) -> Result<BlockRef> {
+    let file = std::fs::File::open(path).map_err(Error::from)?;
+    let size = file.metadata().map_err(Error::from)?.len();
+    let digest =
+        tessera_core::hash::digest_reader(std::io::BufReader::new(file)).map_err(Error::from)?;
+    let mut spec = BlobSpec::new(filename, size);
+    if let Some(mt) = media_type {
+        spec = spec.with_media_type(mt);
+    }
+    Ok(BlockRef {
+        name: name.to_string(),
+        kind: BlockKind::Blob,
+        digest: Some(digest),
+        spec: serde_json::to_value(&spec)?,
+    })
+}
+
 /// Parse a blob block's [`BlobSpec`] descriptor out of its manifest [`BlockRef`] (e.g. to recover the
 /// original filename for `extract`). Errors if `r` is not a blob block or its spec is malformed.
 pub fn spec_of(r: &BlockRef) -> Result<BlobSpec> {

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -41,6 +41,11 @@ pub fn blob_block(
 /// bytes are never loaded into a `Vec`. Pair it with [`crate::pack_streaming`] handing the **same `path`**
 /// as the block's fragment (`(name, path)`), so a multi-GB file seals with bounded RSS. The resulting
 /// `BlockRef` + digest are byte-identical to [`blob_block`] over the same bytes (blake3 is incremental).
+///
+/// **The source file MUST be stable for the duration of the seal.** This hashes the file here, then
+/// `pack_streaming` re-reads it to copy the bytes — a concurrent writer / atomic-replace between the two
+/// reads would seal a `digest` that doesn't match the packed bytes (the `.tsra` would then fail its own
+/// block check on first read — caught, never silent). Ingest a quiescent file (or snapshot it first).
 pub fn blob_ref_streaming(
     name: &str,
     filename: &str,

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -241,6 +241,11 @@ impl<R: Read + Seek> Reader<R> {
     /// [`Self::read_block`] for a large blob: over a cloud `Read + Seek` source the underlying zip read
     /// issues range-GETs for just this block, so a multi-GB blob extracts (locally or from S3) without
     /// buffering it. Verifies the block digest after the last byte; returns the number of bytes written.
+    ///
+    /// **Integrity contract:** the digest is checked only *after* the final byte, so on an
+    /// `Err(Integrity)` `w` will already have received the (unverified) bytes. A caller writing to a
+    /// final destination must stage to a temp path and rename only on `Ok` (as `tessera extract` does)
+    /// — never expose `w`'s contents until this returns `Ok`.
     pub fn stream_block(&mut self, name: &str, w: &mut impl Write) -> Result<u64> {
         let expected = self
             .manifest

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -235,6 +235,48 @@ impl<R: Read + Seek> Reader<R> {
         }
         Ok(buf)
     }
+
+    /// Stream a block's bytes to `w` in **bounded memory** — copy a fixed buffer at a time, hashing as
+    /// the bytes flow, never holding the whole block in a `Vec`. The bounded counterpart of
+    /// [`Self::read_block`] for a large blob: over a cloud `Read + Seek` source the underlying zip read
+    /// issues range-GETs for just this block, so a multi-GB blob extracts (locally or from S3) without
+    /// buffering it. Verifies the block digest after the last byte; returns the number of bytes written.
+    pub fn stream_block(&mut self, name: &str, w: &mut impl Write) -> Result<u64> {
+        let expected = self
+            .manifest
+            .blocks
+            .iter()
+            .find(|b| b.name == name)
+            .and_then(|b| b.digest.clone());
+        let entry = format!("{BLOCKS_PREFIX}{name}");
+        let mut f = self
+            .archive
+            .by_name(&entry)
+            .map_err(|_| Error::Container(format!("no block entry '{entry}'")))?;
+        let mut hasher = tessera_core::hash::StreamHasher::new();
+        let mut buf = [0u8; 64 * 1024];
+        let mut total: u64 = 0;
+        loop {
+            let n = f.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+            w.write_all(&buf[..n])?;
+            total += n as u64;
+        }
+        if let Some(exp) = expected {
+            let actual = hasher.finalize();
+            if actual != exp {
+                return Err(Error::Integrity {
+                    what: "block_payload",
+                    expected: exp,
+                    actual,
+                });
+            }
+        }
+        Ok(total)
+    }
 }
 
 /// Explode a `.tsra` into a directory: `manifest.json` + `blocks/<name>` (the opt-in exploded


### PR DESCRIPTION
Closes #231. Follow-up to the blob tier (#229 / #230) — removes the whole-file-in-RAM limit on **both** sides, so a multi-GB Siemens `.l64` seals and extracts without ever buffering the file.

## Why it needn't be in RAM
blake3 is incremental and `pack_streaming` already `io::copy`s a fragment **file** into the `.tsra` through a fixed buffer — and a blob's fragment *is* the source file on disk. So:

- **WRITE** (`to_blob_product_streaming` → `seal_streaming_to_tsra`): stream the file's blake3 (`core::hash::digest_reader`, 64 KiB), then `pack_streaming` handing the source file as the `data` block's fragment. The engine blob arm uses this.
- **READ** (`Reader::stream_block`): copy a block to a writer in bounded memory, hashing as it flows (digest verified after the last byte). `tessera extract` uses it — and over a cloud `Read+Seek` source the zip read **range-GETs just that block**, so a 3 GB blob extracts from S3 without buffering.

## DRY
- Reuses the **same `pack_streaming`** primitive the HDF/write-engine streaming uses; the blob just hands its source file as the fragment.
- `seal_streaming_to_tsra` mirrors `seal_to_tsra`, **reusing** `apply_spec_metadata` + `sanitize_filename` (only `pack`→`pack_streaming`).
- New `digest_reader` + `StreamHasher` live in `core::hash` (reusable by any block); `digest_reader` is built on `StreamHasher` — one hashing primitive.
- In-RAM + streaming variants mirror the codebase's existing `read_block`/`stream_block` duality.

## Determinism
`streaming_seal_is_identical_to_in_ram` asserts the streamed seal is byte-identical to the in-RAM path (same id / content_hash / manifest_hash / block digest) — blake3 incremental == one-shot, `pack_streaming` == `pack`. No corpus change. Green `nix flake check`.