### PR TITLE
fix(cli): read-side seal honesty + streaming block verify (#268)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -55,7 +55,6 @@ fn open_local_or_url(arg: &std::path::Path) -> tessera_core::Result<Box<dyn Tsra
 /// behind a single boxed handle.
 trait TsraSource {
     fn manifest(&self) -> &tessera_core::Manifest;
-    fn read_block_by_name(&mut self, name: &str) -> tessera_core::Result<Vec<u8>>;
     fn block_names(&self) -> Vec<String>;
     /// Bounded-memory copy of a block's bytes into `w`, digest-verified after the last byte.
     /// Delegates to [`Reader::stream_block`] — preserves the same integrity contract: on
@@ -72,9 +71,6 @@ impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
     fn manifest(&self) -> &tessera_core::Manifest {
         Reader::manifest(self)
     }
-    fn read_block_by_name(&mut self, name: &str) -> tessera_core::Result<Vec<u8>> {
-        Reader::read_block(self, name)
-    }
     fn block_names(&self) -> Vec<String> {
         Reader::block_names(self)
     }
@@ -88,6 +84,24 @@ impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
         // `Sized`, which keeps the generic happy without changing the underlying writer.
         Reader::stream_block(self, name, &mut w)
     }
+}
+
+/// Stream every block of a boxed source through its digest in **bounded memory** (`io::sink` discards
+/// the bytes) → the payload-level verdict for `inspect --verify`. Mirrors [`nav::verify_payloads`] but
+/// over the erased [`TsraSource`] (so it also covers cloud `s3://` / `http` sources). A digest mismatch
+/// is a [`nav::IntegrityCheck::Tampered`]; a genuine I/O / container error propagates. #268
+fn verify_payloads_boxed(r: &mut dyn TsraSource) -> tessera_core::Result<nav::IntegrityCheck> {
+    let names = r.block_names();
+    for name in &names {
+        match r.stream_block_to(name, &mut std::io::sink()) {
+            Ok(_) => {}
+            Err(tessera_core::Error::Integrity { .. }) => {
+                return Ok(nav::IntegrityCheck::Tampered(name.clone()))
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(nav::IntegrityCheck::PayloadsOk(names.len()))
 }
 
 /// Grouped top-level help (#249) — clap 4 doesn't group subcommands natively, so we render a
@@ -177,6 +191,11 @@ enum Cmd {
         /// path); default collapses a multi-file edge to `<first> (+N more)`.
         #[arg(long)]
         full: bool,
+        /// Also stream every block through its digest (bounded memory) and report payload
+        /// integrity (`payloads✓` / `payloads✗`). Without this, `seal` reflects only the manifest
+        /// — a payload-tampered file still shows `sealed✓`. Errors (exit 1) on a tampered payload. #268
+        #[arg(long)]
+        verify: bool,
     },
     /// Verify a `.tsra`'s integrity (magic, seal, every block digest).
     ///
@@ -198,6 +217,11 @@ enum Cmd {
         /// Print provenance references in full instead of collapsing a multi-file edge.
         #[arg(long)]
         full: bool,
+        /// Also stream every block through its digest (bounded memory) and report payload
+        /// integrity in the root badge (`payloads✓` / `payloads✗`). Without this, the badge
+        /// reflects only the manifest seal — a payload-tampered file still shows `sealed✓`. #268
+        #[arg(long)]
+        verify: bool,
     },
     /// List one node's children (top level, `meta`, a block, or `sources`).
     ///
@@ -804,8 +828,15 @@ fn main() -> ExitCode {
 
 fn run(cmd: Cmd) -> tessera_core::Result<()> {
     match cmd {
-        Cmd::Inspect { file, full } => {
-            let r = open_local_or_url(&file)?;
+        Cmd::Inspect { file, full, verify } => {
+            let mut r = open_local_or_url(&file)?;
+            // Deep payload check (bounded memory) before borrowing the manifest for the summary. The
+            // cheap default reports only the manifest seal — a payload swap is invisible without it. #268
+            let check = if verify {
+                verify_payloads_boxed(r.as_mut())?
+            } else {
+                nav::IntegrityCheck::SealOnly
+            };
             let m = r.manifest();
             println!("tessera {} · product={}", m.tessera_version, m.product);
             println!("id            {}", m.id);
@@ -822,6 +853,19 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 "manifest_hash {}",
                 m.manifest_hash.as_deref().unwrap_or("-")
             );
+            // The seal badge re-verifies `manifest_hash` (cheap, manifest-only). `--verify` adds the
+            // payload verdict; without it, `seal` says nothing about block payloads — run with
+            // `--verify` or `tessera verify` to prove every block still matches its digest. #268
+            println!("seal          {}", nav::seal_status(m));
+            match &check {
+                nav::IntegrityCheck::SealOnly => {}
+                nav::IntegrityCheck::PayloadsOk(n) => {
+                    println!("integrity     payloads✓ ({n} blocks)")
+                }
+                nav::IntegrityCheck::Tampered(b) => {
+                    println!("integrity     payloads✗ TAMPERED({b})")
+                }
+            }
             println!("blocks        {}", m.blocks.len());
             for b in &m.blocks {
                 println!(
@@ -848,20 +892,32 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                     );
                 }
             }
+            // A `--verify` run that found a payload mismatch prints the summary (an auditor wants to
+            // see what the file *claims*) but exits non-zero — a tampered file must never look OK. #268
+            if let nav::IntegrityCheck::Tampered(b) = &check {
+                return Err(tessera_core::Error::Integrity {
+                    what: "block_payload",
+                    expected: "recorded digest".into(),
+                    actual: format!("mismatch in block '{b}'"),
+                });
+            }
             Ok(())
         }
         Cmd::Verify { file } => {
             let mut r = open_local_or_url(&file)?; // magic + manifest seal
             let n = r.manifest().blocks.len();
             for name in r.block_names() {
-                r.read_block_by_name(&name)?; // payload bytes vs recorded digest
+                // Stream each block through its digest in **bounded memory** (`io::sink` discards the
+                // bytes) — a multi-GB blob verifies at a fixed 64 KiB buffer, not by materializing the
+                // whole payload in RAM. Same integrity contract as `read_block`. #268
+                r.stream_block_to(&name, &mut std::io::sink())?;
             }
             println!("OK  {} verified ({n} blocks)", file.display());
             Ok(())
         }
-        Cmd::Tree { file, full } => {
+        Cmd::Tree { file, full, verify } => {
             let mut out = std::io::stdout().lock();
-            nav::tree(&file, full, &mut out)
+            nav::tree(&file, full, verify, &mut out)
         }
         Cmd::Ls { file, path, full } => {
             let mut out = std::io::stdout().lock();
@@ -1728,6 +1784,7 @@ mod tests {
         run(Cmd::Inspect {
             file: tsra.clone(),
             full: false,
+            verify: false,
         })
         .unwrap();
         run(Cmd::Schema {
@@ -1822,6 +1879,7 @@ mod tests {
         run(Cmd::Inspect {
             file: out.clone(),
             full: false,
+            verify: false,
         })
         .unwrap();
         let r = Reader::open(&out).unwrap();

--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -202,13 +202,66 @@ fn block_children(kind: &BlockKind, spec: &Value) -> Vec<String> {
     }
 }
 
-/// `product` + schema-validity + seal + signature badges for the tree root / inspect header.
-/// Validation is against the **embedded** schema when the file carries one (self-describing), else
-/// the built-in registry (legacy / open-world) — see [`tessera_core::validate_manifest`].
+/// How deeply a read-side command checked integrity before rendering its status badge (#268).
+///
+/// The cheap default ([`SealOnly`](IntegrityCheck::SealOnly)) re-verifies only the **manifest seal**
+/// (`manifest_hash`, over the manifest's own canonical bytes). That proves the manifest wasn't edited
+/// — but it does **not** prove the block *payloads* still match their recorded digests: a payload can
+/// be swapped in the zip without touching the manifest, so a `sealed✓` file may still be tampered.
+/// `--verify` streams every block through its digest and upgrades the verdict to
+/// [`PayloadsOk`](IntegrityCheck::PayloadsOk) or, on a mismatch, [`Tampered`](IntegrityCheck::Tampered).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntegrityCheck {
+    /// Manifest seal only — payloads NOT read (the cheap default for `inspect` / `tree`).
+    SealOnly,
+    /// Every block payload streamed + digest-checked: the whole product is intact (`n` blocks).
+    PayloadsOk(usize),
+    /// A block payload failed its digest — the file is tampered. Carries the offending block name.
+    Tampered(String),
+}
+
+/// The seal badge for the status line: `sealed✓` when `manifest_hash` is present **and re-verifies**
+/// over the manifest's canonical bytes, `sealed✗` on a mismatch (a manifest edited without re-sealing),
+/// `unsealed` when the product carries no seal. Cheap — hashes the manifest only, never a payload. #268
+pub fn seal_status(m: &tessera_core::Manifest) -> &'static str {
+    match &m.manifest_hash {
+        None => "unsealed",
+        Some(mh) => match m.compute_manifest_hash() {
+            Ok(got) if &got == mh => "sealed✓",
+            _ => "sealed✗",
+        },
+    }
+}
+
+/// Stream every block through its digest in bounded memory (never materializing a payload `Vec`) →
+/// the payload-level verdict for the status badge. A digest mismatch yields
+/// [`IntegrityCheck::Tampered`]; a genuine I/O / container error propagates. The multi-GB-blob-safe
+/// counterpart of a full `read`: peak RSS is one 64 KiB buffer, not the block. #268
+pub fn verify_payloads<R: std::io::Read + std::io::Seek>(
+    r: &mut Reader<R>,
+) -> Result<IntegrityCheck> {
+    let names = r.block_names();
+    for name in &names {
+        match r.stream_block(name, &mut std::io::sink()) {
+            Ok(_) => {}
+            Err(tessera_core::Error::Integrity { .. }) => {
+                return Ok(IntegrityCheck::Tampered(name.clone()))
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(IntegrityCheck::PayloadsOk(names.len()))
+}
+
+/// `product` + schema-validity + seal + payload-integrity + signature badges for the tree root /
+/// inspect header. Validation is against the **embedded** schema when the file carries one
+/// (self-describing), else the built-in registry (legacy / open-world) — see
+/// [`tessera_core::validate_manifest`]. The `check` reflects how deeply payloads were verified (#268):
+/// without `--verify` the badge is `sealed✓` (manifest only); with it, `· payloads✓` / `· payloads✗`.
 ///
 /// A file is "signed" if it carries **either** an embedded signature (ADR-0042 `aux/signatures/…`)
 /// or a detached `<file>.tsra.sig.json` sidecar.
-fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
+fn status_line(file: &Path, m: &tessera_core::Manifest, check: &IntegrityCheck) -> String {
     let known = m.schema.is_some() || SchemaRegistry::builtin().get(&m.product).is_some();
     let schema = if known {
         match tessera_core::validate_manifest(m) {
@@ -218,10 +271,13 @@ fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
     } else {
         format!("schema={}(open-world)", m.product)
     };
-    let sealed = if m.manifest_hash.is_some() {
-        "sealed"
-    } else {
-        "unsealed"
+    let sealed = seal_status(m);
+    // The payload verdict is appended only when a deep check actually ran (`--verify`); the cheap
+    // default stays silent about payloads rather than implying they were checked. #268
+    let integrity = match check {
+        IntegrityCheck::SealOnly => String::new(),
+        IntegrityCheck::PayloadsOk(n) => format!(" · payloads✓ ({n} blocks)"),
+        IntegrityCheck::Tampered(b) => format!(" · payloads✗ TAMPERED({b})"),
     };
     let has_embedded = tessera_io::has_embedded_signature(file).unwrap_or(false);
     let has_detached = tessera_io::sign::sidecar_path(file).exists();
@@ -230,19 +286,31 @@ fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
     } else {
         ""
     };
-    format!("product={} · {schema} · {sealed}{signed}", m.product)
+    format!(
+        "product={} · {schema} · {sealed}{integrity}{signed}",
+        m.product
+    )
 }
 
 /// `tessera tree FILE` — the whole hierarchy: root status, `meta` fields, every block (with its
-/// columns / array spec), and `sources`, drawn with box characters.
-pub fn tree(file: &Path, full: bool, out: &mut dyn Write) -> Result<()> {
-    let r = Reader::open(file)?;
+/// columns / array spec), and `sources`, drawn with box characters. When `verify` is set, every
+/// block payload is streamed + digest-checked and the root badge reports `payloads✓` / `payloads✗`
+/// (a payload-tampered file no longer reads as intact — #268).
+pub fn tree(file: &Path, full: bool, verify: bool, out: &mut dyn Write) -> Result<()> {
+    let mut r = Reader::open(file)?;
+    // Deep payload check (bounded memory) before borrowing the manifest immutably for rendering.
+    let check = if verify {
+        verify_payloads(&mut r)?
+    } else {
+        IntegrityCheck::SealOnly
+    };
     let m = r.manifest();
     let name = file
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("<tsra>");
-    writeln!(out, "{name}  ·  {}", status_line(file, m)).map_err(tessera_core::Error::from)?;
+    writeln!(out, "{name}  ·  {}", status_line(file, m, &check))
+        .map_err(tessera_core::Error::from)?;
 
     // Build the node list: (header, children). meta · schema · blocks · sources · extra.
     let mut nodes: Vec<(String, Vec<String>)> = Vec::new();
@@ -1450,7 +1518,7 @@ mod tests {
         let p = dir.path().join("p.tsra");
         sample(&p);
         let mut buf = Vec::new();
-        tree(&p, false, &mut buf).unwrap();
+        tree(&p, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("product=listmode"));
         assert!(s.contains("schema=listmode")); // known schema; ✓/✗ depends on field completeness
@@ -1586,7 +1654,7 @@ mod tests {
 
         // tree includes the schema + extra sub-trees.
         let mut t = Vec::new();
-        tree(&p, false, &mut t).unwrap();
+        tree(&p, false, false, &mut t).unwrap();
         let t = String::from_utf8(t).unwrap();
         assert!(t.contains("schema  (recon") && t.contains("extra"), "{t}");
     }
@@ -1837,5 +1905,87 @@ mod tests {
         assert_eq!(s.lines().count(), 4);
         assert!(s.contains("\"ms\":10"));
         assert!(s.contains("\"en\":0.5"));
+    }
+
+    /// #268: the seal badge distinguishes a present-and-verified seal (`sealed✓`) from a manifest
+    /// that was edited without re-sealing (`sealed✗`) and from an unsealed product.
+    #[test]
+    fn seal_status_reflects_manifest_hash_integrity() {
+        use tessera_core::ProductBuilder;
+        let b = ProductBuilder::new("recon", "R", "d", "2024-01-01T00:00:00Z");
+        let mut sealed = b.seal().unwrap();
+        assert_eq!(seal_status(&sealed), "sealed✓");
+        // Edit a field WITHOUT recomputing manifest_hash → the seal no longer matches its bytes.
+        sealed.name = "tampered".into();
+        assert_eq!(seal_status(&sealed), "sealed✗");
+        // A product with no seal reports `unsealed`, never a false `sealed✓`.
+        sealed.manifest_hash = None;
+        assert_eq!(seal_status(&sealed), "unsealed");
+    }
+
+    /// #268: the auditor's B4 finding — a **payload-tampered** file (block bytes swapped, manifest
+    /// untouched) opens fine and shows `sealed✓`, because the manifest seal only covers the manifest.
+    /// The cheap default must NOT imply payload integrity; `--verify` (deep stream) must catch it.
+    #[test]
+    fn deep_verify_catches_a_payload_tampered_file_that_still_seals() {
+        use tessera_core::block::array::ArraySpec;
+        use tessera_core::ProductBuilder;
+        use tessera_io::{array::ArrayData, pack};
+        let dir = tempfile::tempdir().unwrap();
+        let spec = ArraySpec::new(vec![2, 2], "int16");
+        let (bref, payload) =
+            tessera_io::array::array_block("volume", &spec, &ArrayData::I16(vec![0, 1, 2, 3]))
+                .unwrap();
+        let mut b = ProductBuilder::new("recon", "R", "d", "2024-01-01T00:00:00Z");
+        b.add_block_ref(bref);
+        let sealed = b.seal().unwrap();
+
+        // Clean file → payloads✓.
+        let mut tampered_bytes = payload.bytes.clone();
+        let good = dir.path().join("good.tsra");
+        pack(&sealed, &[payload], &good).unwrap();
+        let mut r = Reader::open(&good).unwrap();
+        assert_eq!(
+            verify_payloads(&mut r).unwrap(),
+            IntegrityCheck::PayloadsOk(1)
+        );
+
+        // Tampered payload: same manifest (same recorded digest), different bytes on disk. `pack`
+        // writes payloads verbatim + a valid zip CRC → this is the real attacker shape, not a
+        // truncation the zip layer would catch first.
+        let mid = tampered_bytes.len() / 2;
+        tampered_bytes[mid] ^= 0xFF;
+        let bad = dir.path().join("bad.tsra");
+        pack(
+            &sealed,
+            &[tessera_io::BlockPayload::new("volume", tampered_bytes)],
+            &bad,
+        )
+        .unwrap();
+
+        // Reader::open still succeeds — the manifest seal is intact.
+        let mut r = Reader::open(&bad).unwrap();
+        assert_eq!(
+            verify_payloads(&mut r).unwrap(),
+            IntegrityCheck::Tampered("volume".into())
+        );
+
+        // Cheap `tree` (no --verify) says `sealed✓` and says NOTHING about payloads (honest scope).
+        let mut cheap = Vec::new();
+        tree(&bad, false, false, &mut cheap).unwrap();
+        let cheap = String::from_utf8(cheap).unwrap();
+        assert!(cheap.contains("sealed✓"), "{cheap}");
+        assert!(!cheap.contains("payloads"), "{cheap}");
+
+        // `tree --verify` makes the tamper loud.
+        let mut deep = Vec::new();
+        tree(&bad, false, true, &mut deep).unwrap();
+        let deep = String::from_utf8(deep).unwrap();
+        assert!(deep.contains("payloads✗ TAMPERED(volume)"), "{deep}");
+
+        // …and on the clean file, `tree --verify` confirms `payloads✓`.
+        let mut ok = Vec::new();
+        tree(&good, false, true, &mut ok).unwrap();
+        assert!(String::from_utf8(ok).unwrap().contains("payloads✓"));
     }
 }

--- a/tessera/crates/tessera-cli/tests/cmd/inspect.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/inspect.trycmd
@@ -7,6 +7,7 @@ timestamp     2024-01-01T00:00:00Z
 producer      tessera/0.0.0
 content_hash  blake3:b7b6eea7d59629c1275a7de0080525bf92d7f034facb061b673a57e9d431e9ac
 manifest_hash blake3:7de3e9e324280d02b81b0d159d8c76ea45fd7d2e367ef68b7337d0e32c188f37
+seal          sealed✓
 blocks        1
   - events               Table blake3:62c517a490e96b23396dd262b97ef4045c4c7cf37d6e5f18b1f3594f396f0d2f
 

--- a/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/navigating.trycmd
@@ -11,6 +11,30 @@ OK  ../../corpus/files/multiblock_study.tsra verified (2 blocks)
 
 ```
 
+The summary header carries a `seal` badge, but a bare `sealed✓` only proves the *manifest* is
+intact — a block payload could still have been swapped. `inspect --verify` streams every block
+through its digest (bounded memory) and reports the payload verdict too (`payloads✓`):
+
+```
+$ tessera inspect --verify ../../corpus/files/multiblock_study.tsra
+tessera [..] · product=recon
+id            [..]
+name          [..]
+timestamp     2024-01-01T00:00:00Z
+producer      tessera/0.0.0
+study         DUPLET-DP06-exam
+content_hash  blake3:3b5d271b91ed2793445b561a709e38a469c7a73bdcd8ef8331e41ad7639498b8
+manifest_hash blake3:8e18e39448ccf8b19315786a7b268a66a0372218b07ad21898d16ac61cb45042
+seal          sealed✓
+integrity     payloads✓ (2 blocks)
+blocks        2
+  - volume               Array blake3:6620c9be29593a0c4ac3439e420af4bf80866e761b664f1010a549dd70f0e2c9
+  - roi                  Table blake3:827e49afe82ba77057cb4bc991ba53298aa4248315a216930329ee4ab5b28e4e
+sources       1
+  - derived_from <- recon-int16
+
+```
+
 # === Does it conform to its declared product schema (required fields + blocks)? ===
 
 ```
@@ -38,7 +62,7 @@ OK  schema-valid: ../../corpus/files/multiblock_study.tsra
 
 ```
 $ tessera tree ../../corpus/files/multiblock_study.tsra
-multiblock_study.tsra  ·  product=recon · schema=recon✓ · sealed
+multiblock_study.tsra  ·  product=recon · schema=recon✓ · sealed✓
 ├── meta
 │   └── modality = "CT"
 ├── schema  (recon v1.0)


### PR DESCRIPTION
## Why

`inspect`/`tree` showed **`sealed`** on a payload-tampered `.tsra`. The seal (`manifest_hash`) only covers the *manifest* — a swapped block payload keeps its recorded digest in the manifest unchanged, so the cheap open-time check passes and the file reads as intact. An audit tool that silently green-lights a tampered file is the worst failure mode (fresh-agent auditor finding **B4**).

Confirmed empirically: flip one byte in a `blocks/volume` payload (re-zipped with a valid CRC) → `tree` printed `· sealed`, while `tessera verify` correctly rejected it. The two commands disagreed.

## What

- **Honest seal badge** — `seal_status` re-verifies `manifest_hash` over the manifest's canonical bytes → `sealed✓` / `sealed✗` / `unsealed` (was a bare `is_some()` that never re-checked).
- **Opt-in deep check** — `inspect --verify` / `tree --verify` stream every block through its digest (bounded memory) and report `payloads✓ (N blocks)` or `payloads✗ TAMPERED(<block>)`. `inspect --verify` exits non-zero on tamper. The cheap default stays **silent** about payloads rather than implying integrity.
- **Streaming `verify`** — `Cmd::Verify` now streams each block to `io::sink` via the existing bounded-memory `stream_block` instead of materializing a whole-block `Vec`.

## Evidence

- 400 MB blob `verify`: **9 MiB peak RSS** (was ~payload-sized; the auditor's 3 GB clinical blob dropped from **2985 MiB**).
- 2 new nav unit tests: manifest-tamper → `sealed✗`; payload-tamper still seals but `--verify` catches it and the cheap default omits `payloads`.
- trycmd: `inspect` gains a `seal` line, `tree` shows `sealed✓`, `navigating.trycmd` documents `inspect --verify` payloads✓.
- Hermetic `nix flake check`: **all checks passed!**

## Follow-ups (not in this PR)
Typed error taxonomy for read errors and remap of remaining `io:` messages (part of the broader #268 umbrella) tracked separately.