### PR TITLE
docs(adr): resolve block-digest vs sub-block-Merkle-root nuance (#214)

### DIFF
--- a/docs/adr/0027-sub-block-merkle-chunk-index.md
+++ b/docs/adr/0027-sub-block-merkle-chunk-index.md
@@ -11,6 +11,11 @@ index).
 > chunk_index_block`). #221-B measured the leaf-granularity trade-off (knee ≈ 2¹⁴). ADR-0028 is the single
 > carrier; this ADR stands as the focused record of the chunk-index rationale. This is a **terminal**
 > status (not Accepted) — the *generalised* form lives in ADR-0028, not as an independent decision.
+>
+> **The open "should the block digest *be* the sub-block Merkle root" question (§Context below) is
+> resolved in ADR-0028 §4.1: no.** The block digest stays a flat `blake3` of the whole payload so
+> identity is independent of internal chunk layout (a codec choice); the sub-block Merkle rides as the
+> additive `ChunkIndex` companion and reconciles with the flat digest by covering the same bytes. #214
 
 ## Context
 Today the Merkle is **one level deep**: `content_hash = merkle_root([block.digest])`, and a block's

--- a/docs/adr/0028-unified-hierarchy.md
+++ b/docs/adr/0028-unified-hierarchy.md
@@ -83,6 +83,36 @@ The integrity leaves (hashes) are canonical (they *are* the identity); stats/pyr
 derived. The chunk-index straddles — leaf-hashes canonical, stat columns derived — so the manifest tag
 keeps the canonical identity clean while accelerators float above it.
 
+#### 4.1 The block digest stays *flat* — the sub-block Merkle is an additive companion, not the block's identity (#214)
+
+§1 describes the recursive Merkle as the **logical** model (`product → block → chunk → sub-chunk`). The
+**physical identity deliberately does not fold the sub-block tree into the block's own digest.** A
+block's `digest` is a **flat `blake3` of its whole encoded payload**, and `content_hash =
+merkle_root([block.digest, …])` (ADR-0020, one level over blocks). The per-chunk Merkle root + `{hash,
+stats}` leaves live in the **additive `ChunkIndex` companion block** (`tessera_io::chunk_index::
+chunk_index_block`, tagged `derived`), *beside* the data block — never *as* its digest.
+
+Why not make the block digest itself the sub-block MMR root (the seemingly-purer unification)?
+
+- **Identity must be independent of internal chunking.** A block's chunk layout (array 64³ cubes, table
+  2¹⁶-row groups, the #221-B index-leaf size) is a **codec/encoder choice**, not a semantic property of
+  the product. If the block digest were the chunk-tree root, re-chunking the same logical bytes — a
+  legitimate encoder tuning — would change `content_hash` and the product `id`. Keeping the digest a
+  flat hash of the final payload means identity tracks **what the block *is*, not how it was tiled**.
+- **Determinism + corpus stability (S15).** The conformance corpus + writer-determinism gate pin flat
+  block digests. Folding the tree in would couple every golden hash to the chunk-granularity constant,
+  making the frozen `ROWS_PER_GROUP = 2¹⁶` / index-leaf `~2¹⁴` load-bearing for *identity* rather than
+  just for pruning — the exact decoupling #221-B established.
+- **The reconciliation is still exact.** The companion covers the *same bytes* as the data block: a
+  verifier recomputes the flat block digest **and** (optionally) walks the `ChunkIndex` leaves, and the
+  two agree by construction (both hash the block's chunk stream). Per-chunk confirmation + range-read
+  pruning are fully available; they simply ride the additive tier (§4) instead of the identity tier.
+
+So the recursive tree is the **conceptual** unification; the **carried** form is flat-digest + additive
+chunk-index. This is the settled resolution of ADR-0027's "should the block digest be the sub-block
+root" question (its terminal `Superseded` note): **no — identity stays chunk-layout-agnostic, and the
+sub-block Merkle is a first-class *companion*, not the block's name.**
+
 ### 5. The fused streaming pass — encode + hash + tree + stats in one flow
 The hierarchy is **built in the streaming pipeline**, not a separate pass:
 ```


### PR DESCRIPTION
## Why

The chunk-index infra shipped as **ADR-0028 §3** (`tessera_core::chunk_index` + both encoders + the additive `ChunkIndex` companion block; #221-B measured the leaf-granularity knee). The one open nuance from **ADR-0027** — *should a block's own digest **be** the sub-block MMR root?* — was never written down. This records the resolution.

## What

New **ADR-0028 §4.1**: **no.** The block digest stays a flat `blake3` of the whole payload; the sub-block Merkle rides as the additive `ChunkIndex` companion.

Rationale:
- **Identity independent of chunk layout** — chunking (64³ cubes, 2¹⁶-row groups, the ~2¹⁴ index leaf) is a codec choice; folding the tree into the digest would make re-chunking the same bytes change `content_hash`/`id`.
- **Determinism / corpus stability (S15)** — flat digests keep the goldens from coupling to the chunk-granularity constant #221-B deliberately decoupled.
- **Exact reconciliation** — the companion covers the same bytes, so flat-digest verify and `ChunkIndex`-leaf walk agree by construction; per-chunk confirmation + range-prune ride the additive tier without making chunk layout load-bearing for identity.

ADR-0027's terminal note cross-refs §4.1. Docs-only — no code, no format change.

Hermetic `nix flake check`: **all checks passed!**