### PR TITLE
feat(cli): schema field roster — tsra schema lists declared fields (tier + sensitivity + populated/missing)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -1020,6 +1020,33 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                     m.product
                 ),
             }
+            // Field roster: what the schema *declares* vs what this product *carries* — so a user
+            // sees the available fields (populated + missing) with their tier + PHI sensitivity,
+            // not only whatever happens to be filled in. (Answers "always show the avail fields".)
+            let schema = embedded
+                .clone()
+                .or_else(|| SchemaRegistry::builtin().get(&m.product).cloned());
+            if let Some(s) = schema.filter(|s| !s.fields.is_empty()) {
+                println!("fields ({} declared):", s.fields.len());
+                for f in &s.fields {
+                    let (mark, tier) = if f.required {
+                        ('●', "required")
+                    } else if f.recommended {
+                        ('◐', "recommended")
+                    } else {
+                        ('·', "optional")
+                    };
+                    let sens = format!("{:?}", f.sensitivity).to_lowercase();
+                    let val = match m.metadata.get(&f.id) {
+                        Some(v) => format!("= {}", compact_json(v)),
+                        None => match &f.default {
+                            Some(d) => format!("— (default {})", compact_json(d)),
+                            None => "—".to_string(),
+                        },
+                    };
+                    println!("  {mark} {:<22} {tier:<12} {sens:<11} {val}", f.id);
+                }
+            }
             tessera_core::validate_manifest(m)?; // typed error naming the first missing field/block
             println!("OK  schema-valid: {}", file.display());
             Ok(())
@@ -1191,6 +1218,20 @@ fn parse_meta(
         out.insert(k.to_string(), value);
     }
     Ok(out)
+}
+
+/// Compact one-line JSON render of a metadata value for the `schema` field roster (truncated).
+fn compact_json(v: &serde_json::Value) -> String {
+    let s = match v {
+        serde_json::Value::String(s) => format!("\"{s}\""),
+        other => other.to_string(),
+    };
+    if s.chars().count() > 48 {
+        let head: String = s.chars().take(45).collect();
+        format!("{head}…")
+    } else {
+        s
+    }
 }
 
 /// `tessera push` — with the `cloud` feature, runs the in-Rust OCI distribution client; without it,

--- a/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
@@ -16,6 +16,20 @@ OK  ../../corpus/files/multiblock_study.tsra verified (2 blocks)
 ```
 $ tessera schema ../../corpus/files/multiblock_study.tsra
 product 'recon' — embedded schema v1.0 (A reconstructed image volume (CT/PET/μ-map).)
+fields (13 declared):
+  ● modality               required     coded       = "CT"
+  · rescale_slope          optional     public      —
+  · rescale_intercept      optional     public      —
+  · patient_pseudonym      optional     identifying —
+  · acquisition_uid        optional     identifying —
+  ◐ study_instance_uid     recommended  identifying —
+  ◐ series_instance_uid    recommended  identifying —
+  ◐ study_date             recommended  sensitive   —
+  ◐ manufacturer           recommended  public      —
+  ◐ model_name             recommended  public      —
+  ◐ kvp                    recommended  public      —
+  ◐ slice_thickness        recommended  public      —
+  ◐ pixel_spacing          recommended  public      —
 OK  schema-valid: ../../corpus/files/multiblock_study.tsra
 
 ```


### PR DESCRIPTION
`tsra schema` now prints the full declared-field roster (●required ◐recommended ·optional, PHI sensitivity per ADR-0040 §1, populated `= value` vs missing `—`+default) — so a user sees the *available* fields, not only the filled ones. Reads the embedded schema (self-describing) else registry. Answers 'always show the avail fields'; surfaces the curated DICOM fields (#255) as recommended-but-missing on pre-port files. navigating.trycmd regenerated. Gate green.