### PR TITLE
feat(blob): cloud-aware extract + verify-while-pack + opt-in parallel blake3

### DIFF
--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "rayon-core",
 ]
 
 [[package]]
@@ -5204,6 +5205,7 @@ dependencies = [
 name = "tessera-io"
 version = "0.0.0"
 dependencies = [
+ "blake3",
  "bytes",
  "criterion",
  "futures",

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -47,13 +47,23 @@ fn open_local_or_url(arg: &std::path::Path) -> tessera_core::Result<Box<dyn Tsra
     Ok(Box::new(Reader::open(arg)?))
 }
 
-/// CLI-only erased view over a `Reader<R>` — narrows the trait-object surface to the two
-/// methods `inspect` / `verify` actually need (manifest access + per-block read). Hides the
-/// concrete `R` (local `File` vs `ObjectStoreReader`) behind a single boxed handle.
+/// CLI-only erased view over a `Reader<R>` — narrows the trait-object surface to the few
+/// methods `inspect` / `verify` / `extract` actually need (manifest access, per-block read,
+/// bounded-memory stream). Hides the concrete `R` (local `File` vs `ObjectStoreReader`)
+/// behind a single boxed handle.
 trait TsraSource {
     fn manifest(&self) -> &tessera_core::Manifest;
     fn read_block_by_name(&mut self, name: &str) -> tessera_core::Result<Vec<u8>>;
     fn block_names(&self) -> Vec<String>;
+    /// Bounded-memory copy of a block's bytes into `w`, digest-verified after the last byte.
+    /// Delegates to [`Reader::stream_block`] — preserves the same integrity contract: on
+    /// `Err(Integrity)` the writer already saw the unverified bytes, so callers must stage to
+    /// a temp path and only expose the final destination on `Ok`.
+    fn stream_block_to(
+        &mut self,
+        name: &str,
+        w: &mut dyn std::io::Write,
+    ) -> tessera_core::Result<u64>;
 }
 
 impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
@@ -65,6 +75,16 @@ impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
     }
     fn block_names(&self) -> Vec<String> {
         Reader::block_names(self)
+    }
+    fn stream_block_to(
+        &mut self,
+        name: &str,
+        mut w: &mut dyn std::io::Write,
+    ) -> tessera_core::Result<u64> {
+        // `Reader::stream_block` is generic over `W: Write` (implicit `Sized`), so re-borrow the
+        // trait object as `&mut &mut dyn Write` — the mutable-reference impl of `Write` is itself
+        // `Sized`, which keeps the generic happy without changing the underlying writer.
+        Reader::stream_block(self, name, &mut w)
     }
 }
 
@@ -650,14 +670,18 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
             // without buffering, and over a cloud source the zip read range-GETs just it. Stage to a
             // sibling `.part` and atomically rename only AFTER the digest verifies, so a corrupt
             // block never leaves unverified bytes at the destination path.
-            let mut r = Reader::open(&file)?;
+            //
+            // Routed through `open_local_or_url` so `s3://…` / `http(s)://…` work transparently when
+            // the `cloud` feature is built; without it, it's a thin wrapper over `Reader::open` so
+            // local extract behaves exactly as before.
+            let mut r = open_local_or_url(&file)?;
             let mut tmp = out.clone().into_os_string();
             tmp.push(".part");
             let tmp = PathBuf::from(tmp);
             let n = {
                 let f = std::fs::File::create(&tmp).map_err(tessera_core::Error::from)?;
                 let mut w = std::io::BufWriter::new(f);
-                match r.stream_block(&block, &mut w).and_then(|n| {
+                match r.stream_block_to(&block, &mut w).and_then(|n| {
                     std::io::Write::flush(&mut w)
                         .map(|()| n)
                         .map_err(Into::into)

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -35,7 +35,7 @@ use tessera_core::collection::CollectionBuilder;
 use tessera_core::manifest::Manifest;
 use tessera_core::provenance::Source;
 use tessera_core::{Error, Result};
-use tessera_io::{pack, pack_streaming};
+use tessera_io::{pack, pack_streaming_verified};
 
 use crate::spec::{spec_hash, validate, FormatOptions, IngestSpec, StreamingMode};
 
@@ -420,8 +420,13 @@ fn seal_to_tsra(
 }
 
 /// Bounded-memory counterpart of [`seal_to_tsra`]: identical metadata + naming, but the block payloads
-/// are **fragment files on disk** copied straight into the `.tsra` by `pack_streaming` (no in-RAM
-/// `BlockPayload`). Used by the blob backend, whose fragment is the un-parsed source file itself.
+/// are **fragment files on disk** copied straight into the `.tsra` by `pack_streaming_verified` (no
+/// in-RAM `BlockPayload`). Used by the blob backend, whose fragment is the un-parsed source file
+/// itself — so the verified packer is mandatory here, not optional: the two-read race in
+/// [`crate::blob::to_blob_product_streaming`] (hash the file, then pack copies it) becomes a loud
+/// `Err(Integrity)` instead of a dead-on-arrival `.tsra` if the source file changes between the two
+/// reads. The verify happens on the bytes already buffered for the write, so the on-disk archive is
+/// byte-identical to the unverified path (the conformance corpus is unaffected).
 fn seal_streaming_to_tsra(
     m: Manifest,
     sources: &[(String, &Path)],
@@ -430,7 +435,7 @@ fn seal_streaming_to_tsra(
 ) -> Result<Manifest> {
     let m = apply_spec_metadata(m, &p.metadata)?;
     let path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
-    pack_streaming(&m, sources, &path)?;
+    pack_streaming_verified(&m, sources, &path)?;
     Ok(m)
 }
 

--- a/tessera/crates/tessera-io/Cargo.toml
+++ b/tessera/crates/tessera-io/Cargo.toml
@@ -15,7 +15,10 @@ serde_json.workspace = true
 # `Hasher::update_rayon` (see [`blob::digest_file_parallel`]). The base `blake3` is already pulled in
 # by `tessera-core`; this line just turns the `rayon` feature on for builds that include `tessera-io`.
 # The wasm-core gate (`--package tessera-core --lib`) does NOT include this crate, so `rayon` never
-# enters the wasm graph — the spine stays single-threaded and wasm-compatible (ADR-0034).
+# enters the wasm graph — the spine stays single-threaded and wasm-compatible (ADR-0034). NB: a host
+# `cargo build --workspace` DOES feature-unify rayon into blake3 for tessera-core's *host* build (that's
+# fine — rayon is host-portable); the wasm-incompatibility only matters for the wasm32 target, which the
+# isolated `--package tessera-core` gate above never co-builds with tessera-io.
 blake3 = { workspace = true, features = ["rayon"] }
 zip.workspace = true
 zarrs.workspace = true

--- a/tessera/crates/tessera-io/Cargo.toml
+++ b/tessera/crates/tessera-io/Cargo.toml
@@ -11,6 +11,12 @@ authors.workspace = true
 tessera-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# blake3 with the **`rayon`** feature — opt-in multi-core hashing for large-file blob ingest via
+# `Hasher::update_rayon` (see [`blob::digest_file_parallel`]). The base `blake3` is already pulled in
+# by `tessera-core`; this line just turns the `rayon` feature on for builds that include `tessera-io`.
+# The wasm-core gate (`--package tessera-core --lib`) does NOT include this crate, so `rayon` never
+# enters the wasm graph — the spine stays single-threaded and wasm-compatible (ADR-0034).
+blake3 = { workspace = true, features = ["rayon"] }
 zip.workspace = true
 zarrs.workspace = true
 bytes.workspace = true

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -43,9 +43,12 @@ pub fn blob_block(
 /// `BlockRef` + digest are byte-identical to [`blob_block`] over the same bytes (blake3 is incremental).
 ///
 /// **The source file MUST be stable for the duration of the seal.** This hashes the file here, then
-/// `pack_streaming` re-reads it to copy the bytes — a concurrent writer / atomic-replace between the two
-/// reads would seal a `digest` that doesn't match the packed bytes (the `.tsra` would then fail its own
-/// block check on first read — caught, never silent). Ingest a quiescent file (or snapshot it first).
+/// the packer re-reads it to copy the bytes — a concurrent writer / atomic-replace between the two
+/// reads would otherwise seal a `digest` that doesn't match the packed bytes. The ingest engine pairs
+/// this builder with [`crate::pack_streaming_verified`], which re-hashes each fragment **as it copies**
+/// and returns [`Error::Integrity`] (`what = "block_payload"`) on a mismatch — so the race is caught at
+/// pack time, not silently produced and only discovered on the first read. Ingest a quiescent file (or
+/// snapshot it first) to avoid that error path entirely.
 pub fn blob_ref_streaming(
     name: &str,
     filename: &str,

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -237,11 +237,10 @@ mod tests {
         std::fs::write(&path, &bytes).unwrap();
 
         // 1. raw digest helpers: parallel == single-thread streamed == one-shot.
-        let serial =
-            tessera_core::hash::digest_reader(std::io::BufReader::new(
-                std::fs::File::open(&path).unwrap(),
-            ))
-            .unwrap();
+        let serial = tessera_core::hash::digest_reader(std::io::BufReader::new(
+            std::fs::File::open(&path).unwrap(),
+        ))
+        .unwrap();
         let parallel = digest_file_parallel(&path).unwrap();
         let one_shot = tessera_core::hash::digest(&bytes);
         assert_eq!(
@@ -258,13 +257,9 @@ mod tests {
         //    invariant a downstream `verify` will check.
         let serial_ref =
             blob_ref_streaming("data", "big.bin", Some("application/octet-stream"), &path).unwrap();
-        let parallel_ref = blob_ref_streaming_parallel(
-            "data",
-            "big.bin",
-            Some("application/octet-stream"),
-            &path,
-        )
-        .unwrap();
+        let parallel_ref =
+            blob_ref_streaming_parallel("data", "big.bin", Some("application/octet-stream"), &path)
+                .unwrap();
         assert_eq!(serial_ref.name, parallel_ref.name);
         assert_eq!(serial_ref.kind, parallel_ref.kind);
         assert_eq!(serial_ref.digest, parallel_ref.digest);

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -87,7 +87,9 @@ pub fn blob_ref_streaming(
 /// The read loop pulls up to [`PARALLEL_HASH_CHUNK`] (16 MiB) into RAM, then calls
 /// [`blake3::Hasher::update_rayon`] — which fans the chunk out across the global rayon pool. Peak RSS is
 /// one chunk (16 MiB) plus blake3's tiny per-thread state; throughput on a CPU-bound multi-GB hash
-/// scales near-linearly with cores until the disk read rate is the floor.
+/// scales near-linearly with cores until the disk read rate is the floor. The 16 MiB buffer is
+/// allocated **per call** (not a reused pool) — irrelevant for one-file blob ingest, but if you ever
+/// fan this over thousands of small files, hoist the buffer.
 ///
 /// **Opt-in**, host-only (this crate is not in the wasm-core build graph — see the crate's `Cargo.toml`
 /// note on the `rayon` feature). The default ingest path stays [`blob_ref_streaming`]'s single-threaded

--- a/tessera/crates/tessera-io/src/blob.rs
+++ b/tessera/crates/tessera-io/src/blob.rs
@@ -6,11 +6,20 @@
 //! `blake3(bytes)` with the raw bytes and a self-describing [`BlobSpec`]. `tessera verify` then proves the
 //! bytes are unchanged since sealing. The opaque preservation tier behind [`tessera_core::block::blob`].
 
+use std::io::Read;
+use std::path::Path;
+
 use tessera_core::block::blob::BlobSpec;
 use tessera_core::block::{BlockKind, BlockRef};
 use tessera_core::{Error, Result};
 
 use crate::BlockPayload;
+
+/// Chunk size (16 MiB) for [`digest_file_parallel`]'s read → `update_rayon` loop. Sized so each call to
+/// `update_rayon` has enough bytes for blake3's internal tree to split work across many cores (blake3
+/// parallelizes at a 128 KiB internal granularity, so 16 MiB ≈ 128 sub-chunks → cleanly saturates a
+/// 32+ core box), while keeping peak per-call RSS modest (one chunk in RAM at a time).
+const PARALLEL_HASH_CHUNK: usize = 16 * 1024 * 1024;
 
 /// Seal raw `bytes` as an opaque blob block named `name`: digest = `blake3(bytes)`, descriptor records
 /// `filename` / `media_type` / size. The returned payload is the bytes verbatim (stored uncompressed in
@@ -59,6 +68,79 @@ pub fn blob_ref_streaming(
     let size = file.metadata().map_err(Error::from)?.len();
     let digest =
         tessera_core::hash::digest_reader(std::io::BufReader::new(file)).map_err(Error::from)?;
+    let mut spec = BlobSpec::new(filename, size);
+    if let Some(mt) = media_type {
+        spec = spec.with_media_type(mt);
+    }
+    Ok(BlockRef {
+        name: name.to_string(),
+        kind: BlockKind::Blob,
+        digest: Some(digest),
+        spec: serde_json::to_value(&spec)?,
+    })
+}
+
+/// **Multi-core** blake3 of the file at `path` → the same `"blake3:<hex>"` digest as
+/// [`tessera_core::hash::digest_reader`] would produce over the same bytes (blake3 guarantees
+/// byte-identical output regardless of how the input is sliced or how the internal tree is parallelized).
+///
+/// The read loop pulls up to [`PARALLEL_HASH_CHUNK`] (16 MiB) into RAM, then calls
+/// [`blake3::Hasher::update_rayon`] — which fans the chunk out across the global rayon pool. Peak RSS is
+/// one chunk (16 MiB) plus blake3's tiny per-thread state; throughput on a CPU-bound multi-GB hash
+/// scales near-linearly with cores until the disk read rate is the floor.
+///
+/// **Opt-in**, host-only (this crate is not in the wasm-core build graph — see the crate's `Cargo.toml`
+/// note on the `rayon` feature). The default ingest path stays [`blob_ref_streaming`]'s single-threaded
+/// `digest_reader` — callers that *want* the multi-core hash call this directly or
+/// [`blob_ref_streaming_parallel`]. Identical digest, just faster.
+pub fn digest_file_parallel(path: &Path) -> Result<String> {
+    let file = std::fs::File::open(path).map_err(Error::from)?;
+    let mut reader = std::io::BufReader::with_capacity(PARALLEL_HASH_CHUNK, file);
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = vec![0u8; PARALLEL_HASH_CHUNK];
+    loop {
+        // Fill `buf` with one full chunk's worth of bytes (or until EOF) before the parallel `update_rayon`
+        // call — under-filled chunks would just collapse to a single-thread path inside blake3, so we'd
+        // rather pay one extra `Read` than fragment the parallelism.
+        let mut filled = 0usize;
+        while filled < buf.len() {
+            let n = reader.read(&mut buf[filled..]).map_err(Error::from)?;
+            if n == 0 {
+                break;
+            }
+            filled += n;
+        }
+        if filled == 0 {
+            break;
+        }
+        hasher.update_rayon(&buf[..filled]);
+        if filled < buf.len() {
+            break;
+        }
+    }
+    Ok(format!("blake3:{}", hasher.finalize().to_hex()))
+}
+
+/// Parallel-hash variant of [`blob_ref_streaming`]: hashes the file at `path` via
+/// [`digest_file_parallel`] (multi-core blake3), produces a [`BlockRef`] **byte-identical** to the
+/// single-threaded path. Pair it with [`crate::pack_streaming`] handing the **same `path`** as the
+/// block's fragment, same as the serial variant.
+///
+/// Use when: hashing a large (≫ 100 MiB) file on a multi-core box and the disk can keep up with parallel
+/// blake3 (i.e. NVMe/cached). For small files, slow storage, or the wasm build, stick with
+/// [`blob_ref_streaming`] — the parallel path adds a 16 MiB RAM bump and some rayon scheduling overhead
+/// that doesn't pay back below a few hundred MiB of input.
+///
+/// Same quiescence contract as [`blob_ref_streaming`]: the file MUST be stable from this hash through
+/// the subsequent `pack_streaming` re-read, or the sealed digest will not match the packed bytes.
+pub fn blob_ref_streaming_parallel(
+    name: &str,
+    filename: &str,
+    media_type: Option<&str>,
+    path: &Path,
+) -> Result<BlockRef> {
+    let size = std::fs::metadata(path).map_err(Error::from)?.len();
+    let digest = digest_file_parallel(path)?;
     let mut spec = BlobSpec::new(filename, size);
     if let Some(mt) = media_type {
         spec = spec.with_media_type(mt);
@@ -128,5 +210,89 @@ mod tests {
         let spec = spec_of(&reader.manifest().blocks[0]).unwrap();
         assert_eq!(spec.filename, "testscan.l64");
         assert_eq!(spec.size, bytes.len() as u64);
+    }
+
+    /// **Determinism gate** for the opt-in multi-core hash path: hashing the same file with the
+    /// single-threaded [`tessera_core::hash::digest_reader`] / [`blob_ref_streaming`] and the parallel
+    /// [`digest_file_parallel`] / [`blob_ref_streaming_parallel`] MUST produce a byte-identical
+    /// `"blake3:<hex>"` digest. blake3 guarantees this regardless of how the input is sliced or how its
+    /// internal tree is parallelized — this test pins that guarantee at our API boundary so a future
+    /// refactor (chunk size, reader wrapper, etc.) can't silently fork the content-addressed format.
+    ///
+    /// The fixture is sized to cross [`PARALLEL_HASH_CHUNK`] (16 MiB) by ~2.5x so the parallel path
+    /// actually exercises the multi-chunk + rayon split — a sub-chunk file would degenerate to a single
+    /// hash call and miss the load-bearing case.
+    #[test]
+    fn parallel_hash_equals_single_threaded_hash_byte_for_byte() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.bin");
+        // ~40 MiB of pseudo-random bytes: spans 2 full 16 MiB chunks + a partial tail, so the parallel
+        // loop pays the full update_rayon → update_rayon → update_rayon dance the real-world large-blob
+        // path takes.
+        let size: usize = (PARALLEL_HASH_CHUNK * 5) / 2;
+        let mut bytes = vec![0u8; size];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = ((i as u32).wrapping_mul(2_654_435_761) >> 13) as u8;
+        }
+        std::fs::write(&path, &bytes).unwrap();
+
+        // 1. raw digest helpers: parallel == single-thread streamed == one-shot.
+        let serial =
+            tessera_core::hash::digest_reader(std::io::BufReader::new(
+                std::fs::File::open(&path).unwrap(),
+            ))
+            .unwrap();
+        let parallel = digest_file_parallel(&path).unwrap();
+        let one_shot = tessera_core::hash::digest(&bytes);
+        assert_eq!(
+            serial, parallel,
+            "parallel blake3 MUST be byte-identical to the single-thread digest"
+        );
+        assert_eq!(
+            parallel, one_shot,
+            "parallel blake3 MUST also match the one-shot digest over the full buffer"
+        );
+        assert!(parallel.starts_with("blake3:"));
+
+        // 2. and the wrapped [`BlockRef`] producers agree on name/digest/spec.size — the seal-level
+        //    invariant a downstream `verify` will check.
+        let serial_ref =
+            blob_ref_streaming("data", "big.bin", Some("application/octet-stream"), &path).unwrap();
+        let parallel_ref = blob_ref_streaming_parallel(
+            "data",
+            "big.bin",
+            Some("application/octet-stream"),
+            &path,
+        )
+        .unwrap();
+        assert_eq!(serial_ref.name, parallel_ref.name);
+        assert_eq!(serial_ref.kind, parallel_ref.kind);
+        assert_eq!(serial_ref.digest, parallel_ref.digest);
+        assert_eq!(serial_ref.spec, parallel_ref.spec);
+    }
+
+    /// Edge case: an EMPTY file hashes to the empty-input blake3 on both paths. Guards against a chunk
+    /// loop that "forgets" to call `finalize` on a zero-byte input.
+    #[test]
+    fn parallel_hash_handles_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+        let parallel = digest_file_parallel(&path).unwrap();
+        let one_shot = tessera_core::hash::digest(b"");
+        assert_eq!(parallel, one_shot);
+    }
+
+    /// Edge case: a file SMALLER than the parallel chunk (here 1 MiB vs 16 MiB) still produces the same
+    /// digest as the single-thread path — confirms the early-EOF branch of the read loop is correct.
+    #[test]
+    fn parallel_hash_handles_sub_chunk_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small.bin");
+        let bytes: Vec<u8> = (0..1024 * 1024u32).map(|k| (k & 0xff) as u8).collect();
+        std::fs::write(&path, &bytes).unwrap();
+        let parallel = digest_file_parallel(&path).unwrap();
+        let serial = tessera_core::hash::digest(&bytes);
+        assert_eq!(parallel, serial);
     }
 }

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -124,11 +124,39 @@ pub fn pack_streaming_verified(
     pack_streaming_impl(manifest, sources, out, true)
 }
 
-/// Shared body of [`pack_streaming`] / [`pack_streaming_verified`]: identical zip entries +
-/// identical buffered copy loop, with `verify` flipping the per-fragment hash check on. Kept as one
-/// function so the two public surfaces cannot drift in entry order, options, or buffer size — a
-/// drift there would change the on-disk bytes and break the conformance corpus.
+/// Stage-and-rename wrapper for [`pack_streaming`] / [`pack_streaming_verified`]: writes the archive
+/// to a sibling `.part` via [`pack_streaming_to`] and atomically renames it to `out` only on success,
+/// so a failure never leaves a partial / known-bad `.tsra` at the destination.
 fn pack_streaming_impl(
+    manifest: &Manifest,
+    sources: &[(String, &Path)],
+    out: &Path,
+    verify: bool,
+) -> Result<()> {
+    // Stage to a sibling `.part` and atomically rename only on success, so any failure — a write
+    // error or a `verify` mismatch — never leaves a partial / known-bad `.tsra` at `out` (same
+    // crash-safe placement `tessera extract` uses). The bytes written are unchanged, so the
+    // determinism contract / corpus goldens hold.
+    let mut tmp = out.as_os_str().to_os_string();
+    tmp.push(".part");
+    let tmp = std::path::PathBuf::from(tmp);
+    match pack_streaming_to(manifest, sources, &tmp, verify) {
+        Ok(()) => {
+            std::fs::rename(&tmp, out)?;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Write the `.tsra` to `out` (a staging path) — the body shared by [`pack_streaming`] /
+/// [`pack_streaming_verified`]: identical zip entries + identical copy loop, with `verify` flipping
+/// the per-fragment hash check on. Kept as one function so the two surfaces can't drift in entry
+/// order / options / buffer size (a drift would change the on-disk bytes and break the corpus).
+fn pack_streaming_to(
     manifest: &Manifest,
     sources: &[(String, &Path)],
     out: &Path,
@@ -176,12 +204,13 @@ fn pack_streaming_impl(
         // When verifying, we hash the buffer in the same pass — one read, no extra I/O — so the
         // on-disk bytes are identical to the non-verifying path (the conformance corpus stays
         // bit-for-bit stable).
-        let f = File::open(frag)?;
-        let mut br = std::io::BufReader::with_capacity(256 * 1024, f);
+        // Read full-buffer chunks straight from the file — a BufReader would only add a second
+        // 256 KiB buffer with no benefit at this read size.
+        let mut f = File::open(frag)?;
         let mut hasher = verify.then(tessera_core::hash::StreamHasher::new);
         let mut buf = [0u8; 256 * 1024];
         loop {
-            let n = br.read(&mut buf)?;
+            let n = f.read(&mut buf)?;
             if n == 0 {
                 break;
             }
@@ -193,9 +222,8 @@ fn pack_streaming_impl(
         if let (Some(h), Some(exp)) = (hasher, expected_digest) {
             let actual = h.finalize();
             if actual != exp {
-                // Don't bother finalising the archive — a producer surfacing this error has a
-                // truly bad on-disk state (the fragment changed under us) and a partial `.tsra`
-                // is a clearer signal than a complete one with a known-bad payload.
+                // The fragment changed between hash and pack. Bail without finalising; the wrapper
+                // discards the staged `.part`, so nothing lands at the destination.
                 return Err(Error::Integrity {
                     what: "block_payload",
                     expected: exp,

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -94,6 +94,46 @@ pub fn pack(manifest: &Manifest, payloads: &[BlockPayload], path: &Path) -> Resu
 /// — proven by `pack_streaming_equals_pack` below — because both writers share [`tsra_entry_options`]
 /// and emit the mimetype/manifest/blocks in the same order.
 pub fn pack_streaming(manifest: &Manifest, sources: &[(String, &Path)], out: &Path) -> Result<()> {
+    pack_streaming_impl(manifest, sources, out, false)
+}
+
+/// **Verifying streaming pack** — identical bytes-on-disk to [`pack_streaming`], with one extra
+/// guarantee: as each fragment is copied into the zip its bytes are fed through a streaming blake3
+/// (one read, no extra buffering) and the resulting digest is compared to the `BlockRef.digest`
+/// recorded in the manifest. A mismatch returns [`Error::Integrity`] with `what = "block_payload"`
+/// **before** the archive finalises, so a fragment that changed between "hash" and "pack" can never
+/// be silently sealed into a `.tsra` whose recorded `digest` no longer matches its packed bytes
+/// (the race the blob streaming ingest opens by hashing the source file first and copying it
+/// second). For a blob block whose fragment is the **original source file**, this turns a concurrent
+/// writer / atomic-replace between the two reads into a loud `Err(Integrity)` instead of a
+/// dead-on-arrival archive that only surfaces on the first read.
+///
+/// **Determinism contract**: the output is byte-identical to [`pack_streaming`] over the same
+/// inputs (same SSoT [`tsra_entry_options`], same entry order, same copy loop — the verify happens
+/// on the bytes already buffered for the write, never reordering anything). The conformance corpus
+/// goldens MUST remain untouched.
+///
+/// Refuses (without writing) any fragment whose name has no matching block in the manifest, and any
+/// matching block whose [`BlockRef::digest`] is `None` (sealed manifests always have one — an absent
+/// digest is a malformed input, not a verify miss).
+pub fn pack_streaming_verified(
+    manifest: &Manifest,
+    sources: &[(String, &Path)],
+    out: &Path,
+) -> Result<()> {
+    pack_streaming_impl(manifest, sources, out, true)
+}
+
+/// Shared body of [`pack_streaming`] / [`pack_streaming_verified`]: identical zip entries +
+/// identical buffered copy loop, with `verify` flipping the per-fragment hash check on. Kept as one
+/// function so the two public surfaces cannot drift in entry order, options, or buffer size — a
+/// drift there would change the on-disk bytes and break the conformance corpus.
+fn pack_streaming_impl(
+    manifest: &Manifest,
+    sources: &[(String, &Path)],
+    out: &Path,
+    verify: bool,
+) -> Result<()> {
     if !manifest.is_sealed() {
         return Err(Error::Container(
             "refusing to pack an unsealed manifest".into(),
@@ -109,12 +149,60 @@ pub fn pack_streaming(manifest: &Manifest, sources: &[(String, &Path)], out: &Pa
     zw.write_all(manifest.to_json()?.as_bytes())?;
 
     for (name, frag) in sources {
+        // Resolve the manifest-recorded digest UP FRONT (only when verifying) so a typo'd name or
+        // a malformed unsealed-style ref fails before we open the file.
+        let expected_digest = if verify {
+            let r = manifest
+                .blocks
+                .iter()
+                .find(|b| &b.name == name)
+                .ok_or_else(|| {
+                    Error::Container(format!(
+                        "pack_streaming_verified: no manifest block named '{name}'"
+                    ))
+                })?;
+            Some(r.digest.clone().ok_or_else(|| {
+                Error::MissingDigest(format!(
+                    "pack_streaming_verified: block '{name}' has no recorded digest"
+                ))
+            })?)
+        } else {
+            None
+        };
+
         zw.start_file(format!("{BLOCKS_PREFIX}{name}"), stored)
             .map_err(cz)?;
         // Buffered copy: 256 KiB chunks → peak RAM ≈ one buffer (no full-block materialisation).
+        // When verifying, we hash the buffer in the same pass — one read, no extra I/O — so the
+        // on-disk bytes are identical to the non-verifying path (the conformance corpus stays
+        // bit-for-bit stable).
         let f = File::open(frag)?;
         let mut br = std::io::BufReader::with_capacity(256 * 1024, f);
-        std::io::copy(&mut br, &mut zw)?;
+        let mut hasher = verify.then(tessera_core::hash::StreamHasher::new);
+        let mut buf = [0u8; 256 * 1024];
+        loop {
+            let n = br.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            if let Some(h) = hasher.as_mut() {
+                h.update(&buf[..n]);
+            }
+            zw.write_all(&buf[..n])?;
+        }
+        if let (Some(h), Some(exp)) = (hasher, expected_digest) {
+            let actual = h.finalize();
+            if actual != exp {
+                // Don't bother finalising the archive — a producer surfacing this error has a
+                // truly bad on-disk state (the fragment changed under us) and a partial `.tsra`
+                // is a clearer signal than a complete one with a known-bad payload.
+                return Err(Error::Integrity {
+                    what: "block_payload",
+                    expected: exp,
+                    actual,
+                });
+            }
+        }
     }
     zw.finish().map_err(cz)?;
     Ok(())
@@ -438,6 +526,139 @@ mod tests {
         assert_eq!(
             ram_bytes, stream_bytes,
             "pack_streaming and pack must produce byte-identical archives"
+        );
+    }
+
+    #[test]
+    fn pack_streaming_verified_matches_pack_streaming_byte_for_byte_on_honest_input() {
+        // Determinism gate for the verifying packer: with truthful inputs (the fragment bytes hash
+        // to the digest the manifest records) the bytes on disk are byte-identical to
+        // pack_streaming over the same inputs. The verify happens on the bytes already buffered
+        // for the write — no extra entries, no reordered copy, no perturbation. The conformance
+        // corpus (golden archives) MUST stay untouched after this commit.
+        let dir = tempfile::tempdir().unwrap();
+        let mut bldr = ProductBuilder::new("recon", "DPverify", "d", "2024-01-01T00:00:00Z");
+        let payloads: Vec<BlockPayload> = (0..3)
+            .map(|i| {
+                let bytes: Vec<u8> = (0..(290_000 + i * 11))
+                    .map(|k| ((k + i) % 253) as u8)
+                    .collect();
+                let nm = format!("blob_{i}");
+                let digest = tessera_core::hash::digest(&bytes);
+                bldr.add_block_ref(tessera_core::block::BlockRef {
+                    name: nm.clone(),
+                    kind: tessera_core::block::BlockKind::Array,
+                    digest: Some(digest),
+                    spec: serde_json::json!({}),
+                });
+                BlockPayload::new(nm, bytes)
+            })
+            .collect();
+        let sealed = bldr.seal().unwrap();
+
+        let stage = dir.path().join("frags");
+        std::fs::create_dir_all(&stage).unwrap();
+        let mut frag_paths = Vec::new();
+        for p in &payloads {
+            let fp = stage.join(&p.name);
+            std::fs::write(&fp, &p.bytes).unwrap();
+            frag_paths.push((p.name.clone(), fp));
+        }
+        let sources: Vec<(String, &Path)> = frag_paths
+            .iter()
+            .map(|(n, p)| (n.clone(), p.as_path()))
+            .collect();
+        let unverified = dir.path().join("unverified.tsra");
+        let verified = dir.path().join("verified.tsra");
+        pack_streaming(&sealed, &sources, &unverified).unwrap();
+        pack_streaming_verified(&sealed, &sources, &verified).unwrap();
+        assert_eq!(
+            std::fs::read(&unverified).unwrap(),
+            std::fs::read(&verified).unwrap(),
+            "pack_streaming_verified must be byte-identical to pack_streaming on honest input"
+        );
+    }
+
+    #[test]
+    fn pack_streaming_verified_catches_fragment_mutated_between_hash_and_pack() {
+        // The race this exists to close: blob streaming ingest hashes the source file to seal the
+        // manifest, then the packer copies the same file's bytes into the .tsra. If the file is
+        // replaced between those two reads, pack_streaming would silently seal an archive whose
+        // packed bytes don't match the recorded digest (caught only later, on read). The verifying
+        // packer must catch the mismatch AT PACK TIME with a typed Error::Integrity.
+        let dir = tempfile::tempdir().unwrap();
+        // Simulate the race: hash bytes A, seal the manifest with that digest, then write bytes B
+        // to the fragment path. pack_streaming_verified must reject the mismatch.
+        let bytes_a: Vec<u8> = (0..40_000u32).map(|k| (k % 251) as u8).collect();
+        let bytes_b: Vec<u8> = (0..40_000u32).map(|k| ((k + 7) % 251) as u8).collect();
+        assert_ne!(bytes_a, bytes_b, "test setup: A and B must differ");
+
+        let digest_a = tessera_core::hash::digest(&bytes_a);
+        let mut bldr = ProductBuilder::new("blob", "race", "x", "2024-01-01T00:00:00Z");
+        bldr.add_block_ref(tessera_core::block::BlockRef {
+            name: "data".into(),
+            kind: tessera_core::block::BlockKind::Blob,
+            digest: Some(digest_a.clone()),
+            spec: serde_json::json!({}),
+        });
+        let sealed = bldr.seal().unwrap();
+
+        let frag = dir.path().join("race.bin");
+        std::fs::write(&frag, &bytes_b).unwrap(); // "the file changed between hash and pack"
+        let out = dir.path().join("race.tsra");
+        let err = pack_streaming_verified(
+            &sealed,
+            &[("data".to_string(), frag.as_path())],
+            &out,
+        )
+        .expect_err("mismatched fragment must fail the verifying pack");
+        match err {
+            Error::Integrity { what, expected, actual } => {
+                assert_eq!(what, "block_payload");
+                assert_eq!(expected, digest_a, "must surface the manifest-recorded digest");
+                assert_eq!(actual, tessera_core::hash::digest(&bytes_b));
+            }
+            other => panic!("expected Error::Integrity, got {other:?}"),
+        }
+
+        // Sanity: the non-verifying packer happily seals the same race (proving the gap the
+        // verifying packer closes — and that's the silent bad archive that surfaces only on read).
+        let dead = dir.path().join("dead.tsra");
+        pack_streaming(&sealed, &[("data".to_string(), frag.as_path())], &dead).unwrap();
+        let mut rdr = Reader::open(&dead).unwrap();
+        assert!(matches!(
+            rdr.read_block("data"),
+            Err(Error::Integrity { what: "block_payload", .. })
+        ));
+    }
+
+    #[test]
+    fn pack_streaming_verified_rejects_unknown_block_name() {
+        // A typo'd source name (no matching block in the manifest) is a producer bug, not a verify
+        // miss — fail loudly, before opening the file, with a typed Container error.
+        let dir = tempfile::tempdir().unwrap();
+        let bytes = b"abcd".to_vec();
+        let digest = tessera_core::hash::digest(&bytes);
+        let mut bldr = ProductBuilder::new("blob", "x", "x", "2024-01-01T00:00:00Z");
+        bldr.add_block_ref(tessera_core::block::BlockRef {
+            name: "data".into(),
+            kind: tessera_core::block::BlockKind::Blob,
+            digest: Some(digest),
+            spec: serde_json::json!({}),
+        });
+        let sealed = bldr.seal().unwrap();
+        let frag = dir.path().join("f.bin");
+        std::fs::write(&frag, &bytes).unwrap();
+        let out = dir.path().join("x.tsra");
+        let err = pack_streaming_verified(
+            &sealed,
+            &[("typo".to_string(), frag.as_path())],
+            &out,
+        )
+        .expect_err("unknown block name must be rejected");
+        assert!(
+            matches!(err, Error::Container(ref m) if m.contains("no manifest block named 'typo'")),
+            "expected Container error naming the missing block, got {err:?}"
         );
     }
 

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -606,16 +606,19 @@ mod tests {
         let frag = dir.path().join("race.bin");
         std::fs::write(&frag, &bytes_b).unwrap(); // "the file changed between hash and pack"
         let out = dir.path().join("race.tsra");
-        let err = pack_streaming_verified(
-            &sealed,
-            &[("data".to_string(), frag.as_path())],
-            &out,
-        )
-        .expect_err("mismatched fragment must fail the verifying pack");
+        let err = pack_streaming_verified(&sealed, &[("data".to_string(), frag.as_path())], &out)
+            .expect_err("mismatched fragment must fail the verifying pack");
         match err {
-            Error::Integrity { what, expected, actual } => {
+            Error::Integrity {
+                what,
+                expected,
+                actual,
+            } => {
                 assert_eq!(what, "block_payload");
-                assert_eq!(expected, digest_a, "must surface the manifest-recorded digest");
+                assert_eq!(
+                    expected, digest_a,
+                    "must surface the manifest-recorded digest"
+                );
                 assert_eq!(actual, tessera_core::hash::digest(&bytes_b));
             }
             other => panic!("expected Error::Integrity, got {other:?}"),
@@ -628,7 +631,10 @@ mod tests {
         let mut rdr = Reader::open(&dead).unwrap();
         assert!(matches!(
             rdr.read_block("data"),
-            Err(Error::Integrity { what: "block_payload", .. })
+            Err(Error::Integrity {
+                what: "block_payload",
+                ..
+            })
         ));
     }
 
@@ -650,12 +656,8 @@ mod tests {
         let frag = dir.path().join("f.bin");
         std::fs::write(&frag, &bytes).unwrap();
         let out = dir.path().join("x.tsra");
-        let err = pack_streaming_verified(
-            &sealed,
-            &[("typo".to_string(), frag.as_path())],
-            &out,
-        )
-        .expect_err("unknown block name must be rejected");
+        let err = pack_streaming_verified(&sealed, &[("typo".to_string(), frag.as_path())], &out)
+            .expect_err("unknown block name must be rejected");
         assert!(
             matches!(err, Error::Container(ref m) if m.contains("no manifest block named 'typo'")),
             "expected Container error naming the missing block, got {err:?}"

--- a/tessera/crates/tessera-io/src/lib.rs
+++ b/tessera/crates/tessera-io/src/lib.rs
@@ -36,7 +36,10 @@ pub use collection::{
     prefix_layout, retention_mode, to_oci_index, to_rocrate, OCI_INDEX_MEDIA_TYPE,
 };
 pub use config::{parse_byte_size, WriteConfig, DEFAULT_RAM_BUDGET};
-pub use container::{pack, pack_dir, pack_streaming, unpack, BlockPayload, Reader, MIMETYPE};
+pub use container::{
+    pack, pack_dir, pack_streaming, pack_streaming_verified, unpack, BlockPayload, Reader,
+    MIMETYPE,
+};
 pub use multiblock::{ColumnBlockIter, LogicalTableView};
 pub use range::CountingReader;
 #[cfg(feature = "cloud")]

--- a/tessera/crates/tessera-io/src/lib.rs
+++ b/tessera/crates/tessera-io/src/lib.rs
@@ -37,8 +37,7 @@ pub use collection::{
 };
 pub use config::{parse_byte_size, WriteConfig, DEFAULT_RAM_BUDGET};
 pub use container::{
-    pack, pack_dir, pack_streaming, pack_streaming_verified, unpack, BlockPayload, Reader,
-    MIMETYPE,
+    pack, pack_dir, pack_streaming, pack_streaming_verified, unpack, BlockPayload, Reader, MIMETYPE,
 };
 pub use multiblock::{ColumnBlockIter, LogicalTableView};
 pub use range::CountingReader;


### PR DESCRIPTION
The three blob follow-up niceties (built in parallel, integrated + gated together). Green `nix flake check`.

## A — cloud-aware `extract`
`tessera extract` now routes through `open_local_or_url`, so `s3://…` / `http(s)://` work under `--features cloud` (range-GETs just the block), with the local path unchanged. The stage-to-`.part` + atomic-rename-on-`Ok` safety is preserved byte-for-byte.

## B — verify-while-pack (closes the hash/pack double-read race)
`blob_ref_streaming` hashes the file, then `pack_streaming` re-reads it — a file change between the two would seal a digest that doesn't match the packed bytes (a silent DOA archive). New `pack_streaming_verified` re-hashes each fragment **as it copies** (shared loop with `pack_streaming` → byte-identical output) and returns `Error::Integrity` on mismatch. The blob ingest arm (`seal_streaming_to_tsra`) routes through it. **Corpus goldens untouched** (asserted by the conformance tests + a byte-equality test).

## C — opt-in parallel blake3
`digest_file_parallel` / `blob_ref_streaming_parallel` (16 MiB chunks → `update_rayon`) for CPU-bound multi-GB hashing. **Default path unchanged** (single-thread); callers opt in. blake3 `rayon` feature added to `tessera-io` only — **`tessera-core` (wasm) stays rayon-free** (verified via `cargo tree --target wasm32`). A determinism test asserts `serial == parallel == one-shot`.

Each was clippy-clean + crate-tested in isolation and re-verified combined; full gate green.