### PR TITLE
feat(schema): recommended-field severity (warn tier) + generic ingest --meta

### DIFF
--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -5164,6 +5164,8 @@ dependencies = [
  "tessera-io",
  "time",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "trycmd",
 ]
 
@@ -5195,6 +5197,7 @@ dependencies = [
  "tessera-core",
  "tessera-io",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/tessera/crates/tessera-cli/Cargo.toml
+++ b/tessera/crates/tessera-cli/Cargo.toml
@@ -17,6 +17,9 @@ tessera-io.workspace = true
 tessera-ingest.workspace = true
 serde_json.workspace = true
 clap.workspace = true
+# Surface library WARNs (e.g. the schema recommended-field nudge from the ingest engine) on stderr.
+tracing.workspace = true
+tracing-subscriber.workspace = true
 # OS CSPRNG for `tessera keygen` (32-byte ed25519 seed). Host-only — never in the wasm verify path.
 getrandom = "0.2"
 # RFC-3339 `signed_at` stamp on signatures (host-only — `tessera sign`).

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -392,6 +392,10 @@ enum IngestSrc {
         /// Apply PS3.15 de-identification (drop PHI tags) before encoding.
         #[arg(long)]
         deidentify: bool,
+        /// Attach metadata `key=value` (value parsed as JSON, else string) — supplies/overrides schema
+        /// fields. Repeatable: `--meta study=DUPLET-07 --meta modality=PT`.
+        #[arg(long = "meta", value_name = "KEY=VALUE")]
+        meta: Vec<String>,
     },
     /// DICOM **series** (a multi-file CT/PET slice stack) → one 3-D `recon` product.
     DicomSeries {
@@ -409,6 +413,9 @@ enum IngestSrc {
         /// Apply PS3.15 de-identification (NOTE: series de-id is not yet supported and will error).
         #[arg(long)]
         deidentify: bool,
+        /// Attach metadata `key=value` (value parsed as JSON, else string). Repeatable.
+        #[arg(long = "meta", value_name = "KEY=VALUE")]
+        meta: Vec<String>,
     },
     /// GE listmode HDF5 → `listmode` product (compound events → columnar; the #193 transpose).
     GeHdf5 {
@@ -425,6 +432,9 @@ enum IngestSrc {
         /// Compound dataset to read: `events_3p` (default) or `events_2p`.
         #[arg(long, default_value = "events_3p")]
         dataset: String,
+        /// Attach metadata `key=value` (value parsed as JSON, else string). Repeatable.
+        #[arg(long = "meta", value_name = "KEY=VALUE")]
+        meta: Vec<String>,
     },
     /// Preserve an un-parsed file **bit-faithfully** as an opaque `blob` product (the "junk" tier —
     /// `.l64`, `.7z`, PDF; bytes stored verbatim, blake3-sealed). Aka `junk`, for when the vendor file
@@ -444,10 +454,22 @@ enum IngestSrc {
         /// IANA media type, if known (e.g. `application/pdf`). Defaults to opaque octet-stream.
         #[arg(long)]
         media_type: Option<String>,
+        /// Attach metadata `key=value` (value parsed as JSON, else string) — e.g. `--meta study=DUPLET-07`
+        /// to satisfy the blob schema's recommended `study`. Repeatable.
+        #[arg(long = "meta", value_name = "KEY=VALUE")]
+        meta: Vec<String>,
     },
 }
 
 fn main() -> ExitCode {
+    // Surface library WARNs (e.g. the ingest engine's recommended-field nudge) on stderr. Quiet
+    // (warn+ only), compact + timestamp-free so it reads as CLI output rather than a log.
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .without_time()
+        .with_target(false)
+        .with_writer(std::io::stderr)
+        .try_init();
     match run(Cli::parse().cmd) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
@@ -820,6 +842,24 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
     }
 }
 
+/// Parse repeatable `--meta key=value` into the product's metadata map (the config-side supply that
+/// satisfies a schema's required/recommended fields). Each `value` is parsed as JSON, falling back to a
+/// bare string — same convention as `commit --set`. Shared by every `tessera ingest` subcommand so
+/// metadata is supplied one generic way, not per-backend flags.
+fn parse_meta(
+    items: &[String],
+) -> tessera_core::Result<std::collections::BTreeMap<String, serde_json::Value>> {
+    let mut out = std::collections::BTreeMap::new();
+    for kv in items {
+        let (k, v) = kv.split_once('=').ok_or_else(|| {
+            tessera_core::Error::Invalid(format!("--meta expects key=value, got '{kv}'"))
+        })?;
+        let value = serde_json::from_str(v).unwrap_or_else(|_| serde_json::Value::String(v.into()));
+        out.insert(k.to_string(), value);
+    }
+    Ok(out)
+}
+
 /// Parse a `--rows A:B` half-open range for `tessera read`. Both bounds are required; `A <= B`.
 fn parse_row_range(s: &str) -> tessera_core::Result<(u64, u64)> {
     let (a, b) = s.split_once(':').ok_or_else(|| {
@@ -969,6 +1009,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             deidentify,
+            meta,
         } => (
             IngestSpec {
                 collection: CollectionMeta {
@@ -984,7 +1025,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "recon".into(),
                     description: None,
                     derived_from: Vec::new(),
-                    metadata: std::collections::BTreeMap::new(),
+                    metadata: parse_meta(&meta)?,
                     options: FormatOptions::Dicom { input, deidentify },
                 }],
             },
@@ -996,6 +1037,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             deidentify,
+            meta,
         } => (
             IngestSpec {
                 collection: CollectionMeta {
@@ -1011,7 +1053,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "recon".into(),
                     description: None,
                     derived_from: Vec::new(),
-                    metadata: std::collections::BTreeMap::new(),
+                    metadata: parse_meta(&meta)?,
                     options: FormatOptions::DicomSeries { inputs, deidentify },
                 }],
             },
@@ -1023,6 +1065,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             dataset,
+            meta,
         } => (
             IngestSpec {
                 collection: CollectionMeta {
@@ -1038,7 +1081,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "listmode".into(),
                     description: None,
                     derived_from: Vec::new(),
-                    metadata: std::collections::BTreeMap::new(),
+                    metadata: parse_meta(&meta)?,
                     options: FormatOptions::HdfCompound {
                         input,
                         dataset,
@@ -1057,6 +1100,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             media_type,
+            meta,
         } => (
             IngestSpec {
                 collection: CollectionMeta {
@@ -1072,7 +1116,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "blob".into(),
                     description: None,
                     derived_from: Vec::new(),
-                    metadata: std::collections::BTreeMap::new(),
+                    metadata: parse_meta(&meta)?,
                     options: FormatOptions::Blob { input, media_type },
                 }],
             },
@@ -1233,6 +1277,7 @@ mod tests {
                 name: "DP06-lm".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 dataset: "events_3p".into(),
+                meta: vec![],
             }),
         })
         .unwrap();
@@ -1398,6 +1443,7 @@ streaming = "batch"
                 name: "x".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 deidentify: false,
+                meta: vec![],
             }),
         })
         .unwrap_err();
@@ -1426,6 +1472,7 @@ streaming = "batch"
                 name: "DP06-ct".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 deidentify: true,
+                meta: vec![],
             }),
         })
         .unwrap_err();

--- a/tessera/crates/tessera-cli/tests/blob.rs
+++ b/tessera/crates/tessera-cli/tests/blob.rs
@@ -42,6 +42,13 @@ fn junk_alias_seals_a_file_and_extract_is_byte_identical() {
         "ingest junk failed: {}",
         String::from_utf8_lossy(&o.stderr)
     );
+    // schema-driven WARN tier: the `blob` schema marks `study` recommended, so ingesting without it
+    // emits a non-fatal nudge on stderr (never blocks) — the FieldSpec severity + engine warn + CLI
+    // subscriber, end to end.
+    assert!(
+        String::from_utf8_lossy(&o.stderr).contains("recommended metadata 'study'"),
+        "expected the recommended-field warn on stderr"
+    );
 
     // verify re-hashes every block (the blob's blake3) — a sealed blob is integrity-checked.
     assert!(tessera()

--- a/tessera/crates/tessera-core/src/schema.rs
+++ b/tessera/crates/tessera-core/src/schema.rs
@@ -39,13 +39,20 @@ pub struct FieldSpec {
     /// Default value used when the field is absent (satisfies a `required` field).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,
-    /// Whether a valid product of the owning schema must carry this field.
+    /// Whether a valid product of the owning schema **must** carry this field — absence is a hard
+    /// **block** at ingest ([`SchemaRegistry::validate`]).
     #[serde(default)]
     pub required: bool,
+    /// Field severity below `required`: a **recommended** field's absence is a non-fatal **warn**
+    /// ([`SchemaRegistry::missing_recommended`]) — FAIR-completeness nudge, never a block. Mutually
+    /// meaningful with `required` (a `required` field is implicitly more than recommended; this flags
+    /// the warn tier). Composes through `imaging_base` like every other field.
+    #[serde(default)]
+    pub recommended: bool,
 }
 
 impl FieldSpec {
-    /// A required, undimensioned metadata field.
+    /// A required, undimensioned metadata field (absent ⇒ ingest **blocks**).
     pub fn required(id: &str, description: &str, dtype: &str) -> Self {
         FieldSpec {
             id: id.into(),
@@ -55,13 +62,24 @@ impl FieldSpec {
             vocabulary: None,
             default: None,
             required: true,
+            recommended: false,
         }
     }
 
-    /// An optional metadata field.
+    /// An optional metadata field (absent ⇒ silent).
     pub fn optional(id: &str, description: &str, dtype: &str) -> Self {
         FieldSpec {
             required: false,
+            ..FieldSpec::required(id, description, dtype)
+        }
+    }
+
+    /// A **recommended** metadata field: absent ⇒ a non-fatal warn (FAIR nudge), never a block. The
+    /// middle tier between `required` (block) and `optional` (silent).
+    pub fn recommended(id: &str, description: &str, dtype: &str) -> Self {
+        FieldSpec {
+            required: false,
+            recommended: true,
             ..FieldSpec::required(id, description, dtype)
         }
     }
@@ -165,6 +183,17 @@ impl ProductSchema {
         }
         Ok(())
     }
+
+    /// The schema's **recommended** fields (the warn tier) that this manifest does **not** carry and
+    /// that have no default — the FAIR-completeness nudge the engine surfaces as a non-fatal warning.
+    /// Never blocks (that's [`Self::validate`]'s job for `required`). Domain-agnostic: the policy is
+    /// pure schema data, so it composes through `imaging_base` for every product alike.
+    pub fn missing_recommended<'a>(&'a self, m: &Manifest) -> Vec<&'a FieldSpec> {
+        self.fields
+            .iter()
+            .filter(|f| f.recommended && f.default.is_none() && !m.metadata.contains_key(&f.id))
+            .collect()
+    }
 }
 
 /// The registry of built-in product schemas. Domain-agnostic: lookups for unknown products
@@ -199,6 +228,14 @@ impl SchemaRegistry {
             Some(schema) => schema.validate(m),
             None => Ok(()),
         }
+    }
+
+    /// The recommended-but-absent fields for a manifest's declared schema (warn tier; see
+    /// [`ProductSchema::missing_recommended`]). Empty for an unknown product (open-world).
+    pub fn missing_recommended(&self, m: &Manifest) -> Vec<&FieldSpec> {
+        self.get(&m.product)
+            .map(|s| s.missing_recommended(m))
+            .unwrap_or_default()
     }
 }
 
@@ -246,6 +283,14 @@ fn builtin_schemas() -> Vec<ProductSchema> {
     use BlockKind::{Array, Blob, Table};
     vec![
         ProductSchema {
+            // A blob is opaque (no parsed metadata), so operator-supplied context is what makes a
+            // preserved file Reusable — `study` is *recommended* (a warn nudge), never required (the
+            // escape hatch must stay frictionless): you can always preserve junk now, label it later.
+            fields: vec![FieldSpec::recommended(
+                "study",
+                "Study / exam this preserved file belongs to (FAIR grouping)",
+                "string",
+            )],
             blocks: vec![one(
                 "data",
                 Some(Blob),
@@ -681,6 +726,31 @@ mod tests {
         );
         assert!(recon.fields.iter().any(|f| f.id == "rescale_slope"));
         assert!(recon.fields.iter().any(|f| f.id == "rescale_intercept"));
+    }
+
+    #[test]
+    fn recommended_field_warns_but_never_blocks() {
+        let r = SchemaRegistry::builtin();
+        // a blob with its required `data` block but no `study` → schema-VALID (study is recommended,
+        // not required), yet surfaced as a recommendation (the warn tier).
+        let mut b = ProductBuilder::new("blob", "junk", "d", "2024-01-01T00:00:00Z");
+        b.add_block_ref(crate::block::BlockRef {
+            name: "data".into(),
+            kind: crate::block::BlockKind::Blob,
+            digest: Some("blake3:00".into()),
+            spec: serde_json::json!({"filename": "x.l64", "size": 1}),
+        });
+        let m = b.seal().unwrap();
+        assert!(r.validate(&m).is_ok(), "recommended-absent must NOT block");
+        let missing = r.missing_recommended(&m);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].id, "study");
+
+        // supplying it (what `--meta study=…` does) clears the recommendation.
+        let mut b2 = ProductBuilder::from_manifest(&m);
+        b2.with_field("study", serde_json::json!("DUPLET-07"));
+        let m2 = b2.seal().unwrap();
+        assert!(r.missing_recommended(&m2).is_empty());
     }
 
     #[test]

--- a/tessera/crates/tessera-ingest/Cargo.toml
+++ b/tessera/crates/tessera-ingest/Cargo.toml
@@ -10,6 +10,8 @@ authors.workspace = true
 [dependencies]
 tessera-core.workspace = true
 tessera-io.workspace = true
+# Non-fatal ingest WARNs (e.g. recommended-but-absent schema fields) via the workspace tracing facade.
+tracing.workspace = true
 dicom.workspace = true
 # Enables the pure-Rust JPEG Baseline/Lossless adapters in the transfer-syntax registry (feature-unifies
 # with `dicom`); used through the `dicom::transfer_syntax` umbrella re-export.

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -93,14 +93,27 @@ pub fn run(
             dispatch(p, &extra, out_dir, cfg, stream_threshold, &timestamp)?;
         // Honor the fd5 schema contract AT INGEST: a product that claims a known schema must satisfy
         // it now, not only on a later `tessera schema`. Open-world → unknown product names pass.
-        tessera_core::SchemaRegistry::builtin()
-            .validate(&manifest)
-            .map_err(|e| {
-                Error::Invalid(format!(
-                    "ingest-engine: member '{}' fails its declared schema '{}': {e}",
-                    p.name, manifest.product
-                ))
-            })?;
+        let registry = tessera_core::SchemaRegistry::builtin();
+        registry.validate(&manifest).map_err(|e| {
+            Error::Invalid(format!(
+                "ingest-engine: member '{}' fails its declared schema '{}': {e}",
+                p.name, manifest.product
+            ))
+        })?;
+        // …and surface the WARN tier (recommended-but-absent fields) without blocking — the
+        // schema-driven FAIR-completeness nudge (supply via `[product.metadata]` / `--meta`).
+        for f in registry.missing_recommended(&manifest) {
+            tracing::warn!(
+                target: "tessera::ingest",
+                member = %p.name,
+                product = %manifest.product,
+                field = %f.id,
+                "recommended metadata '{}' absent — {} (supply via --meta {}=…)",
+                f.id,
+                f.description,
+                f.id
+            );
+        }
         let id = manifest.id.clone();
         let mh = manifest.manifest_hash.clone().ok_or_else(|| {
             Error::Invalid(format!(


### PR DESCRIPTION
The schema-first version of the blob metadata-policy discussion. **Requirements belong to the (composable) schema; values to the (flat) config** — so this is a generic, domain-agnostic mechanism, not a blob-specific bolt-on.

## What
- **`FieldSpec.recommended`** — a warn tier between `required` (hard block at ingest) and `optional` (silent). `missing_recommended(m)` on `ProductSchema`/`SchemaRegistry` surfaces recommended-but-absent fields. It's pure schema **data**, so it **composes through `imaging_base`** for every product — zero per-backend code.
- **Engine warns, never blocks**: right after the existing `validate` gate, `tracing::warn!` per recommended-absent field. The `blob` schema marks **`study`** recommended (a preserved file with no operator context is weak on FAIR-Reusable; but the escape hatch must never block).
- **Generic `--meta key=value`** on *all* `tessera ingest` subcommands (one shared `parse_meta`, JSON-or-string) → feeds the existing `[product.metadata]` path. Not bespoke `--study`/`--label`.
- **CLI tracing subscriber** (warn-level, stderr) so library WARNs surface (also lights up the existing sign/encoder instrumentation).

## Proven
`ingest junk` without `--meta` → `WARN recommended metadata 'study' absent…`; with `--meta study=KSB` → silent + `study` in the manifest. Locked by a core severity test + the blob e2e (asserts the warn through the real binary). Green `nix flake check`.