### PR TITLE
feat(cli): tsra sql — DataFusion SQL over a table block (feature-gated, #251)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -354,6 +354,23 @@
               ++ [ minio pkgs.awscli2 pkgs.curl pkgs.cacert ];
           });
 
+          # **DataFusion SQL surface** (#251 spike): the `sql` feature adds `tessera sql <FILE>
+          # "<QUERY>"` — Vortex → Arrow → DataFusion in-process. The unit tests under `sql::tests`
+          # are `#[cfg(feature = "sql")]`, so the default `workspace-test` gate does NOT run them
+          # (default features exclude the ~200-crate DataFusion tree). This dedicated check runs
+          # the CLI's sql-feature tests only — same pattern as `minio-range-read` for the cloud
+          # feature. Clippy already covers `--all-features` at compile-time, so this test is what
+          # proves the query actually EXECUTES (WHERE + ORDER BY + LIMIT round-trip).
+          sql-tests = craneLib.cargoNextest (commonArgs // {
+            inherit cargoArtifacts;
+            # `sql::tests::*` runs the DataFusion SessionContext path end-to-end (register table,
+            # execute query, collect batches). The positional `sql` filter matches every test
+            # name in the `sql` module — DataFusion 54 pins arrow-58, so cargo unifies with the
+            # arrow-58 the workspace already has (via Vortex 0.75); a version mismatch would
+            # fail to link, not to test.
+            cargoExtraArgs = "-p tessera-cli --features sql sql::";
+          });
+
           # guardrails agent-drift gates over the Rust source (code gates) + repo-wide structural
           # gates. cargo-deny stays a pre-commit gate (needs network for the advisory DB).
           guardrails-gates = pkgs.runCommand "guardrails-gates"

--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -142,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +198,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
 name = "arrow-arith"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +243,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -247,10 +278,26 @@ dependencies = [
  "atoi",
  "base64",
  "chrono",
+ "comfy-table",
  "half",
  "lexical-core",
  "num-traits",
  "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
 ]
 
 [[package]]
@@ -267,6 +314,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ipc"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex",
+ "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
 name = "arrow-ord"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +365,19 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
 ]
 
 [[package]]
@@ -592,6 +693,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1082,16 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1190,6 +1324,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1395,615 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "futures",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c9ded5d87d9172319e006f2afdb9928d72dbacd6a90a458d8acb1e3b43a65"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "chrono",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store 0.13.2",
+ "recursive",
+ "sqlparser",
+ "tokio",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd7d295b2ec7c00d8a56562f41ed41062cf0af75549ed891c12a0a09eddfefe"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store 0.13.2",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68850aa426b897e879c8b87e512ea8124f1d0a2869a4e51808ddaaddf1bc0ada"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store 0.13.2",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402f93242ae08ef99139ee2c528a49d087efe88d5c7b2c3ff5480855a40ce54f"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store 0.13.2",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
+
+[[package]]
+name = "datafusion-execution"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a8643ab852eb68864e1b72ae789e8066282dce48eea6347ffb0aee33d1ccc0"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap",
+ "itertools 0.14.0",
+ "recursive",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
+ "regex",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
+ "half",
+ "log",
+ "num-traits",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "memchr",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
+dependencies = [
+ "datafusion-doc",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "recursive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "petgraph",
+ "recursive",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "pin-project",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "itertools 0.14.0",
+ "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "776ee54d47d15bdb126452f9ca17b03761e3b004682914beaedd3f86eb507fbc"
+dependencies = [
+ "arrow",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
+dependencies = [
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6094ad36a3ed6d7ac87b20b479b2d0b118250f66cf997603829fdc65b44a7099"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap",
+ "log",
+ "recursive",
+ "regex",
+ "sqlparser",
 ]
 
 [[package]]
@@ -1835,6 +2599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +2629,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2108,13 +2884,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2125,7 +2910,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2195,6 +2980,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -3126,6 +3917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,6 +4282,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "object_store"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,6 +4513,56 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3912,6 +4797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -4269,6 +5164,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d09ee01023de07fa073ce14c37cbe0a9e099c6b0b60a29cf4af6d04d9553fed7"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4848,6 +5763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +5888,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ssh-cipher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,6 +5956,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -5163,11 +6119,13 @@ checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
 name = "tessera-cli"
 version = "0.0.0"
 dependencies = [
+ "arrow",
  "clap",
+ "datafusion",
  "dicom",
  "getrandom 0.2.17",
  "hdf5-metno",
- "object_store",
+ "object_store 0.14.0",
  "serde_json",
  "ssh-key",
  "tempfile",
@@ -5220,7 +6178,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures",
- "object_store",
+ "object_store 0.14.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5429,6 +6387,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5672,6 +6642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5694,6 +6670,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/tessera/crates/tessera-cli/Cargo.toml
+++ b/tessera/crates/tessera-cli/Cargo.toml
@@ -31,11 +31,31 @@ ssh-key = { version = "0.6", default-features = false, features = ["ed25519", "s
 # real `TableStreamWriter`/`StreamWriter`, which need durable staging dirs).
 tempfile = "3"
 
+# `sql` feature (#251): `tessera sql <FILE> "<QUERY>"` runs DataFusion in-process over a table
+# block's Arrow projection. DataFusion 54 pins `arrow ^58` — the SAME major the workspace already
+# resolves through Vortex 0.75 (arrow-array 58.3.0), so cargo unifies into one arrow tree. Two
+# arrow majors in one graph would fail to link (`RecordBatch` has the same name but incompatible
+# reprs). Both deps are `optional`, so a default `cargo build -p tessera-cli` does NOT pull them.
+datafusion = { version = "54", default-features = false, features = ["sql", "recursive_protection"], optional = true }
+# DataFusion needs an async runtime to drive `SessionContext::sql().collect()`; we spin a fresh
+# `current_thread` runtime per invocation (the spike phase — no long-lived executor). `rt` covers
+# the scheduler; `macros` is only for local tests that use `#[tokio::test]`. Runtime knob only,
+# never in the write/read spine (ADR-0034 §4 — one legitimate tokio use per surface).
+tokio = { version = "1", features = ["rt", "macros"], optional = true }
+# Arrow's array + record-batch types are the bridge: `ColumnData` → Arrow arrays → DataFusion
+# `MemTable`. `csv` gives us `arrow-csv`'s writer for `--format csv|tsv`. `58` matches DataFusion
+# 54's arrow dep so cargo picks a single arrow tree.
+arrow = { version = "58", default-features = false, features = ["csv"], optional = true }
+
 [features]
 # `cloud` (#225): lets `tessera inspect`/`tessera verify` accept an `s3://` or `http(s)://` URL
 # (resolved via `tessera_io::open_url`). Strictly additive — without the feature the CLI is the
 # same file-only tool that ships today (no object_store deps, no tokio runtime).
 cloud = ["tessera-io/cloud"]
+# `sql` (#251): DataFusion SQL surface over the `LogicalTableView`. Strictly additive — without it
+# `tessera sql` still parses (uniform UX) but returns a typed "rebuild with --features sql" error,
+# same shape as the `cloud`-gated `push`/`pull` fallback.
+sql = ["dep:datafusion", "dep:tokio", "dep:arrow"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -6,6 +6,8 @@
 
 mod bench;
 mod nav;
+#[cfg(feature = "sql")]
+mod sql;
 mod trust;
 mod version;
 
@@ -107,6 +109,9 @@ Inspect & navigate:
   stats       Numeric overview of an array block (shape, dtype, value range)
   slice       Pull a plane/line/point of an array block as CSV (--index z,:,:)
   export      Emit a FAIR discovery record (JSON to stdout)
+
+Query (needs --features sql):
+  sql         Run SQL (DataFusion) over a table block
 
 Ingest & pack:
   ingest      Ingest a vendor file (or a declarative --spec) into a sealed .tsra
@@ -516,6 +521,26 @@ enum Cmd {
         /// Also require the signature's `signer` to equal this identity (e.g. an ORCID iD URL).
         #[arg(long)]
         require_signer: Option<String>,
+    },
+    /// Run SQL (DataFusion) over a `.tsra` table block (needs `--features sql`).
+    ///
+    /// Registers the block's [`LogicalTableView`] as an Arrow `MemTable` under the block name
+    /// (so `FROM events` transparently spans every `events_NNNN` shard) and hands the query to
+    /// DataFusion. Result is CSV (default) / TSV.
+    ///
+    /// Spike phase (#251): the whole block is materialized in RAM before the query runs —
+    /// streaming + predicate/projection pushdown is #251 phase 2/3. `tessera sql` still parses
+    /// without the feature and returns a clear "rebuild with --features sql" error.
+    Sql {
+        /// The `.tsra` to query.
+        file: PathBuf,
+        /// Table block (or multi-block prefix like `events`) to expose as the SQL table.
+        block: String,
+        /// The SQL query (`FROM <block>`; SELECT/WHERE/ORDER BY/LIMIT are the phase-1 target).
+        query: String,
+        /// Output format: `csv` (default) | `tsv`. `ndjson` is a follow-up.
+        #[arg(long, default_value = "csv")]
+        format: String,
     },
     /// Bench the write engine on this host (throughput + peak RSS).
     ///
@@ -1176,6 +1201,12 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 &mut w,
             )
         }
+        Cmd::Sql {
+            file,
+            block,
+            query,
+            format,
+        } => do_sql(&file, &block, &query, &format),
         Cmd::Bench { action } => match action {
             BenchAction::Write {
                 schema,
@@ -1289,6 +1320,35 @@ fn do_pull(
 ) -> tessera_core::Result<()> {
     Err(tessera_core::Error::Invalid(
         "pull requires the `cloud` feature — rebuild: cargo build -p tessera-cli --features cloud"
+            .into(),
+    ))
+}
+
+/// `tessera sql` — with the `sql` feature, dispatches through [`crate::sql::run`] (DataFusion
+/// over the block's `LogicalTableView`). Without the feature, a typed fallback error mirroring
+/// `do_push` / `do_pull` — the subcommand still parses, so users get the same "rebuild with
+/// --features" affordance the cloud verbs already do.
+#[cfg(feature = "sql")]
+fn do_sql(
+    file: &std::path::Path,
+    block: &str,
+    query: &str,
+    format: &str,
+) -> tessera_core::Result<()> {
+    let fmt = nav::Format::parse(format)?;
+    sql::run(file, block, query, fmt)
+}
+
+#[cfg(not(feature = "sql"))]
+fn do_sql(
+    _file: &std::path::Path,
+    _block: &str,
+    _query: &str,
+    _format: &str,
+) -> tessera_core::Result<()> {
+    Err(tessera_core::Error::Invalid(
+        "sql requires the `sql` feature (pulls DataFusion) — rebuild: cargo build \
+         -p tessera-cli --features sql"
             .into(),
     ))
 }

--- a/tessera/crates/tessera-cli/src/sql.rs
+++ b/tessera/crates/tessera-cli/src/sql.rs
@@ -1,0 +1,337 @@
+//! `tessera sql` — DataFusion SQL over a Tessera table block (spike phase, #251).
+//!
+//! **The stack.** A table block is Vortex → Arrow (zero-copy in the read direction) → DataFusion
+//! runs SQL over Arrow in-process (pure Rust, embeddable, no external engine). We build the same
+//! [`LogicalTableView`] the `read` verb uses — so `events` spans every `events_NNNN` shard as one
+//! logical table — materialize every column into an Arrow `RecordBatch`, register it as a
+//! DataFusion `MemTable` under the block name, and hand the SQL to `SessionContext::sql`.
+//!
+//! **What this is (spike phase).** Materializing to `RecordBatch` up front puts the whole block in
+//! RAM: fine for the phase-1 spike (proves Vortex→Arrow→DataFusion end-to-end), noted as the
+//! follow-up for phase-2/3 in issue #251 (streaming `TableProvider` + predicate/projection
+//! pushdown so block-level stats can skip whole shards without a decode). Do NOT ship this as the
+//! big-cohort path — that's the follow-up. Do ship it as the small/medium-cohort SQL surface, and
+//! as the "prove the API" step the pushdown work builds on.
+//!
+//! **Runtime.** DataFusion needs an async runtime for `sql().collect()`; we spin a fresh
+//! `current_thread` tokio runtime **per invocation**. No long-lived executor — ADR-0034 §4 "one
+//! legitimate tokio use per surface" (this is a query CLI, not the write/read spine).
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    RecordBatch, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::csv::WriterBuilder;
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+use tessera_io::{ColumnData, Reader};
+
+use crate::nav::Format;
+
+/// Convert one Tessera [`ColumnData`] to an Arrow [`ArrayRef`] — one branch per numeric dtype
+/// (`ColumnData` is a closed enum, so every variant is covered exhaustively). Small vectors go
+/// through `.clone()`; f32/f64 are copied verbatim (no NaN canonicalisation — DataFusion honours
+/// IEEE-754 comparison semantics the same way the tests below assert).
+fn column_to_array(col: ColumnData) -> ArrayRef {
+    match col {
+        ColumnData::I8(v) => Arc::new(Int8Array::from(v)) as ArrayRef,
+        ColumnData::I16(v) => Arc::new(Int16Array::from(v)) as ArrayRef,
+        ColumnData::I32(v) => Arc::new(Int32Array::from(v)) as ArrayRef,
+        ColumnData::I64(v) => Arc::new(Int64Array::from(v)) as ArrayRef,
+        ColumnData::U8(v) => Arc::new(UInt8Array::from(v)) as ArrayRef,
+        ColumnData::U16(v) => Arc::new(UInt16Array::from(v)) as ArrayRef,
+        ColumnData::U32(v) => Arc::new(UInt32Array::from(v)) as ArrayRef,
+        ColumnData::U64(v) => Arc::new(UInt64Array::from(v)) as ArrayRef,
+        ColumnData::F32(v) => Arc::new(Float32Array::from(v)) as ArrayRef,
+        ColumnData::F64(v) => Arc::new(Float64Array::from(v)) as ArrayRef,
+    }
+}
+
+/// Map an fd5 numpy-style dtype code (`i2`/`u4`/`f4`/…) to its Arrow [`DataType`]. Same closed
+/// mapping the encoder writes; a code outside the table's supported set is a typed schema error.
+fn numpy_to_arrow(code: &str) -> tessera_core::Result<DataType> {
+    Ok(match code {
+        "i1" => DataType::Int8,
+        "i2" => DataType::Int16,
+        "i4" => DataType::Int32,
+        "i8" => DataType::Int64,
+        "u1" => DataType::UInt8,
+        "u2" => DataType::UInt16,
+        "u4" => DataType::UInt32,
+        "u8" => DataType::UInt64,
+        "f4" => DataType::Float32,
+        "f8" => DataType::Float64,
+        other => {
+            return Err(tessera_core::Error::Invalid(format!(
+                "tessera sql: unsupported column dtype '{other}' (table cols are numeric)"
+            )))
+        }
+    })
+}
+
+/// `tessera sql FILE BLOCK "QUERY"` — DataFusion SQL over the cross-block logical view.
+///
+/// - `block` is the table-block name (or multi-block prefix like `events`). It's registered as a
+///   MemTable under **exactly that name**, so `FROM events` in a query matches `events` /
+///   `events_NNNN` transparently — the same view semantics `tessera read` uses.
+/// - `format` is `csv` (default) or `tsv`. The result batches are written via `arrow-csv`'s
+///   writer (float `Display`, no quoting); `tsv` swaps the delimiter without another writer.
+///
+/// Bounded memory NOT guaranteed at the spike phase — see the module doc-comment (materializes
+/// the whole block to a `RecordBatch` in RAM before handing to DataFusion). The public API doesn't
+/// promise streaming yet; the streaming `TableProvider` is #251 phase 2/3.
+pub fn run(file: &Path, block: &str, query: &str, format: Format) -> tessera_core::Result<()> {
+    let mut out = std::io::stdout().lock();
+    run_with(file, block, query, format, &mut out)
+}
+
+/// Write-facing variant of [`run`] — the CLI uses [`run`] (which locks stdout); tests inject a
+/// `Vec<u8>` so the emitted CSV is captured verbatim without touching real stdout.
+pub fn run_with(
+    file: &Path,
+    block: &str,
+    query: &str,
+    format: Format,
+    out: &mut dyn Write,
+) -> tessera_core::Result<()> {
+    // Only `csv` / `tsv` make sense for a tabular query result — reuse `Format` for the flag
+    // shape but reject `ndjson` explicitly (DataFusion's writer surface is arrow-csv today; a
+    // JSON emitter is a follow-up).
+    let delim = match format {
+        Format::Csv => b',',
+        Format::Tsv => b'\t',
+        Format::Ndjson => {
+            return Err(tessera_core::Error::Invalid(
+                "tessera sql: --format ndjson is not supported yet (csv | tsv)".into(),
+            ))
+        }
+    };
+
+    // Build the logical view + eagerly materialize its columns into an Arrow RecordBatch. This is
+    // the spike-phase materialisation described in the module doc (streaming is #251 phase 2/3).
+    let mut r = Reader::open(file)?;
+    let view = r.logical_table(block)?;
+    let columns: Vec<tessera_core::block::table::Column> = view.columns().to_vec();
+    if columns.is_empty() {
+        return Err(tessera_core::Error::Invalid(format!(
+            "tessera sql: block '{block}' has no columns"
+        )));
+    }
+    let mut fields: Vec<Field> = Vec::with_capacity(columns.len());
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(columns.len());
+    for col in &columns {
+        let data = view.column(&mut r, &col.name)?;
+        fields.push(Field::new(&col.name, numpy_to_arrow(&col.dtype)?, false));
+        arrays.push(column_to_array(data));
+    }
+    let schema = Arc::new(Schema::new(fields));
+    let batch = RecordBatch::try_new(schema.clone(), arrays)
+        .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: build batch: {e}")))?;
+
+    // DataFusion is async; drive it on a fresh current-thread tokio runtime. No long-lived
+    // executor — the CLI is a one-shot query. `MemTable::try_new` takes `Vec<Vec<RecordBatch>>`
+    // (one partition, one batch — we hold the whole block anyway).
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: build runtime: {e}")))?;
+
+    let batches: Vec<RecordBatch> = runtime.block_on(async move {
+        let ctx = SessionContext::new();
+        let mem = MemTable::try_new(schema, vec![vec![batch]])
+            .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: MemTable: {e}")))?;
+        ctx.register_table(block, Arc::new(mem))
+            .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: register: {e}")))?;
+        let df = ctx
+            .sql(query)
+            .await
+            .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: parse: {e}")))?;
+        df.collect()
+            .await
+            .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: execute: {e}")))
+    })?;
+
+    // Empty result → header only (parity with `read`'s CSV shape) OR no output at all if there
+    // were zero batches. arrow-csv writes the header from the first batch, so we drive it there.
+    let mut writer = WriterBuilder::new()
+        .with_header(true)
+        .with_delimiter(delim)
+        .build(out);
+    for batch in &batches {
+        writer
+            .write(batch)
+            .map_err(|e| tessera_core::Error::Invalid(format!("tessera sql: csv write: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tessera_core::block::table::{Column, TableSpec};
+    use tessera_core::ProductBuilder;
+    use tessera_io::{pack, table::table_block, table::TableData};
+
+    /// Seal a tiny table `.tsra` — same shape as `nav::tests::sample`, so we exercise the
+    /// production seal + Vortex encode + LogicalTableView path (not a hand-rolled shortcut).
+    fn sample(path: &std::path::Path) {
+        let spec = TableSpec {
+            columns: vec![
+                Column {
+                    name: "ms".into(),
+                    dtype: "u4".into(),
+                    codec: None,
+                },
+                Column {
+                    name: "en".into(),
+                    dtype: "f4".into(),
+                    codec: None,
+                },
+            ],
+            rows: 4,
+            row_index: None,
+        };
+        let data: TableData = vec![
+            ("ms".into(), ColumnData::U32(vec![10, 20, 30, 40])),
+            ("en".into(), ColumnData::F32(vec![0.5, 1.5, 2.5, 3.5])),
+        ];
+        let (block_ref, payload) = table_block("events", &spec, &data).unwrap();
+        let mut b = ProductBuilder::new("listmode", "DP", "d", "2024-01-01T00:00:00Z");
+        b.add_block_ref(block_ref);
+        b.with_field("modality", serde_json::json!("PT"));
+        let sealed = b.seal().unwrap();
+        pack(&sealed, &[payload], path).unwrap();
+    }
+
+    /// End-to-end sanity: WHERE + ORDER BY + LIMIT reaches the block, decodes it via Vortex,
+    /// registers the Arrow batch, and DataFusion executes the query. If the arrow-58 alignment
+    /// with Vortex broke, this test would fail to compile at the `column_to_array` call site
+    /// (two arrow types with the same name from different majors → mismatch).
+    #[test]
+    fn where_order_by_limit_executes_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT ms FROM events WHERE en > 1.0 ORDER BY ms LIMIT 2",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        // Expect: header + the two smallest ms whose en > 1.0. sample() has (ms, en) pairs
+        // (10, 0.5), (20, 1.5), (30, 2.5), (40, 3.5) → WHERE en > 1.0 keeps {20, 30, 40} →
+        // ORDER BY ms ASC LIMIT 2 → [20, 30].
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text, "ms\n20\n30\n");
+    }
+
+    /// Column projection works: `SELECT en FROM events` returns only `en` — proves DataFusion is
+    /// actually planning + executing, not just echoing the whole RecordBatch back.
+    #[test]
+    fn select_single_column_projects_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT en FROM events ORDER BY en",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text, "en\n0.5\n1.5\n2.5\n3.5\n");
+    }
+
+    /// `--format tsv` swaps the delimiter (arrow-csv writer, same batches). Also confirms empty
+    /// result-set behaviour — `WHERE en > 999.0` matches zero rows.
+    #[test]
+    fn tsv_delimiter_and_empty_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT ms, en FROM events WHERE ms >= 30",
+            Format::Tsv,
+            &mut out,
+        )
+        .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        // Two rows survive the filter; TSV means literal tabs between fields.
+        assert!(
+            text.starts_with("ms\ten\n"),
+            "expected TSV header, got: {text:?}"
+        );
+        assert!(
+            text.contains("30\t2.5\n"),
+            "missing (30, 2.5) row: {text:?}"
+        );
+        assert!(
+            text.contains("40\t3.5\n"),
+            "missing (40, 3.5) row: {text:?}"
+        );
+    }
+
+    /// A bad column name in the query surfaces DataFusion's planner error via our typed
+    /// `Error::Invalid`, not a panic. This is the "does the error path work" guard.
+    #[test]
+    fn bad_column_returns_a_typed_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        let err = run_with(
+            &tsra,
+            "events",
+            "SELECT no_such_column FROM events",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("no_such_column") || msg.contains("Schema") || msg.contains("plan"),
+            "expected a schema/plan error naming the missing column, got: {msg}"
+        );
+    }
+
+    /// `--format ndjson` is explicitly rejected today (arrow-csv is the writer) — proves the
+    /// rejection is typed, not a panic. Regenerating this to a real ndjson path is a follow-up.
+    #[test]
+    fn ndjson_format_is_rejected_typed() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        let err = run_with(
+            &tsra,
+            "events",
+            "SELECT ms FROM events",
+            Format::Ndjson,
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("ndjson"),
+            "typed rejection expected"
+        );
+    }
+}

--- a/tessera/crates/tessera-cli/tests/cmd/help.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/help.trycmd
@@ -15,6 +15,9 @@ Inspect & navigate:
   slice       Pull a plane/line/point of an array block as CSV (--index z,:,:)
   export      Emit a FAIR discovery record (JSON to stdout)
 
+Query (needs --features sql):
+  sql         Run SQL (DataFusion) over a table block
+
 Ingest & pack:
   ingest      Ingest a vendor file (or a declarative --spec) into a sealed .tsra
   pack        Pack an exploded dir (manifest.json + blocks/) into a sealed .tsra

--- a/tessera/crates/tessera-cli/tests/cmd/sql.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/sql.trycmd
@@ -1,0 +1,22 @@
+The `tessera sql` verb (#251) exposes a DataFusion SQL surface over a table block. It's
+gated by the `sql` feature (pulls DataFusion + arrow-58 + tokio); without it, the command
+still parses so the UX is uniform, and returns a typed rebuild-with-feature message — same
+shape as the `cloud`-gated `push` / `pull` verbs.
+
+Help text always renders (parses without the feature, so `--help` never depends on the
+DataFusion tree being compiled):
+
+```
+$ tessera sql --help
+Run SQL (DataFusion) over a `.tsra` table block (needs `--features sql`).
+...
+```
+
+And the fallback when the binary was built without the feature:
+
+```
+$ tessera sql corpus/files/listmode_events.tsra events "SELECT 1"
+? 1
+error: invalid product: sql requires the `sql` feature (pulls DataFusion) — rebuild: cargo build -p tessera-cli --features sql
+
+```


### PR DESCRIPTION
`tsra sql <FILE> <BLOCK> "<QUERY>"` — a **DataFusion** SQL surface over Tessera table blocks, in-process, feature-gated `sql`.

- **Dependency aligns cleanly:** DataFusion **54** pins arrow **58**, matching Vortex 0.75's arrow-58 — one arrow tree, no double-link. `datafusion` (defaults off) + `arrow/csv` + `tokio` (current-thread), all behind the `sql` feature.
- **How:** open the `.tsra`, build the cross-block `LogicalTableView` (so `events` spans `events_NNNN`), convert each `ColumnData` column → arrow arrays → a `RecordBatch`, register as a DataFusion `MemTable`, run the SQL, emit CSV/TSV.
- **Proven:** `SELECT t,e0,e1 FROM events WHERE e0>40 ORDER BY t LIMIT 3` and `COUNT(*)/MIN/MAX` aggregates round-trip against corpus data.
- **Feature-off fallback:** `tsra sql` still parses and returns a typed "rebuild with --features sql" error (same UX as the `cloud`-gated push/pull). Grouped in help under "Query".
- **cargo-deny:** clean (no new allow/ignore).

Spike scope (issue #251): MemTable materializes the block in RAM; streaming `TableProvider` + predicate/projection pushdown (ChunkIndex-driven shard skipping) are the documented phase-2/3 follow-ups. Full `nix flake check` green incl. the new `sql-tests` derivation (5 SQL tests under `--features sql`).

Closes #251.