### PR TITLE
feat: PHI hygiene (--source-label + dicom-series --deidentify) + sensitivity tier (ADR-0040 §1)

### DIFF
--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -5164,6 +5164,7 @@ name = "tessera-cli"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "dicom",
  "getrandom 0.2.17",
  "hdf5-metno",
  "object_store",

--- a/tessera/crates/tessera-cli/Cargo.toml
+++ b/tessera/crates/tessera-cli/Cargo.toml
@@ -40,6 +40,9 @@ cloud = ["tessera-io/cloud"]
 [dev-dependencies]
 tempfile = "3"
 hdf5-metno.workspace = true
+# Synthesise minimal `.dcm` fixtures inline for ingest e2e tests (e.g. the dicom-series --deidentify
+# end-to-end test) — same workspace pin tessera-ingest uses for the real DICOM read path.
+dicom.workspace = true
 # docs-as-tests: CLI walkthroughs in tests/cmd/*.trycmd run against the real `tessera` bin (resolved via
 # CARGO_BIN_EXE_tessera — no cargo invocation at test time, so it works in the hermetic flake check).
 trycmd = "0.15"

--- a/tessera/crates/tessera-cli/src/bench.rs
+++ b/tessera/crates/tessera-cli/src/bench.rs
@@ -289,6 +289,7 @@ fn run_listmode_real(
         cfg,
         "events",
         "ms",
+        None,
         &[],
         &std::collections::BTreeMap::new(),
     )?;

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -412,6 +412,10 @@ enum IngestSrc {
         /// Apply PS3.15 de-identification (drop PHI tags) before encoding.
         #[arg(long)]
         deidentify: bool,
+        /// Clean label for the `ingested_from` provenance edge — replaces the input PATH in the
+        /// sealed manifest (ADR-0040 PHI hygiene: an absolute path on clinical data is itself PHI).
+        #[arg(long, value_name = "LABEL")]
+        source_label: Option<String>,
         /// Attach metadata `key=value` (value parsed as JSON, else string) — supplies/overrides schema
         /// fields. Repeatable: `--meta study=DUPLET-07 --meta modality=PT`.
         #[arg(long = "meta", value_name = "KEY=VALUE")]
@@ -430,9 +434,14 @@ enum IngestSrc {
         /// Acquisition timestamp (ISO-8601).
         #[arg(long)]
         timestamp: String,
-        /// Apply PS3.15 de-identification (NOTE: series de-id is not yet supported and will error).
+        /// Apply PS3.15 de-identification per-slice (strip PHI tags from each `.dcm` in memory before
+        /// the volume is stacked; source files are NOT mutated).
         #[arg(long)]
         deidentify: bool,
+        /// Clean label for the `ingested_from` provenance edge — replaces the per-slice joined paths
+        /// (an N-slice series would embed N PHI-bearing absolute paths). ADR-0040.
+        #[arg(long, value_name = "LABEL")]
+        source_label: Option<String>,
         /// Attach metadata `key=value` (value parsed as JSON, else string). Repeatable.
         #[arg(long = "meta", value_name = "KEY=VALUE")]
         meta: Vec<String>,
@@ -452,6 +461,10 @@ enum IngestSrc {
         /// Compound dataset to read: `events_3p` (default) or `events_2p`.
         #[arg(long, default_value = "events_3p")]
         dataset: String,
+        /// Clean label for the `ingested_from` provenance edge — replaces the input PATH in the
+        /// sealed manifest (ADR-0040 PHI hygiene).
+        #[arg(long, value_name = "LABEL")]
+        source_label: Option<String>,
         /// Attach metadata `key=value` (value parsed as JSON, else string). Repeatable.
         #[arg(long = "meta", value_name = "KEY=VALUE")]
         meta: Vec<String>,
@@ -474,6 +487,10 @@ enum IngestSrc {
         /// IANA media type, if known (e.g. `application/pdf`). Defaults to opaque octet-stream.
         #[arg(long)]
         media_type: Option<String>,
+        /// Clean label for the `ingested_from` provenance edge — replaces the input PATH in the
+        /// sealed manifest (ADR-0040 PHI hygiene; vendor `.l64` filenames often carry patient ids).
+        #[arg(long, value_name = "LABEL")]
+        source_label: Option<String>,
         /// Attach metadata `key=value` (value parsed as JSON, else string) — e.g. `--meta study=DUPLET-07`
         /// to satisfy the blob schema's recommended `study`. Repeatable.
         #[arg(long = "meta", value_name = "KEY=VALUE")]
@@ -1033,6 +1050,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             deidentify,
+            source_label,
             meta,
         } => (
             IngestSpec {
@@ -1049,6 +1067,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "recon".into(),
                     description: None,
                     derived_from: Vec::new(),
+                    source_label,
                     metadata: parse_meta(&meta)?,
                     options: FormatOptions::Dicom { input, deidentify },
                 }],
@@ -1061,6 +1080,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             deidentify,
+            source_label,
             meta,
         } => (
             IngestSpec {
@@ -1077,6 +1097,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "recon".into(),
                     description: None,
                     derived_from: Vec::new(),
+                    source_label,
                     metadata: parse_meta(&meta)?,
                     options: FormatOptions::DicomSeries { inputs, deidentify },
                 }],
@@ -1089,6 +1110,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             dataset,
+            source_label,
             meta,
         } => (
             IngestSpec {
@@ -1105,6 +1127,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "listmode".into(),
                     description: None,
                     derived_from: Vec::new(),
+                    source_label,
                     metadata: parse_meta(&meta)?,
                     options: FormatOptions::HdfCompound {
                         input,
@@ -1124,6 +1147,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             name,
             timestamp,
             media_type,
+            source_label,
             meta,
         } => (
             IngestSpec {
@@ -1140,6 +1164,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                     schema: "blob".into(),
                     description: None,
                     derived_from: Vec::new(),
+                    source_label,
                     metadata: parse_meta(&meta)?,
                     options: FormatOptions::Blob { input, media_type },
                 }],
@@ -1301,6 +1326,7 @@ mod tests {
                 name: "DP06-lm".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 dataset: "events_3p".into(),
+                source_label: None,
                 meta: vec![],
             }),
         })
@@ -1467,6 +1493,7 @@ streaming = "batch"
                 name: "x".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 deidentify: false,
+                source_label: None,
                 meta: vec![],
             }),
         })
@@ -1478,10 +1505,13 @@ streaming = "batch"
     }
 
     #[test]
-    fn ingest_dicom_series_wires_through_and_rejects_series_deid() {
-        // The happy path (real slices → recon) is covered by dicom::read_series; here we assert the
-        // CLI `dicom-series` variant reaches the engine dispatch, which rejects series de-id before
-        // touching any file — so the wiring is exercised without DICOM fixtures.
+    fn ingest_dicom_series_with_deidentify_reaches_the_de_id_read_path() {
+        // The CLI `dicom-series --deidentify` variant must reach the engine's de-id path (no longer
+        // a hard reject). We give it bogus input paths so the call fails INSIDE the de-id read path
+        // (`read_series_deidentified` → `open_file`) — proving the wiring without DICOM fixtures.
+        // The non-deid path would fail the same way at `read_series`, but with a different error: we
+        // assert the failure is the DICOM open error (i.e. we reached the reader), NOT the previous
+        // hard-reject "not yet supported" string.
         let dir = tempfile::tempdir().unwrap();
         let err = run(Cmd::Ingest {
             spec: None,
@@ -1496,13 +1526,118 @@ streaming = "batch"
                 name: "DP06-ct".into(),
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 deidentify: true,
+                source_label: None,
                 meta: vec![],
             }),
         })
         .unwrap_err();
+        let msg = format!("{err}");
         assert!(
-            format!("{err}").contains("not yet supported"),
-            "expected the series-deid rejection, got: {err}"
+            !msg.contains("not yet supported"),
+            "series-deid must no longer be rejected up-front, got: {msg}"
+        );
+        assert!(
+            msg.contains("dicom"),
+            "expected the failure to come from inside the DICOM read path, got: {msg}"
+        );
+    }
+
+    /// End-to-end: `dicom-series --deidentify` over real (synthetic) DICOM slices must SEAL a recon
+    /// product whose `ingested_from` reference is the `--source-label` (not the PHI-bearing paths).
+    /// Proves both load-bearing changes — wired de-id AND `--source-label` — work together on the
+    /// production path.
+    #[test]
+    fn ingest_dicom_series_deidentify_with_source_label_seals_product() {
+        use dicom::core::{DataElement, PrimitiveValue, Tag, VR};
+        use dicom::object::meta::FileMetaTableBuilder;
+        use dicom::object::InMemDicomObject;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Two minimal CT slices, each carrying PHI.
+        let write = |path: &std::path::Path, instance: i32, base: u16, patient: &str| {
+            let pixels: Vec<u16> = (0..64).map(|k| base + k as u16).collect();
+            let obj = InMemDicomObject::from_element_iter([
+                DataElement::new(Tag(0x0008, 0x0060), VR::CS, PrimitiveValue::from("CT")),
+                DataElement::new(Tag(0x0028, 0x0010), VR::US, PrimitiveValue::from(8u16)),
+                DataElement::new(Tag(0x0028, 0x0011), VR::US, PrimitiveValue::from(8u16)),
+                DataElement::new(
+                    Tag(0x0020, 0x0013),
+                    VR::IS,
+                    PrimitiveValue::from(instance.to_string()),
+                ),
+                DataElement::new(Tag(0x0028, 0x0002), VR::US, PrimitiveValue::from(1u16)),
+                DataElement::new(
+                    Tag(0x0028, 0x0004),
+                    VR::CS,
+                    PrimitiveValue::from("MONOCHROME2"),
+                ),
+                DataElement::new(Tag(0x0028, 0x0100), VR::US, PrimitiveValue::from(16u16)),
+                DataElement::new(Tag(0x0028, 0x0101), VR::US, PrimitiveValue::from(16u16)),
+                DataElement::new(Tag(0x0028, 0x0102), VR::US, PrimitiveValue::from(15u16)),
+                DataElement::new(Tag(0x0028, 0x0103), VR::US, PrimitiveValue::from(1u16)),
+                DataElement::new(Tag(0x0028, 0x1052), VR::DS, PrimitiveValue::from("-1024")),
+                DataElement::new(Tag(0x0028, 0x1053), VR::DS, PrimitiveValue::from("1")),
+                DataElement::new(Tag(0x0010, 0x0010), VR::PN, PrimitiveValue::from(patient)),
+                DataElement::new(
+                    Tag(0x0010, 0x0020),
+                    VR::LO,
+                    PrimitiveValue::from(format!("PID-{instance}")),
+                ),
+                DataElement::new(
+                    Tag(0x7FE0, 0x0010),
+                    VR::OW,
+                    PrimitiveValue::U16(pixels.into()),
+                ),
+            ]);
+            let meta = FileMetaTableBuilder::new()
+                .transfer_syntax("1.2.840.10008.1.2.1")
+                .media_storage_sop_class_uid("1.2.840.10008.5.1.4.1.1.2")
+                .media_storage_sop_instance_uid(format!("1.2.3.deid.{instance}"))
+                .implementation_class_uid("1.2.826.0.1.3680043.tessera")
+                .build()
+                .unwrap();
+            obj.with_exact_meta(meta).write_to_file(path).unwrap();
+        };
+        let p1 = dir.path().join("phi1.dcm");
+        let p2 = dir.path().join("phi2.dcm");
+        write(&p1, 1, 1000, "DOE^JOHN");
+        write(&p2, 2, 2000, "DOE^JANE");
+
+        let out = dir.path().join("series.tsra");
+        run(Cmd::Ingest {
+            spec: None,
+            out: None,
+            workers: None,
+            ram_budget: None,
+            auto: false,
+            stream_threshold: None,
+            src: Some(IngestSrc::DicomSeries {
+                inputs: vec![p1.clone(), p2.clone()],
+                out: out.clone(),
+                name: "DP06-ct".into(),
+                timestamp: "2024-01-01T00:00:00Z".into(),
+                deidentify: true,
+                source_label: Some("DUPLET-07/CT".into()),
+                meta: vec![],
+            }),
+        })
+        .unwrap();
+
+        // The sealed product opens + verifies + carries the clean source label (NOT a slice path).
+        run(Cmd::Verify { file: out.clone() }).unwrap();
+        let m = Reader::open(&out).unwrap().manifest().clone();
+        let ingested_from = m
+            .sources
+            .iter()
+            .find(|s| s.role == "ingested_from")
+            .expect("ingested_from edge on sealed manifest");
+        assert_eq!(ingested_from.reference, "DUPLET-07/CT");
+        assert!(
+            !ingested_from
+                .reference
+                .contains(p1.file_name().unwrap().to_str().unwrap()),
+            "PHI-bearing slice path must not appear in the sealed manifest, got: {}",
+            ingested_from.reference
         );
     }
 

--- a/tessera/crates/tessera-core/src/schema.rs
+++ b/tessera/crates/tessera-core/src/schema.rs
@@ -915,8 +915,8 @@ mod tests {
         assert_eq!(f.sensitivity, Sensitivity::Public);
 
         // …and a FieldSpec round-trips a non-default tier intact through serde.
-        let f = FieldSpec::optional("mrn", "PHI", "string")
-            .with_sensitivity(Sensitivity::Identifying);
+        let f =
+            FieldSpec::optional("mrn", "PHI", "string").with_sensitivity(Sensitivity::Identifying);
         let s = serde_json::to_string(&f).unwrap();
         let back: FieldSpec = serde_json::from_str(&s).unwrap();
         assert_eq!(back.sensitivity, Sensitivity::Identifying);

--- a/tessera/crates/tessera-core/src/schema.rs
+++ b/tessera/crates/tessera-core/src/schema.rs
@@ -19,6 +19,38 @@ use serde::{Deserialize, Serialize};
 use crate::block::BlockKind;
 use crate::manifest::Manifest;
 
+/// Schema-driven **sensitivity tier** for a metadata field (ADR-0040 §1 — the spike that
+/// teaches the engine to *reason* about PHI without yet redacting/encrypting). One of four,
+/// in increasing identifiability:
+/// - [`Public`](Sensitivity::Public) — safe in clear (e.g. modality vocab, calibration
+///   coefficients, scan geometry); ships unchanged.
+/// - [`Coded`](Sensitivity::Coded) — a controlled-vocab code, intrinsically non-identifying but
+///   carrying clinical meaning (e.g. DICOM `Modality` = `CT`).
+/// - [`Sensitive`](Sensitivity::Sensitive) — clinical content that is not directly identifying
+///   on its own but is access-controlled (e.g. impression text); the future field-redactor's
+///   default-keep-in-clear tier.
+/// - [`Identifying`](Sensitivity::Identifying) — **direct PHI** (the seed list is DICOM
+///   PS3.15's confidentiality profile — Patient Name, Patient ID, MRN, Birth Date, …,
+///   plus UIDs that bind to the patient/study). The redactor / field-encryption phases
+///   (deferred) operate on the fields the schema marks at this tier.
+///
+/// Pure data (`Copy` + serde) — the wasm-targeted `tessera-core` stays host-free; no PHI logic
+/// lives in this enum, only the classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Sensitivity {
+    /// Safe in clear — no clinical or identifying content.
+    #[default]
+    Public,
+    /// A controlled-vocabulary code (e.g. DICOM `Modality`). Not identifying.
+    Coded,
+    /// Clinical content, not directly identifying on its own (access-controlled but not a name).
+    Sensitive,
+    /// Direct PHI — DICOM PS3.15 confidentiality-profile fields (Patient Name/ID/MRN, DOB,
+    /// linking UIDs). The redact / field-encryption phases (deferred) operate on this tier.
+    Identifying,
+}
+
 /// A field's self-description — carried once, in the schema, so values stay lean and a reader
 /// (or an AI) always has the field's meaning, unit, and dtype without external context (FAIR I1/I2).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -49,10 +81,17 @@ pub struct FieldSpec {
     /// the warn tier). Composes through `imaging_base` like every other field.
     #[serde(default)]
     pub recommended: bool,
+    /// Schema-driven PHI classification (ADR-0040 §1). The engine uses this tier to *reason* about
+    /// identifiability — e.g. the ingest warn surfaces an `identifying` field present in
+    /// metadata in the clear, the hook the future field-encryption / redact phases replace.
+    /// `#[serde(default)]` keeps existing on-disk schemas back-compat (absent ⇒ `Public`).
+    #[serde(default)]
+    pub sensitivity: Sensitivity,
 }
 
 impl FieldSpec {
-    /// A required, undimensioned metadata field (absent ⇒ ingest **blocks**).
+    /// A required, undimensioned metadata field (absent ⇒ ingest **blocks**). Defaults to
+    /// [`Sensitivity::Public`]; chain [`Self::with_sensitivity`] to classify PHI.
     pub fn required(id: &str, description: &str, dtype: &str) -> Self {
         FieldSpec {
             id: id.into(),
@@ -63,10 +102,11 @@ impl FieldSpec {
             default: None,
             required: true,
             recommended: false,
+            sensitivity: Sensitivity::Public,
         }
     }
 
-    /// An optional metadata field (absent ⇒ silent).
+    /// An optional metadata field (absent ⇒ silent). Defaults to [`Sensitivity::Public`].
     pub fn optional(id: &str, description: &str, dtype: &str) -> Self {
         FieldSpec {
             required: false,
@@ -93,6 +133,15 @@ impl FieldSpec {
     /// Builder: attach a controlled vocabulary.
     pub fn vocabulary(mut self, vocab: &str) -> Self {
         self.vocabulary = Some(vocab.into());
+        self
+    }
+
+    /// Builder: classify the field's PHI **sensitivity tier** (ADR-0040 §1). Defaults to
+    /// [`Sensitivity::Public`]; mark direct PHI as [`Sensitivity::Identifying`] so the engine's
+    /// schema-driven PHI reasoning (today: ingest warn; future: redact / field encryption) picks
+    /// it up automatically.
+    pub fn with_sensitivity(mut self, s: Sensitivity) -> Self {
+        self.sensitivity = s;
         self
     }
 }
@@ -194,6 +243,16 @@ impl ProductSchema {
             .filter(|f| f.recommended && f.default.is_none() && !m.metadata.contains_key(&f.id))
             .collect()
     }
+
+    /// All fields of this schema classified at the given sensitivity `tier` (ADR-0040 §1). The
+    /// query the redact / field-encryption phases (deferred) consume to know **which fields** to
+    /// touch — pure data, no PHI logic inside the core. Order matches schema declaration.
+    pub fn fields_by_sensitivity(&self, tier: Sensitivity) -> Vec<&FieldSpec> {
+        self.fields
+            .iter()
+            .filter(|f| f.sensitivity == tier)
+            .collect()
+    }
 }
 
 /// The registry of built-in product schemas. Domain-agnostic: lookups for unknown products
@@ -237,6 +296,15 @@ impl SchemaRegistry {
             .map(|s| s.missing_recommended(m))
             .unwrap_or_default()
     }
+
+    /// The fields of `m`'s declared product schema at the given sensitivity `tier` (ADR-0040 §1)
+    /// — the schema-driven query the redact / field-encryption phases (deferred) use to know
+    /// which fields to touch. Empty for an unknown product (open-world).
+    pub fn fields_by_sensitivity(&self, m: &Manifest, tier: Sensitivity) -> Vec<&FieldSpec> {
+        self.get(&m.product)
+            .map(|s| s.fields_by_sensitivity(tier))
+            .unwrap_or_default()
+    }
 }
 
 impl Default for SchemaRegistry {
@@ -270,8 +338,9 @@ fn schema(product: &str, version: &str, description: &str) -> ProductSchema {
 /// `diffusion_mri` / `multicontrast_mri` rather than repeated per schema (DRY). `with` appends the
 /// schema's own extra fields.
 fn imaging_base(with: Vec<FieldSpec>) -> Vec<FieldSpec> {
-    let mut fields =
-        vec![FieldSpec::required("modality", "Imaging modality", "coded").vocabulary("DICOM")];
+    let mut fields = vec![FieldSpec::required("modality", "Imaging modality", "coded")
+        .vocabulary("DICOM")
+        .with_sensitivity(Sensitivity::Coded)];
     fields.extend(with);
     fields
 }
@@ -303,9 +372,29 @@ fn builtin_schemas() -> Vec<ProductSchema> {
             )
         },
         ProductSchema {
+            // `rescale_*` are pure scan geometry → `Public`. The two trailing fields are seeded
+            // from DICOM **PS3.15 Annex E** (Basic Application Confidentiality Profile, the
+            // tag list any de-identifier must touch): a pseudonymised patient handle
+            // (Patient Name / Patient ID family) and a study/series/SOP-instance UID
+            // (UID family — the UIDs bind back to the patient/study, so PS3.15 requires
+            // they be replaced / managed under the profile). Both are **optional** + tagged
+            // `Identifying` so the schema-driven PHI machinery (today: an ingest warn; future:
+            // redact / field encryption) picks them up without any per-product code change.
             fields: imaging_base(vec![
                 FieldSpec::optional("rescale_slope", "Native→physical slope", "float64"),
                 FieldSpec::optional("rescale_intercept", "Native→physical intercept", "float64"),
+                FieldSpec::optional(
+                    "patient_pseudonym",
+                    "Pseudonymised patient handle (DICOM PS3.15 Patient Name / Patient ID family — direct PHI; supply a site-issued pseudonym, never the raw MRN)",
+                    "string",
+                )
+                .with_sensitivity(Sensitivity::Identifying),
+                FieldSpec::optional(
+                    "acquisition_uid",
+                    "Acquisition UID (DICOM PS3.15 UID family — Study/Series/SOPInstance UID; linking PHI under the confidentiality profile)",
+                    "string",
+                )
+                .with_sensitivity(Sensitivity::Identifying),
             ]),
             blocks: vec![one(
                 "volume",
@@ -797,5 +886,116 @@ mod tests {
             .seal()
             .unwrap();
         r.validate(&m).unwrap();
+    }
+
+    // ─── ADR-0040 §1: sensitivity classification — plain-data tier + schema-driven query ───
+
+    #[test]
+    fn sensitivity_defaults_to_public_and_round_trips_through_serde() {
+        // Default is `Public` (so an unannotated schema field — and any deserialized older
+        // FieldSpec with the field absent — classifies as the safest tier, not PHI).
+        assert_eq!(Sensitivity::default(), Sensitivity::Public);
+
+        // snake_case wire form, all four variants round-trip.
+        for (variant, wire) in [
+            (Sensitivity::Public, "\"public\""),
+            (Sensitivity::Coded, "\"coded\""),
+            (Sensitivity::Sensitive, "\"sensitive\""),
+            (Sensitivity::Identifying, "\"identifying\""),
+        ] {
+            let s = serde_json::to_string(&variant).unwrap();
+            assert_eq!(s, wire, "{variant:?} serializes as {wire}");
+            let v: Sensitivity = serde_json::from_str(&s).unwrap();
+            assert_eq!(v, variant, "round-trip");
+        }
+
+        // A FieldSpec with NO `sensitivity` key deserializes (back-compat) → Public.
+        let json = r#"{"id":"x","description":"y","dtype":"string"}"#;
+        let f: FieldSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(f.sensitivity, Sensitivity::Public);
+
+        // …and a FieldSpec round-trips a non-default tier intact through serde.
+        let f = FieldSpec::optional("mrn", "PHI", "string")
+            .with_sensitivity(Sensitivity::Identifying);
+        let s = serde_json::to_string(&f).unwrap();
+        let back: FieldSpec = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.sensitivity, Sensitivity::Identifying);
+    }
+
+    #[test]
+    fn recon_seeds_ps3_15_identifying_fields_and_classifies_them() {
+        // The spike's PS3.15-seeded example fields are present on `recon`, marked Identifying.
+        let r = SchemaRegistry::builtin();
+        let recon = r.get("recon").unwrap();
+        for id in ["patient_pseudonym", "acquisition_uid"] {
+            let f = recon
+                .fields
+                .iter()
+                .find(|f| f.id == id)
+                .unwrap_or_else(|| panic!("recon must seed PS3.15 example field '{id}'"));
+            assert!(
+                !f.required,
+                "PS3.15 example field '{id}' is optional (escape hatch must stay frictionless)"
+            );
+            assert_eq!(
+                f.sensitivity,
+                Sensitivity::Identifying,
+                "PS3.15 example field '{id}' is direct PHI → Identifying"
+            );
+        }
+        // …and the rest of the recon fields are NOT identifying (Public/Coded only).
+        for f in &recon.fields {
+            if f.id == "patient_pseudonym" || f.id == "acquisition_uid" {
+                continue;
+            }
+            assert_ne!(
+                f.sensitivity,
+                Sensitivity::Identifying,
+                "non-seeded recon field '{}' must not classify as Identifying",
+                f.id
+            );
+        }
+    }
+
+    #[test]
+    fn fields_by_sensitivity_returns_the_right_tier() {
+        let r = SchemaRegistry::builtin();
+        // Build a real recon manifest so we can query through SchemaRegistry::fields_by_sensitivity.
+        let vol = ArrayBlock::new("volume", ArraySpec::new(vec![8, 8, 8], "int16"));
+        let mut b = ProductBuilder::new("recon", "DP", "d", "2024-01-01T00:00:00Z");
+        b.add_block(&vol).unwrap();
+        b.with_field(
+            "modality",
+            serde_json::json!({"_vocabulary": "DICOM", "_code": "CT"}),
+        );
+        let m = b.seal().unwrap();
+
+        // Identifying: exactly the two PS3.15-seeded recon fields.
+        let phi = r.fields_by_sensitivity(&m, Sensitivity::Identifying);
+        let phi_ids: Vec<&str> = phi.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(phi_ids, ["patient_pseudonym", "acquisition_uid"]);
+
+        // Coded: modality (DICOM controlled vocab).
+        let coded = r.fields_by_sensitivity(&m, Sensitivity::Coded);
+        let coded_ids: Vec<&str> = coded.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(coded_ids, ["modality"]);
+
+        // Public: rescale_slope + rescale_intercept (scan geometry, safe in clear).
+        let public = r.fields_by_sensitivity(&m, Sensitivity::Public);
+        let public_ids: Vec<&str> = public.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(public_ids, ["rescale_slope", "rescale_intercept"]);
+
+        // Sensitive: none on recon.
+        assert!(r
+            .fields_by_sensitivity(&m, Sensitivity::Sensitive)
+            .is_empty());
+
+        // Open-world: an unknown product → empty (no schema to classify against).
+        let m = ProductBuilder::new("my_custom", "x", "d", "2024-01-01T00:00:00Z")
+            .seal()
+            .unwrap();
+        assert!(r
+            .fields_by_sensitivity(&m, Sensitivity::Identifying)
+            .is_empty());
     }
 }

--- a/tessera/crates/tessera-ingest/src/blob.rs
+++ b/tessera/crates/tessera-ingest/src/blob.rs
@@ -14,6 +14,9 @@ use tessera_io::BlockPayload;
 /// basename is preserved in the descriptor (the default `tessera extract` name). `extra_sources` flow in
 /// after the `ingested_from` edge (the declarative engine threads `derived_from` / `ingested_via_spec`).
 ///
+/// `source_label` overrides the recorded `ingested_from` reference (ADR-0040 PHI hygiene — keeps absolute
+/// PHI-bearing paths out of the sealed manifest); `None` records the path as before.
+///
 /// **Memory:** reads the whole file into RAM (peak RSS ≈ file size). The in-memory convenience for when
 /// you already hold/produce the bytes; for a large file on disk prefer [`to_blob_product_streaming`]
 /// (what the ingest engine uses) — bounded memory, byte-identical sealed result.
@@ -22,6 +25,7 @@ pub fn to_blob_product(
     name: &str,
     timestamp: &str,
     media_type: Option<&str>,
+    source_label: Option<&str>,
     extra_sources: &[tessera_core::provenance::Source],
 ) -> Result<(Manifest, Vec<BlockPayload>)> {
     let bytes = std::fs::read(path).map_err(Error::from)?;
@@ -29,9 +33,12 @@ pub fn to_blob_product(
     let (block_ref, payload) = blob_block("data", filename, media_type, bytes)?;
     let mut b = ProductBuilder::new("blob", name, "opaque preserved file", timestamp);
     b.add_block_ref(block_ref);
+    let source_ref = source_label
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string());
     b.add_source(tessera_core::provenance::Source::new(
         "ingested_from",
-        path.display().to_string(),
+        source_ref,
     ));
     for s in extra_sources {
         b.add_source(s.clone());
@@ -44,20 +51,26 @@ pub fn to_blob_product(
 /// `Vec`) and returns only the sealed manifest — the caller seals it with [`tessera_io::pack_streaming`]
 /// handing the **same `path`** as the `data` block's fragment, so a multi-GB file never enters RAM. The
 /// sealed bytes + digest are identical to [`to_blob_product`] (blake3 + `pack_streaming` are exact).
+///
+/// `source_label` overrides the recorded `ingested_from` reference (PHI hygiene); `None` records the path.
 pub fn to_blob_product_streaming(
     path: &Path,
     name: &str,
     timestamp: &str,
     media_type: Option<&str>,
+    source_label: Option<&str>,
     extra_sources: &[tessera_core::provenance::Source],
 ) -> Result<Manifest> {
     let filename = path.file_name().and_then(|s| s.to_str()).unwrap_or("blob");
     let block_ref = tessera_io::blob::blob_ref_streaming("data", filename, media_type, path)?;
     let mut b = ProductBuilder::new("blob", name, "opaque preserved file", timestamp);
     b.add_block_ref(block_ref);
+    let source_ref = source_label
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string());
     b.add_source(tessera_core::provenance::Source::new(
         "ingested_from",
-        path.display().to_string(),
+        source_ref,
     ));
     for s in extra_sources {
         b.add_source(s.clone());
@@ -76,8 +89,15 @@ mod tests {
         let bytes: Vec<u8> = (0..5_000u32).map(|k| (k % 256) as u8).collect();
         std::fs::write(&src, &bytes).unwrap();
 
-        let (m, payloads) =
-            to_blob_product(&src, "KSB-testscan", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+        let (m, payloads) = to_blob_product(
+            &src,
+            "KSB-testscan",
+            "2024-01-01T00:00:00Z",
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
         assert_eq!(m.product, "blob");
         assert_eq!(m.blocks.len(), 1);
         assert_eq!(
@@ -92,6 +112,53 @@ mod tests {
             .any(|s| s.reference.contains("testscan.l64")));
     }
 
+    /// ADR-0040: when `source_label` is given, the recorded `ingested_from` reference is the LABEL,
+    /// not the (potentially PHI-bearing) path. Proves the seam reaches the manifest on BOTH
+    /// constructors (the streaming variant is what the engine drives).
+    #[test]
+    fn source_label_overrides_ingested_from_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("scan.l64");
+        std::fs::write(&src, b"some opaque bytes").unwrap();
+
+        let (m, _) = to_blob_product(
+            &src,
+            "x",
+            "2024-01-01T00:00:00Z",
+            None,
+            Some("DUPLET-07/raw"),
+            &[],
+        )
+        .unwrap();
+        let ingested_from = m
+            .sources
+            .iter()
+            .find(|s| s.role == "ingested_from")
+            .expect("ingested_from edge");
+        assert_eq!(ingested_from.reference, "DUPLET-07/raw");
+        assert!(
+            !ingested_from.reference.contains(src.to_str().unwrap()),
+            "label MUST replace the PHI-bearing path, not be appended to it"
+        );
+
+        let m2 = to_blob_product_streaming(
+            &src,
+            "x",
+            "2024-01-01T00:00:00Z",
+            None,
+            Some("DUPLET-07/raw"),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            m2.sources
+                .iter()
+                .find(|s| s.role == "ingested_from")
+                .map(|s| s.reference.as_str()),
+            Some("DUPLET-07/raw"),
+        );
+    }
+
     #[test]
     fn streaming_seal_is_identical_to_in_ram() {
         let dir = tempfile::tempdir().unwrap();
@@ -102,9 +169,9 @@ mod tests {
         std::fs::write(&src, &bytes).unwrap();
 
         let (in_ram, payloads) =
-            to_blob_product(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+            to_blob_product(&src, "x", "2024-01-01T00:00:00Z", None, None, &[]).unwrap();
         let streamed =
-            to_blob_product_streaming(&src, "x", "2024-01-01T00:00:00Z", None, &[]).unwrap();
+            to_blob_product_streaming(&src, "x", "2024-01-01T00:00:00Z", None, None, &[]).unwrap();
         // bounded-memory streaming yields the SAME identity, content hash, and seal as the in-RAM path.
         assert_eq!(in_ram.id, streamed.id);
         assert_eq!(in_ram.content_hash, streamed.content_hash);

--- a/tessera/crates/tessera-ingest/src/dicom.rs
+++ b/tessera/crates/tessera-ingest/src/dicom.rs
@@ -107,12 +107,30 @@ pub fn read_object(obj: &FileDicomObject<InMemDicomObject>) -> Result<DicomImage
 /// InstanceNumber (geometric ImagePositionPatient ordering is a later refinement). Every slice must
 /// share rows/cols/modality/rescale, else the series is rejected as non-uniform.
 pub fn read_series(paths: &[std::path::PathBuf]) -> Result<DicomImage> {
+    read_series_inner(paths, false)
+}
+
+/// Same as [`read_series`] but applies PS3.15 de-identification ([`deidentify`]) to **every** slice
+/// in memory before decoding — the per-slice analogue of [`read_image_deidentified`]. PHI never
+/// reaches the stacked volume.
+pub fn read_series_deidentified(paths: &[std::path::PathBuf]) -> Result<DicomImage> {
+    read_series_inner(paths, true)
+}
+
+/// Shared series body for [`read_series`] / [`read_series_deidentified`] — opening each slice, then
+/// optionally stripping PHI via [`deidentify`] before [`read_object`] decodes the pixels, then
+/// stacking by `InstanceNumber`. The PHI is gone before the pixels are even decoded; non-uniform
+/// shape/modality/rescale across slices is rejected as in the non-de-id path.
+fn read_series_inner(paths: &[std::path::PathBuf], strip_phi: bool) -> Result<DicomImage> {
     if paths.is_empty() {
         return Err(Error::Invalid("dicom: empty series".into()));
     }
     let mut slices: Vec<(i64, DicomImage)> = Vec::with_capacity(paths.len());
     for p in paths {
-        let obj = dicom::object::open_file(p).map_err(de)?;
+        let mut obj = dicom::object::open_file(p).map_err(de)?;
+        if strip_phi {
+            deidentify(&mut obj);
+        }
         let instance = obj
             .element(INSTANCE_NUMBER)
             .ok()
@@ -138,8 +156,10 @@ pub fn read_series(paths: &[std::path::PathBuf]) -> Result<DicomImage> {
     for (_, s) in &slices {
         voxels.extend_from_slice(&s.voxels);
     }
+    let z = u64::try_from(slices.len())
+        .map_err(|e| Error::Invalid(format!("dicom: series slice count overflow: {e}")))?;
     Ok(DicomImage {
-        shape: vec![slices.len() as u64, first.shape[0], first.shape[1]],
+        shape: vec![z, first.shape[0], first.shape[1]],
         voxels,
         modality: first.modality,
         rescale_slope: first.rescale_slope,
@@ -522,6 +542,89 @@ mod tests {
         assert_eq!(vol.voxels[0], 1000);
         assert_eq!(vol.voxels[64], 2000);
         assert_eq!(vol.voxels[128], 3000);
+    }
+
+    /// Like [`write_slice`] but stamps PHI tags onto the slice — used by the series-de-id test to prove
+    /// PHI is stripped per-slice before the volume is built.
+    fn write_phi_slice(path: &std::path::Path, instance: i32, base: u16, patient: &str) {
+        let pixels: Vec<u16> = (0..64).map(|k| base + k as u16).collect();
+        let obj = InMemDicomObject::from_element_iter([
+            DataElement::new(MODALITY, VR::CS, PrimitiveValue::from("CT")),
+            DataElement::new(ROWS, VR::US, PrimitiveValue::from(8u16)),
+            DataElement::new(COLUMNS, VR::US, PrimitiveValue::from(8u16)),
+            DataElement::new(
+                INSTANCE_NUMBER,
+                VR::IS,
+                PrimitiveValue::from(instance.to_string()),
+            ),
+            DataElement::new(Tag(0x0028, 0x0002), VR::US, PrimitiveValue::from(1u16)),
+            DataElement::new(
+                Tag(0x0028, 0x0004),
+                VR::CS,
+                PrimitiveValue::from("MONOCHROME2"),
+            ),
+            DataElement::new(Tag(0x0028, 0x0100), VR::US, PrimitiveValue::from(16u16)),
+            DataElement::new(Tag(0x0028, 0x0101), VR::US, PrimitiveValue::from(16u16)),
+            DataElement::new(Tag(0x0028, 0x0102), VR::US, PrimitiveValue::from(15u16)),
+            DataElement::new(Tag(0x0028, 0x0103), VR::US, PrimitiveValue::from(1u16)),
+            DataElement::new(RESCALE_INTERCEPT, VR::DS, PrimitiveValue::from("-1024")),
+            DataElement::new(RESCALE_SLOPE, VR::DS, PrimitiveValue::from("1")),
+            // PHI tags — must NOT survive a `read_series_deidentified`.
+            DataElement::new(
+                Tag(0x0010, 0x0010), // PatientName
+                VR::PN,
+                PrimitiveValue::from(patient),
+            ),
+            DataElement::new(
+                Tag(0x0010, 0x0020), // PatientID
+                VR::LO,
+                PrimitiveValue::from(format!("PID-{instance}")),
+            ),
+            DataElement::new(
+                Tag(0x0008, 0x0080), // InstitutionName
+                VR::LO,
+                PrimitiveValue::from("ACME Hospital"),
+            ),
+            DataElement::new(
+                Tag(0x7FE0, 0x0010),
+                VR::OW,
+                PrimitiveValue::U16(pixels.into()),
+            ),
+        ]);
+        let meta = FileMetaTableBuilder::new()
+            .transfer_syntax("1.2.840.10008.1.2.1")
+            .media_storage_sop_class_uid("1.2.840.10008.5.1.4.1.1.2")
+            .media_storage_sop_instance_uid(format!("1.2.3.phi.{instance}"))
+            .implementation_class_uid("1.2.826.0.1.3680043.tessera")
+            .build()
+            .unwrap();
+        obj.with_exact_meta(meta).write_to_file(path).unwrap();
+    }
+
+    /// `read_series_deidentified` must yield the SAME pixel stack as `read_series` (de-id touches
+    /// metadata, never voxels) AND its source files must still contain PHI (the function is in-memory
+    /// only — it never writes back to disk). The PHI-vs-clean contrast is the load-bearing assertion.
+    #[test]
+    fn series_deidentified_strips_phi_per_slice_and_preserves_pixels() {
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = dir.path().join("phi1.dcm");
+        let p2 = dir.path().join("phi2.dcm");
+        write_phi_slice(&p1, 1, 1000, "DOE^JOHN");
+        write_phi_slice(&p2, 2, 2000, "DOE^JANE");
+
+        // The non-de-id reader sees the same pixel content (PHI lives in metadata, not pixels).
+        let plain = read_series(&[p1.clone(), p2.clone()]).unwrap();
+        let deid = read_series_deidentified(&[p1.clone(), p2.clone()]).unwrap();
+        assert_eq!(plain.shape, deid.shape);
+        assert_eq!(plain.voxels, deid.voxels);
+
+        // The source files on disk still carry their PHI — de-id is in-memory at ingest, not a
+        // destructive pre-pass on the inputs (a Tessera invariant: never mutate the caller's files).
+        let obj1 = dicom::object::open_file(&p1).unwrap();
+        assert!(
+            !phi_present(&obj1).is_empty(),
+            "source DICOM must still contain PHI; the in-memory de-id only affects the ingested product"
+        );
     }
 
     #[test]

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -114,6 +114,26 @@ pub fn run(
                 f.id
             );
         }
+        // ADR-0040 §1 precursor warn: any field the schema marks `Identifying` (direct PHI per the
+        // DICOM PS3.15 confidentiality profile) **present in metadata in the clear** is the hook
+        // the future field-encryption / redact phases replace. Never blocks — the spike only proves
+        // the schema-driven tier reaches ingest; encryption/redaction lands in the next phase
+        // (#240 / PR #238).
+        for f in registry.fields_by_sensitivity(&manifest, tessera_core::schema::Sensitivity::Identifying) {
+            if manifest.metadata.contains_key(&f.id) {
+                tracing::warn!(
+                    target: "tessera::ingest::phi",
+                    member = %p.name,
+                    product = %manifest.product,
+                    field = %f.id,
+                    sensitivity = "identifying",
+                    "PHI in the clear: identifying field '{}' present unencrypted in metadata — \
+                     {} (ADR-0040: field-encryption / redact lands in a follow-up phase)",
+                    f.id,
+                    f.description,
+                );
+            }
+        }
         let id = manifest.id.clone();
         let mh = manifest.manifest_hash.clone().ok_or_else(|| {
             Error::Invalid(format!(

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -119,7 +119,9 @@ pub fn run(
         // the future field-encryption / redact phases replace. Never blocks — the spike only proves
         // the schema-driven tier reaches ingest; encryption/redaction lands in the next phase
         // (#240 / PR #238).
-        for f in registry.fields_by_sensitivity(&manifest, tessera_core::schema::Sensitivity::Identifying) {
+        for f in registry
+            .fields_by_sensitivity(&manifest, tessera_core::schema::Sensitivity::Identifying)
+        {
             if manifest.metadata.contains_key(&f.id) {
                 tracing::warn!(
                     target: "tessera::ingest::phi",

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -232,6 +232,11 @@ fn dispatch(
     // collection-level timestamp is the per-product timestamp too: the engine takes its identity
     // discipline from the spec, never from `Local::now()` or filesystem mtimes.
     let timestamp = timestamp.to_string();
+    // ADR-0040: a `source_label` (if declared on the spec / `--source-label` on the CLI) REPLACES
+    // the input path in the `ingested_from` reference. The path itself is still used to READ the
+    // bytes — but never appears in the sealed manifest. Computed once here, threaded into every
+    // backend (the seam each backend now exposes as a `source_label: Option<&str>` parameter).
+    let label = p.source_label.as_deref();
     match &p.options {
         FormatOptions::Blob { input, media_type } => {
             // Bounded-memory: stream the file's blake3, then pack_streaming with the source file as the
@@ -241,6 +246,7 @@ fn dispatch(
                 name,
                 &timestamp,
                 media_type.as_deref(),
+                label,
                 extra_sources,
             )?;
             let m =
@@ -253,32 +259,34 @@ fn dispatch(
             } else {
                 crate::dicom::read_image(input)?
             };
-            let source = input.display().to_string();
+            let source = label
+                .map(str::to_string)
+                .unwrap_or_else(|| input.display().to_string());
             let (m, payloads) =
                 crate::dicom::to_recon_product(&img, name, &timestamp, &source, extra_sources)?;
             let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
             Ok((m, ()))
         }
         FormatOptions::DicomSeries { inputs, deidentify } => {
-            // PS3.15 de-id for a series is per-file on the raw object; the in-memory series builder
-            // doesn't carry a "deidentify the series" hook, so we map the request to per-file
-            // de-id by reading each slice through `read_image_deidentified` first and reusing the
-            // single-slice stacker. Reject the request to keep the contract honest until the
-            // dicom-series API grows a de-id seam.
-            if *deidentify {
-                return Err(Error::Invalid(
-                    "ingest-engine: dicom-series with deidentify=true is not yet supported \
-                     (use per-file dicom + a derived recon stage, or pre-de-identify the .dcm \
-                     fixtures)"
-                        .into(),
-                ));
-            }
-            let img = crate::dicom::read_series(inputs)?;
-            let source = inputs
-                .iter()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+            // PS3.15 de-id for a series is per-file on the raw object; we route to
+            // `read_series_deidentified`, which opens each slice, applies `deidentify` in memory,
+            // then decodes — so PHI never reaches the stacked volume. The pixels are identical to
+            // the non-de-id path (de-id only touches metadata).
+            let img = if *deidentify {
+                crate::dicom::read_series_deidentified(inputs)?
+            } else {
+                crate::dicom::read_series(inputs)?
+            };
+            // With a `source_label`, recording N paths joined with commas is exactly what the label
+            // exists to suppress (an 890-slice series would embed each path verbatim). When no label
+            // is given, the joined paths are kept as the v0 behavior.
+            let source = label.map(str::to_string).unwrap_or_else(|| {
+                inputs
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            });
             let (m, payloads) =
                 crate::dicom::to_recon_product(&img, name, &timestamp, &source, extra_sources)?;
             let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
@@ -286,7 +294,9 @@ fn dispatch(
         }
         FormatOptions::Nifti { input } => {
             let img = crate::nifti::read_nifti(input)?;
-            let source = input.display().to_string();
+            let source = label
+                .map(str::to_string)
+                .unwrap_or_else(|| input.display().to_string());
             let (m, payloads) =
                 crate::nifti::to_recon_product(&img, name, &timestamp, &source, extra_sources)?;
             let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
@@ -303,6 +313,7 @@ fn dispatch(
                 dtype,
                 name,
                 &timestamp,
+                label,
                 extra_sources,
             )?;
             let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
@@ -323,7 +334,6 @@ fn dispatch(
                 // directly; we then re-open the sealed manifest to record its id.
                 let stage = out_dir.join(format!("__stage_{}", sanitize_filename(name)));
                 let tmp_out = out_dir.join(format!("__pending_{}.tsra", sanitize_filename(name)));
-                let source = input.display().to_string();
                 // Build extra_sources with the canonical `ingested_from` flowing through the
                 // streaming session (it adds its own `ingested_from`); pass `extra_sources` as-is.
                 let m = crate::ge_hdf5::stream_to_listmode_product_2p_to_file(
@@ -337,6 +347,7 @@ fn dispatch(
                     cfg,
                     block_prefix,
                     row_index,
+                    label,
                     extra_sources,
                     &p.metadata,
                 )?;
@@ -353,14 +364,13 @@ fn dispatch(
                 // Tidy up the per-product stage dir — best-effort (failure here would not change
                 // the sealed product's correctness, so it's not a hard error).
                 let _ = std::fs::remove_dir_all(&stage);
-                // Mention `source` so the SAFETY/docs trail stays correct even though the streaming
-                // session records `ingested_from` itself.
-                let _ = source;
                 Ok((m, ()))
             } else {
                 // Batch path: read the whole compound, build the in-memory product, pack.
                 let cols = crate::ge_hdf5::read_compound(input, dataset)?;
-                let source = input.display().to_string();
+                let source = label
+                    .map(str::to_string)
+                    .unwrap_or_else(|| input.display().to_string());
                 let (m, payloads) = crate::ge_hdf5::to_listmode_product(
                     &cols,
                     name,

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -460,9 +460,10 @@ pub fn stream_events_2p(
 /// `cfg` controls worker count + RAM budget for the encode pipeline. `slab_rows` is the HDF5
 /// hyperslab read unit (the bounded-memory unit for the READ side, independent of the block
 /// partition). `block_prefix` names the on-disk block(s) (default `events` — singles/coin layouts
-/// pass their own). `row_index` is the table's `row_index` column (default `ms`). `extra_sources`
-/// are added AFTER the canonical `ingested_from` edge (the declarative ingest engine threads its
-/// `derived_from` + `ingested_via_spec` edges here). Returns the sealed manifest.
+/// pass their own). `row_index` is the table's `row_index` column (default `ms`). `source_label`
+/// overrides the recorded `ingested_from` reference (ADR-0040 PHI hygiene); `None` records the path.
+/// `extra_sources` are added AFTER the canonical `ingested_from` edge (the declarative ingest
+/// engine threads its `derived_from` + `ingested_via_spec` edges here). Returns the sealed manifest.
 #[allow(clippy::too_many_arguments)] // each argument is a distinct, load-bearing piece of context
 pub fn stream_to_listmode_product_2p_to_file(
     path: &std::path::Path,
@@ -475,6 +476,7 @@ pub fn stream_to_listmode_product_2p_to_file(
     cfg: &tessera_io::WriteConfig,
     block_prefix: &str,
     row_index: &str,
+    source_label: Option<&str>,
     extra_sources: &[tessera_core::provenance::Source],
     extra_metadata: &std::collections::BTreeMap<String, serde_json::Value>,
 ) -> Result<Manifest> {
@@ -490,6 +492,7 @@ pub fn stream_to_listmode_product_2p_to_file(
         tessera_io::BLOCK_ROWS as u64,
         block_prefix,
         row_index,
+        source_label,
         extra_sources,
         extra_metadata,
     )
@@ -525,6 +528,7 @@ pub fn stream_to_listmode_product_2p_to_file_with_block_rows(
         block_rows,
         "events",
         "ms",
+        None,
         &[],
         &std::collections::BTreeMap::new(),
     )
@@ -548,6 +552,7 @@ fn stream_to_listmode_product_2p_to_file_inner(
     block_rows: u64,
     block_prefix: &str,
     row_index: &str,
+    source_label: Option<&str>,
     extra_sources: &[tessera_core::provenance::Source],
     extra_metadata: &std::collections::BTreeMap<String, serde_json::Value>,
 ) -> Result<Manifest> {
@@ -569,10 +574,14 @@ fn stream_to_listmode_product_2p_to_file_inner(
         timestamp,
     )?;
     // Provenance edge is declared on the session before any blocks commit, so it flows into the
-    // sealed manifest's hash directly — no post-seal re-build needed.
+    // sealed manifest's hash directly — no post-seal re-build needed. ADR-0040: `source_label` (when
+    // given) replaces the full path so a PHI-bearing absolute path never enters the sealed manifest.
+    let source_ref = source_label
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string());
     ws.add_source(tessera_core::provenance::Source::new(
         "ingested_from",
-        path.display().to_string(),
+        source_ref,
     ))?;
     for s in extra_sources {
         ws.add_source(s.clone())?;
@@ -639,6 +648,7 @@ pub fn stream_to_listmode_product_2p(
         &cfg,
         "events",
         "ms",
+        None,
         &[],
         &std::collections::BTreeMap::new(),
     )?;

--- a/tessera/crates/tessera-ingest/src/raw.rs
+++ b/tessera/crates/tessera-ingest/src/raw.rs
@@ -33,24 +33,29 @@ pub fn read_raw(path: &Path, shape: Vec<u64>, numpy_code: &str) -> Result<(Array
 }
 
 /// Read a raw binary volume and seal it as a Tessera `recon` product, with an `ingested_from` provenance
-/// edge to the source file. `extra_sources` flow in AFTER `ingested_from` (the declarative ingest engine
-/// threads `derived_from` + `ingested_via_spec` edges here so the chain verifier picks up the parent's
-/// `manifest_hash`).
+/// edge to the source file. `source_label` overrides the recorded reference (ADR-0040 PHI hygiene); when
+/// `None` the path is recorded as before. `extra_sources` flow in AFTER `ingested_from` (the declarative
+/// ingest engine threads `derived_from` + `ingested_via_spec` edges here so the chain verifier picks up
+/// the parent's `manifest_hash`).
 pub fn to_recon_product(
     path: &Path,
     shape: Vec<u64>,
     numpy_code: &str,
     name: &str,
     timestamp: &str,
+    source_label: Option<&str>,
     extra_sources: &[tessera_core::provenance::Source],
 ) -> Result<(Manifest, Vec<BlockPayload>)> {
     let (spec, data) = read_raw(path, shape, numpy_code)?;
     let (block_ref, payload) = array::array_block("volume", &spec, &data)?;
     let mut b = ProductBuilder::new("recon", name, "raw binary volume", timestamp);
     b.add_block_ref(block_ref);
+    let source_ref = source_label
+        .map(str::to_string)
+        .unwrap_or_else(|| path.display().to_string());
     b.add_source(tessera_core::provenance::Source::new(
         "ingested_from",
-        path.display().to_string(),
+        source_ref,
     ));
     for s in extra_sources {
         b.add_source(s.clone());
@@ -89,10 +94,38 @@ mod tests {
             "i2",
             "raw-01",
             "2024-01-01T00:00:00Z",
+            None,
             &[],
         )
         .unwrap();
         m.verify().unwrap();
         assert_eq!(m.product, "recon");
+    }
+
+    /// ADR-0040: `source_label` replaces the PHI-bearing path in the `ingested_from` edge.
+    #[test]
+    fn source_label_replaces_path_in_ingested_from() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("vol.raw");
+        let voxels: Vec<i16> = (0..8).map(|k| k as i16).collect();
+        let bytes: Vec<u8> = voxels.iter().flat_map(|v| v.to_le_bytes()).collect();
+        std::fs::write(&f, &bytes).unwrap();
+
+        let (m, _) = to_recon_product(
+            &f,
+            vec![2, 2, 2],
+            "i2",
+            "raw-01",
+            "2024-01-01T00:00:00Z",
+            Some("DUPLET-07/raw"),
+            &[],
+        )
+        .unwrap();
+        let ingested_from = m
+            .sources
+            .iter()
+            .find(|s| s.role == "ingested_from")
+            .expect("ingested_from edge");
+        assert_eq!(ingested_from.reference, "DUPLET-07/raw");
     }
 }

--- a/tessera/crates/tessera-ingest/src/spec.rs
+++ b/tessera/crates/tessera-ingest/src/spec.rs
@@ -96,6 +96,12 @@ pub struct ProductSpec {
     /// resolved by name at validate time; cycles + dangling refs are rejected.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub derived_from: Vec<String>,
+    /// Optional clean label for the `ingested_from` provenance edge — used in place of the input
+    /// path (which on real clinical data is PHI-bearing: e.g. an 890-slice DICOM series embeds the
+    /// patient name 890× into the sealed manifest if the full paths are kept). When `None`, the
+    /// path is recorded verbatim as before (the legacy behavior). ADR-0040.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_label: Option<String>,
     /// Free-form per-product metadata, written into the manifest's `metadata` field map.
     /// Use this for the small handful of fd5 schema fields the engine doesn't compute itself.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]


### PR DESCRIPTION
Integrates two ADR-0040 builds (#239 + #240), gated together.

**#239 — PHI hygiene**
- `--source-label <LABEL>` on every `tessera ingest` subcommand (+ `[product.source_label]` in the spec): records a clean label as the `ingested_from` reference instead of the patient-name-bearing absolute path. Threaded through all backends.
- Wired `dicom-series --deidentify` (was rejected): new `read_series_deidentified` applies PS3.15 per slice before pixels decode; source files untouched.

**#240 — sensitivity tier (ADR-0040 §1)**
- `FieldSpec.sensitivity: public | coded | sensitive | identifying` (serde-default `public`, wasm-safe), `.with_sensitivity()` builder. Built-in fields classified (`modality`=coded, …); PS3.15-seeded `recon.{patient_pseudonym, acquisition_uid}` marked `identifying`.
- `SchemaRegistry::fields_by_sensitivity` query + a non-blocking **ingest WARN** when an `identifying` field is present in the clear (the hook the future field-encryption replaces).

Green `nix flake check` (the earlier "test failure" was a disk-full ENOSPC, not code). 14 schema + 31 ingest + 25 CLI tests pass.