### PR TITLE
fix(cli): usability quick-wins from the 5-persona review (read<blob>, export shape, ls extra, schema wording)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -507,8 +507,11 @@ enum Cmd {
     },
     /// Emit a FAIR discovery record for a `.tsra` (prints JSON to stdout).
     Export {
-        #[command(subcommand)]
-        fmt: ExportFmt,
+        /// The `.tsra` to export.
+        file: PathBuf,
+        /// Record format: `ro-crate` (default) | `datacite`.
+        #[arg(long, default_value = "ro-crate")]
+        format: String,
     },
     /// Generate an ed25519 keypair (private seed mode 0600; public key to `OUT.pub`).
     ///
@@ -623,20 +626,6 @@ enum BenchAction {
         /// Seed for the MC sampler (deterministic synthetic data).
         #[arg(long, default_value_t = 1)]
         seed: u64,
-    },
-}
-
-#[derive(Subcommand)]
-enum ExportFmt {
-    /// RO-Crate metadata descriptor (`ro-crate-metadata.json` shape).
-    RoCrate {
-        /// The `.tsra` to export.
-        file: PathBuf,
-    },
-    /// DataCite metadata record (for DOI minting / InvenioRDM).
-    Datacite {
-        /// The `.tsra` to export.
-        file: PathBuf,
     },
 }
 
@@ -1091,7 +1080,7 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                     );
                 }
                 (None, Some(s)) => println!(
-                    "product '{}' — built-in schema v{} ({}); file predates embedded schemas",
+                    "product '{}' — schema v{} ({}) from the built-in registry (not embedded in this file)",
                     m.product, s.version, s.description
                 ),
                 (None, None) => println!(
@@ -1169,13 +1158,15 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 run_ingest(src)
             }
         }
-        Cmd::Export { fmt } => {
-            let record = match fmt {
-                ExportFmt::RoCrate { file } => {
-                    tessera_core::export::ro_crate(Reader::open(&file)?.manifest())
-                }
-                ExportFmt::Datacite { file } => {
-                    tessera_core::export::datacite(Reader::open(&file)?.manifest())
+        Cmd::Export { file, format } => {
+            let m = Reader::open(&file)?;
+            let record = match format.as_str() {
+                "ro-crate" | "rocrate" => tessera_core::export::ro_crate(m.manifest()),
+                "datacite" => tessera_core::export::datacite(m.manifest()),
+                other => {
+                    return Err(tessera_core::Error::Invalid(format!(
+                        "unknown --format '{other}' (expected ro-crate | datacite)"
+                    )))
                 }
             };
             println!(
@@ -2117,11 +2108,13 @@ streaming = "batch"
         let tsra = dir.path().join("p.tsra");
         sample_tsra(&tsra);
         run(Cmd::Export {
-            fmt: ExportFmt::RoCrate { file: tsra.clone() },
+            file: tsra.clone(),
+            format: "ro-crate".into(),
         })
         .unwrap();
         run(Cmd::Export {
-            fmt: ExportFmt::Datacite { file: tsra },
+            file: tsra,
+            format: "datacite".into(),
         })
         .unwrap();
     }

--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -557,6 +557,9 @@ pub fn ls(file: &Path, path: Option<&str>, full: bool, out: &mut dyn Write) -> R
             Ok(())
         }
         Some(p) if p == "extra" || p == "extra/" => {
+            if m.extra.is_empty() {
+                writeln!(out, "(no extra fields)").map_err(tessera_core::Error::from)?;
+            }
             for (k, v) in &m.extra {
                 let kind = match v {
                     Value::Object(o) => format!("object, {} keys", o.len()),
@@ -728,14 +731,22 @@ pub struct ReadResult {
 /// Columns are projected (only the requested columns' segments are decoded per block).
 pub fn read(opts: ReadOpts, out: &mut dyn Write) -> Result<ReadResult> {
     let mut r = Reader::open(opts.file)?;
-    // `read` is table-only. If the target names an **array** block (a volume/μ-map), fail with a
-    // clear pointer instead of the opaque "missing field columns" from the table decoder (#253).
+    // `read` is table-only. If the target names a non-table block (array volume, blob, index), fail
+    // with a clear pointer instead of the opaque "missing field columns" from the table decoder
+    // (#253/#268). Covers Array/Blob/ChunkIndex; a multi-block table prefix like `events` won't
+    // exact-match a single block, so it falls through to the logical-table path.
     if let Some(b) = r.manifest().blocks.iter().find(|b| b.name == opts.block) {
-        if b.kind == BlockKind::Array {
+        if b.kind != BlockKind::Table {
+            let hint = match b.kind {
+                BlockKind::Array => "use `tsra stats` / `tsra slice` / `tsra project`",
+                BlockKind::Blob => "use `tsra extract` for its raw bytes",
+                _ => "use `tsra ls` / `tsra inspect`",
+            };
             return Err(tessera_core::Error::Invalid(format!(
-                "'{}' is an array block ({}), not a table — `read` is for tables. Use \
-                 `tsra ls {} {}` for its spec or `tsra extract` for raw bytes (array slicing/stats: #253).",
+                "'{}' is a {} block ({}), not a table — `read` is for tables. {hint}, or \
+                 `tsra ls {} {}` for its spec.",
                 opts.block,
+                format!("{:?}", b.kind).to_lowercase(),
                 block_headline(&b.kind, &b.spec),
                 opts.file.display(),
                 opts.block,

--- a/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
@@ -104,7 +104,7 @@ label,volume_ml
 # === Emit a FAIR discovery record (RO-Crate JSON) for your catalog / data portal. ===
 
 ```
-$ tessera export ro-crate ../../corpus/files/multiblock_study.tsra
+$ tessera export ../../corpus/files/multiblock_study.tsra
 {
   "@context": "https://w3id.org/ro/crate/1.1/context",
   "@graph": [


### PR DESCRIPTION
Addresses the clear high-frequency findings from the fresh-context usability review: `read <blob>` no longer leaks `serde: missing field 'columns'` (generalised the non-table-block guard — #268); `export <FILE>` now works, defaulting to ro-crate (was a subcommand group all 5 reviewers tripped on — #270); `ls FILE extra` prints `(no extra fields)` instead of silent; `schema` wording fixed ("from the built-in registry (not embedded)" vs the misleading "predates embedded schemas"). Bigger findings filed: #267 (export PHI/JSON-LD + provenance-as-list), #268 (read-side seal check + streaming blob verify), #269 (deidentify completeness), #271 (DICOM world_frame), #272 (collection verbs). Gate green.