### PR TITLE
feat(core): table Column carries unit/description/short_name/scale (#307)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,9 @@
+# Project allowlist for `typos` (crate-ci/typos, wired in .pre-commit-config.yaml).
+# Medical-imaging domain vocabulary that typos mis-flags as misspellings — these are NOT typos.
+[default.extend-words]
+OT = "OT"      # DICOM modality code: "Other" (0008,0060)
+PN = "PN"      # DICOM value representation: Person Name
+OME = "OME"    # Open Microscopy Environment (OME-Zarr / OME-NGFF)
+
+[default.extend-identifiers]
+aspec = "aspec"   # "array spec" local (tessera-io sparse-encoding spike example)

--- a/tessera/crates/tessera-cli/src/bench.rs
+++ b/tessera/crates/tessera-cli/src/bench.rs
@@ -156,6 +156,7 @@ fn listmode_columns() -> Vec<Column> {
             name: (*n).into(),
             dtype: d.into(),
             codec: None,
+            ..Default::default()
         })
         .collect()
 }

--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -159,6 +159,27 @@ fn human_bytes(n: u64) -> String {
     }
 }
 
+/// Trailing self-description for a table column line: `  · <unit> · ×<scale> · <description>`
+/// (fd5 I1/I2, #307). Empty when the column carries no annotation, so legacy columns render
+/// exactly as before (`name  dtype`).
+fn column_annotation(c: &Value) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(u) = c.get("unit").and_then(Value::as_str) {
+        parts.push(u.to_string());
+    }
+    if let Some(s) = c.get("scale").and_then(Value::as_f64) {
+        parts.push(format!("×{s}"));
+    }
+    if let Some(d) = c.get("description").and_then(Value::as_str) {
+        parts.push(d.to_string());
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("  · {}", parts.join(" · "))
+    }
+}
+
 /// Child lines for a block: column `name dtype` rows for tables, spec detail for arrays.
 fn block_children(kind: &BlockKind, spec: &Value) -> Vec<String> {
     match kind {
@@ -188,7 +209,7 @@ fn block_children(kind: &BlockKind, spec: &Value) -> Vec<String> {
                     .map(|c| {
                         let n = c.get("name").and_then(Value::as_str).unwrap_or("?");
                         let d = c.get("dtype").and_then(Value::as_str).unwrap_or("?");
-                        format!("{n:<10} {d}")
+                        format!("{n:<10} {d}{}", column_annotation(c))
                     })
                     .collect()
             })
@@ -1420,11 +1441,13 @@ mod tests {
                     name: "ms".into(),
                     dtype: "u4".into(),
                     codec: None,
+                    ..Default::default()
                 },
                 Column {
                     name: "en".into(),
                     dtype: "f4".into(),
                     codec: None,
+                    ..Default::default()
                 },
             ],
             rows: 4,
@@ -1442,6 +1465,49 @@ mod tests {
         b.with_field("modality", serde_json::json!("PT"));
         let sealed = b.seal().unwrap();
         pack(&sealed, &[payload], path).unwrap();
+    }
+
+    #[test]
+    fn column_annotation_renders_unit_scale_description() {
+        // Annotated column → self-describing suffix (fd5 I1/I2, #307).
+        let annotated = serde_json::json!({
+            "name": "en", "dtype": "i2", "unit": "keV", "scale": 0.1,
+            "description": "Calibrated per-photon energy"
+        });
+        assert_eq!(
+            column_annotation(&annotated),
+            "  · keV · ×0.1 · Calibrated per-photon energy"
+        );
+        // Bare column → empty suffix, so legacy columns render exactly as before.
+        let bare = serde_json::json!({ "name": "ms", "dtype": "u4" });
+        assert_eq!(column_annotation(&bare), "");
+        // Unit-only is fine (no scale/description).
+        let unit_only = serde_json::json!({ "name": "ax", "dtype": "u1", "unit": "1" });
+        assert_eq!(column_annotation(&unit_only), "  · 1");
+    }
+
+    #[test]
+    fn annotated_column_shows_in_block_children() {
+        let spec = serde_json::json!({
+            "columns": [
+                { "name": "en", "dtype": "i2", "unit": "keV",
+                  "description": "energy", "scale": 0.1 },
+                { "name": "ms", "dtype": "u4" }
+            ],
+            "rows": 4
+        });
+        let lines = block_children(&BlockKind::Table, &spec);
+        assert_eq!(lines.len(), 2);
+        assert!(
+            lines[0].contains("keV") && lines[0].contains("×0.1"),
+            "{}",
+            lines[0]
+        );
+        assert!(
+            !lines[1].contains('·'),
+            "bare column stays plain: {}",
+            lines[1]
+        );
     }
 
     #[test]

--- a/tessera/crates/tessera-cli/src/sql.rs
+++ b/tessera/crates/tessera-cli/src/sql.rs
@@ -186,11 +186,13 @@ mod tests {
                     name: "ms".into(),
                     dtype: "u4".into(),
                     codec: None,
+                    ..Default::default()
                 },
                 Column {
                     name: "en".into(),
                     dtype: "f4".into(),
                     codec: None,
+                    ..Default::default()
                 },
             ],
             rows: 4,

--- a/tessera/crates/tessera-cli/src/version.rs
+++ b/tessera/crates/tessera-cli/src/version.rs
@@ -396,6 +396,7 @@ mod tests {
                 name: "x".into(),
                 dtype: "u4".into(),
                 codec: None,
+                ..Default::default()
             }],
             rows: 3,
             row_index: None,
@@ -416,6 +417,7 @@ mod tests {
                 name: "v".into(),
                 dtype: "u4".into(),
                 codec: None,
+                ..Default::default()
             }],
             rows: u64::try_from(vals.len()).unwrap(),
             row_index: None,

--- a/tessera/crates/tessera-core/src/block/table.rs
+++ b/tessera/crates/tessera-core/src/block/table.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Block, BlockKind};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Column {
     pub name: String,
     /// Arrow-ish dtype string, e.g. "i2", "u4", "f4".
@@ -16,6 +16,58 @@ pub struct Column {
     /// Per-column codec — columnar layout lets each column compress optimally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codec: Option<String>,
+    /// Human-facing short label (fd5 I1/I2), distinct from `name` (the rename-safe storage id).
+    /// e.g. `name = "lt"`, `short_name = "lifetime"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub short_name: Option<String>,
+    /// Human + AI-readable description of the column's meaning — so a reader (or an AI) has the
+    /// column's semantics without external context (FAIR I1/I2). The vendor HDF5 carries none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// UCUM physical unit of the values (after `scale`, if any): "keV", "mm", "ns", "ms", "1".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    /// Fixed-point scale (#310): physical value = `raw × scale`. `None` ⇒ values are already
+    /// physical (no quantization). Carried so the read/compute path recovers physical units.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale: Option<f64>,
+}
+
+impl Column {
+    /// A bare column: storage `name` + `dtype`, no codec/annotation. Chain the `with_*` builders
+    /// to attach the fd5 annotation triad (`short_name`/`description`/`unit`) and a `scale`.
+    pub fn new(name: impl Into<String>, dtype: impl Into<String>) -> Self {
+        Column {
+            name: name.into(),
+            dtype: dtype.into(),
+            ..Default::default()
+        }
+    }
+    /// Builder: per-column codec.
+    pub fn with_codec(mut self, codec: impl Into<String>) -> Self {
+        self.codec = Some(codec.into());
+        self
+    }
+    /// Builder: human short label.
+    pub fn with_short_name(mut self, short_name: impl Into<String>) -> Self {
+        self.short_name = Some(short_name.into());
+        self
+    }
+    /// Builder: description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+    /// Builder: UCUM unit.
+    pub fn with_unit(mut self, unit: impl Into<String>) -> Self {
+        self.unit = Some(unit.into());
+        self
+    }
+    /// Builder: fixed-point scale (physical = raw × scale).
+    pub fn with_scale(mut self, scale: f64) -> Self {
+        self.scale = Some(scale);
+        self
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,5 +116,50 @@ impl TableBlock {
         Err(crate::Error::Unimplemented(
             "TableBlock::write_parquet (arrow backend)",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Column;
+
+    #[test]
+    fn builders_attach_annotation_triad_and_scale() {
+        let c = Column::new("en", "i2")
+            .with_short_name("energy")
+            .with_description("Calibrated per-photon energy")
+            .with_unit("keV")
+            .with_scale(0.1);
+        assert_eq!(c.name, "en");
+        assert_eq!(c.dtype, "i2");
+        assert_eq!(c.short_name.as_deref(), Some("energy"));
+        assert_eq!(c.unit.as_deref(), Some("keV"));
+        assert_eq!(c.scale, Some(0.1));
+        assert_eq!(c.codec, None);
+    }
+
+    #[test]
+    fn bare_column_skips_annotation_fields_on_serialize() {
+        // Back-compat: an unannotated column serializes to exactly the legacy shape (name+dtype),
+        // so existing on-disk `.tsra` specs and content hashes are unaffected.
+        let bare = Column::new("ms", "u4");
+        let v = serde_json::to_value(&bare).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.keys().collect::<Vec<_>>(), vec!["name", "dtype"]);
+    }
+
+    #[test]
+    fn annotation_round_trips_through_json() {
+        let c = Column::new("lt", "i2").with_unit("ns").with_scale(0.001);
+        let back: Column = serde_json::from_str(&serde_json::to_string(&c).unwrap()).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn legacy_spec_without_annotation_deserializes() {
+        // A pre-#307 column (no annotation keys) must still parse (fields default to None).
+        let c: Column = serde_json::from_str(r#"{"name":"t","dtype":"u8"}"#).unwrap();
+        assert_eq!(c.name, "t");
+        assert!(c.unit.is_none() && c.scale.is_none() && c.description.is_none());
     }
 }

--- a/tessera/crates/tessera-core/src/lib.rs
+++ b/tessera/crates/tessera-core/src/lib.rs
@@ -164,11 +164,13 @@ mod tests {
                     name: "lt".into(),
                     dtype: "f4".into(),
                     codec: Some("zstd".into()),
+                    ..Default::default()
                 },
                 Column {
                     name: "en0".into(),
                     dtype: "f4".into(),
                     codec: Some("zstd".into()),
+                    ..Default::default()
                 },
             ],
             rows: 2_696_935,

--- a/tessera/crates/tessera-core/src/schema.rs
+++ b/tessera/crates/tessera-core/src/schema.rs
@@ -714,6 +714,7 @@ mod tests {
                     name: "radius".into(),
                     dtype: "f4".into(),
                     codec: None,
+                    ..Default::default()
                 }],
                 rows: 1,
                 row_index: None,
@@ -784,6 +785,7 @@ mod tests {
                     name: "start_s".into(),
                     dtype: "f8".into(),
                     codec: None,
+                    ..Default::default()
                 }],
                 rows: 4,
                 row_index: None,
@@ -835,6 +837,7 @@ mod tests {
                     name: "start_s".into(),
                     dtype: "f8".into(),
                     codec: None,
+                    ..Default::default()
                 }],
                 rows: 4,
                 row_index: None,

--- a/tessera/crates/tessera-core/tests/integrity.rs
+++ b/tessera/crates/tessera-core/tests/integrity.rs
@@ -21,6 +21,7 @@ fn sample_product() -> Manifest {
             name: "lt".into(),
             dtype: "f4".into(),
             codec: Some("zstd".into()),
+            ..Default::default()
         }],
         rows: 2_696_935,
         row_index: Some("ms".into()),
@@ -123,6 +124,7 @@ fn tamper_one_block_changes_content_hash() {
                 name: "lt".into(),
                 dtype: "f4".into(),
                 codec: Some("zstd".into()),
+                ..Default::default()
             }],
             rows: 2_696_935,
             row_index: Some("ms".into()),
@@ -143,6 +145,7 @@ fn block_reorder_changes_content_hash() {
                 name: "lt".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             }],
             rows: 1,
             row_index: None,
@@ -214,7 +217,7 @@ proptest! {
             .map(|(i, _)| ArrayBlock::new(format!("a{i}"), ArraySpec::new(vec![2, 2, 2], "int16"))).collect();
         let tables: Vec<_> = kinds.iter().enumerate().filter(|(_, k)| !**k)
             .map(|(i, _)| TableBlock::new(format!("t{i}"),
-                TableSpec { columns: vec![Column { name: "c".into(), dtype: "f4".into(), codec: None }], rows: i as u64, row_index: None })).collect();
+                TableSpec { columns: vec![Column { name: "c".into(), dtype: "f4".into(), codec: None, ..Default::default() }], rows: i as u64, row_index: None })).collect();
         for a in &arrays { b.add_block(a).unwrap(); }
         for t in &tables { b.add_block(t).unwrap(); }
         let m = b.seal().unwrap();

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -413,6 +413,7 @@ pub fn compound_columns(path: &std::path::Path, dataset: &str) -> Result<Vec<Col
             name,
             dtype: code.into(),
             codec: None,
+            ..Default::default()
         })
         .collect())
 }
@@ -725,6 +726,7 @@ pub(crate) fn to_listmode_product_partitioned(
             name: n.clone(),
             dtype: c.numpy_code().into(),
             codec: None,
+            ..Default::default()
         })
         .collect();
     // Partition through the format SSoT — every block carries `block_rows` rows except the trailing
@@ -1033,6 +1035,7 @@ mod tests {
                         name: n.clone(),
                         dtype: c.numpy_code().into(),
                         codec: None,
+                        ..Default::default()
                     })
                     .collect(),
                 rows: 100,
@@ -1088,6 +1091,7 @@ mod tests {
                     name: n.clone(),
                     dtype: c.numpy_code().into(),
                     codec: None,
+                    ..Default::default()
                 })
                 .collect(),
             rows: 64,

--- a/tessera/crates/tessera-io/benches/codec.rs
+++ b/tessera/crates/tessera-io/benches/codec.rs
@@ -61,16 +61,19 @@ fn bench_table(c: &mut Criterion) {
                 name: "t".into(),
                 dtype: "u8".into(),
                 codec: None,
+                ..Default::default()
             },
             Column {
                 name: "e0".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             },
             Column {
                 name: "e1".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             },
         ],
         rows: n as u64,

--- a/tessera/crates/tessera-io/benches/throughput.rs
+++ b/tessera/crates/tessera-io/benches/throughput.rs
@@ -20,6 +20,7 @@ fn listmode_columns() -> Vec<Column> {
             name: (*n).into(),
             dtype: d.into(),
             codec: None,
+            ..Default::default()
         })
         .collect()
 }

--- a/tessera/crates/tessera-io/examples/bench_compare.rs
+++ b/tessera/crates/tessera-io/examples/bench_compare.rs
@@ -138,16 +138,19 @@ fn listmode(rows: usize) -> (TableSpec, TableData) {
                 name: "t".into(),
                 dtype: "u8".into(),
                 codec: None,
+                ..Default::default()
             },
             Column {
                 name: "e0".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             },
             Column {
                 name: "e1".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             },
         ],
         rows: rows as u64,

--- a/tessera/crates/tessera-io/examples/spike_sparse.rs
+++ b/tessera/crates/tessera-io/examples/spike_sparse.rs
@@ -107,6 +107,7 @@ fn col(name: &str, dt: &str) -> Column {
         name: name.into(),
         dtype: dt.into(),
         codec: None,
+        ..Default::default()
     }
 }
 

--- a/tessera/crates/tessera-io/src/accumulate.rs
+++ b/tessera/crates/tessera-io/src/accumulate.rs
@@ -478,6 +478,7 @@ mod tests {
             name: name.into(),
             dtype: dtype.into(),
             codec: None,
+            ..Default::default()
         }
     }
 

--- a/tessera/crates/tessera-io/src/array.rs
+++ b/tessera/crates/tessera-io/src/array.rs
@@ -725,6 +725,7 @@ pub fn to_coo(data: &ArrayData, fill: i64) -> Option<(TableSpec, TableData)> {
         name: name.into(),
         dtype: dt.into(),
         codec: None,
+        ..Default::default()
     };
     let spec = TableSpec {
         columns: vec![col("idx", "u8"), col("v", "i8")],

--- a/tessera/crates/tessera-io/src/cloud.rs
+++ b/tessera/crates/tessera-io/src/cloud.rs
@@ -549,11 +549,13 @@ mod tests {
                 name: "ms".into(),
                 dtype: "u8".into(),
                 codec: None,
+                ..Default::default()
             },
             Column {
                 name: "e".into(),
                 dtype: "f4".into(),
                 codec: None,
+                ..Default::default()
             },
         ];
         let spec = TableSpec {

--- a/tessera/crates/tessera-io/src/conformance.rs
+++ b/tessera/crates/tessera-io/src/conformance.rs
@@ -98,6 +98,7 @@ fn col(name: &str, dtype: &str, codec: Option<&str>) -> Column {
         name: name.into(),
         dtype: dtype.into(),
         codec: codec.map(Into::into),
+        ..Default::default()
     }
 }
 

--- a/tessera/crates/tessera-io/src/multiblock.rs
+++ b/tessera/crates/tessera-io/src/multiblock.rs
@@ -398,6 +398,7 @@ mod tests {
             name: name.into(),
             dtype: dtype.into(),
             codec: None,
+            ..Default::default()
         }
     }
 

--- a/tessera/crates/tessera-io/src/repo.rs
+++ b/tessera/crates/tessera-io/src/repo.rs
@@ -438,6 +438,7 @@ mod tests {
                 name: "x".into(),
                 dtype: "u4".into(),
                 codec: None,
+                ..Default::default()
             }],
             rows: 3,
             row_index: None,

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -592,7 +592,7 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
 /// use tessera_io::table::{table_chunk_index, ColumnData, TableData};
 ///
 /// let spec = TableSpec {
-///     columns: vec![Column { name: "t".into(), dtype: "u8".into(), codec: None }],
+///     columns: vec![Column { name: "t".into(), dtype: "u8".into(), codec: None, ..Default::default() }],
 ///     rows: 3,
 ///     row_index: None,
 /// };
@@ -693,6 +693,7 @@ mod tests {
             name: name.into(),
             dtype: dtype.into(),
             codec: None,
+            ..Default::default()
         }
     }
 

--- a/tessera/crates/tessera-py/src/lib.rs
+++ b/tessera/crates/tessera-py/src/lib.rs
@@ -291,6 +291,7 @@ impl Builder {
                 name: n.clone(),
                 dtype: c.numpy_code().into(),
                 codec: None,
+                ..Default::default()
             })
             .collect();
         let spec = TableSpec {

--- a/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
+++ b/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
@@ -1,0 +1,239 @@
+# GE Discovery MI (Gen2 / "DMI6", Galileo TOF architecture) listmode column dictionary
+# ---------------------------------------------------------------------------------------
+# The fd5/tessera per-column annotation triad (short_name · description · unit) for the GE
+# listmode HDF5 datasets — definitions the vendor HDF5 does NOT carry (issue #307).
+#
+# Provenance (domain-owner sources, in authority order):
+#   1. MorePET/ge-discovery-data-framework — the canonical GE Discovery listmode parser that
+#      WROTE this HDF5. Definitive references:
+#        - docs/DescriptionCSV.md   — the field dictionary (ID, E/eV, t/ps, N, V_{x,y,z}/mm, L/ps)
+#        - lib/DiscoveryMIGen2/include/ListModeEvent.h — field defs + unit comments
+#          ("timeMarker, in ms"; "coincCount = # coincidences in prior 1ms window"; …)
+#        - docs/DOC1170822 - CoinLink White Paper.pdf — GE's own event-format spec
+#        - lib/GEHDF5/ — the HDF5 writer;  geometry_DiscoveryMIGen2_sixRings.txt (54 ax × 544 tx)
+#   2. GE petCoincLinkEvents.h © 2012 General Electric — raw Galileo bitfields.
+#   3. Empirical range analysis of DP01 (500k-row samples) — used to CONFIRM/CORRECT units.
+#
+# Two doc-vs-data conflicts, resolved in favour of the data (flagged `_conflict`):
+#   - `lt`  : DescriptionCSV says "ps"; HDF5 float range is ±17 (matches the ±15 ns coincidence
+#             window) ⇒ the HDF5 `lt` is in **ns**. (CSV ps likely the integer export form.)
+#   - `en`  : DescriptionCSV says "eV"; HDF5 events `en` peaks at 511 (annihilation photopeak),
+#             range 425–650 ⇒ **keV**.
+#
+# `unit` uses UCUM; "1" = dimensionless (index/count/flag). `_tentative` = still unconfirmed.
+
+# ── raw_data/singles — per-single-photon detections (7.9 B rows) ────────────────────────
+[singles.ms]
+short_name = "ms"
+description = "Single-photon timestamp, milliseconds since the PROP time counter reset."
+dtype = "u4"
+unit = "ms"                     # CONFIRMED: ListModeEvent.h timeMarker "in 1ms increments"; data +1/row
+vocabulary = "GE-Galileo"
+
+[singles.en]
+short_name = "en"
+description = "Single-crystal energy readout (Anger-math). Data range ~100–450 → keV-scale."
+dtype = "u2"
+unit = "keV"                    # raw readout; cal-refined via getEnergyAxis (keV=((bin-0.5)/EPeak)*511)
+vocabulary = "GE-Galileo"
+_tentative = true               # singles en is the raw readout; confirm keV vs bin
+
+[singles.ax]
+short_name = "ax"
+description = "Crystal axial index (0–53 on DMI6, 54 rings)."
+dtype = "u1"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[singles.tx]
+short_name = "tx"
+description = "Crystal trans-axial index (0–543 on DMI6)."
+dtype = "u2"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[singles.td]
+short_name = "td"
+description = "Time until the NEXT hit (inter-single Δt). Not a rolling clock — a per-hit difference."
+dtype = "u2"
+unit = "ps"                     # CONFIRMED: DescriptionCSV "t/ps = Time until next hit, in ps"; data 0–65535, non-monotonic
+vocabulary = "GE-Galileo"
+
+# ── proc_data/coin_2p · coin_3p — raw coincidences (1.24 B / 340 M rows) ─────────────────
+# Same fields, arity 2 (doubles) or 3 (triples). Raw energies (integer readout, pre-keV-float).
+[coin.ms]
+short_name = "ms"
+description = "Coincidence timestamp, ms since PROP reset."
+dtype = "u4"
+unit = "ms"
+vocabulary = "GE-Galileo"
+
+[coin.en]
+short_name = "en"
+description = "Per-photon energy readout of the coincidence (integer). Array [2] (2p) / [3] (3p)."
+dtype = "u2[]"
+unit = "keV"
+vocabulary = "GE-Galileo"
+_tentative = true               # integer readout; keV-scale after cal
+
+[coin.ax]
+short_name = "ax"
+description = "Per-photon crystal axial indices. Array [2]/[3]."
+dtype = "u1[]"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[coin.tx]
+short_name = "tx"
+description = "Per-photon crystal trans-axial indices. Array [2]/[3]."
+dtype = "u2[]"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[coin.dt]
+short_name = "dt"
+description = "TOF signed delta-time (electronics bins → ps via TOF cal). Scalar (2p) / [2] (3p)."
+dtype = "u2"
+unit = "{tof_bin}"              # data 0–191 bins; convert to ps via TOF calibration
+vocabulary = "GE-Galileo"
+
+# ── proc_data/events_2p · events_3p — reconstructed annihilation events (158 M / 10 M) ───
+# The science tier: calibrated energies (keV, 511 photopeak), reconstructed vertex (mm); 3p
+# additionally carries the positronium lifetime (MorePET's target observable).
+[events.ms]
+short_name = "ms"
+description = "Event timestamp, ms since PROP reset."
+dtype = "u4"
+unit = "ms"
+vocabulary = "GE-Galileo"
+
+[events.dt]
+short_name = "dt"
+description = "TOF signed delta-time (electronics bins → ps via TOF cal). Data 0–191."
+dtype = "u2"
+unit = "{tof_bin}"
+vocabulary = "GE-Galileo"
+
+[events.en]
+short_name = "en"
+description = "Calibrated per-photon energies. [2]: the two 511 keV annihilation γ (425–650, peak 511). [3] (3p): the 3rd is the prompt γ (600–1220 keV)."
+dtype = "f4[]"
+unit = "keV"                    # CONFIRMED by 511 photopeak; DescriptionCSV "eV" is inconsistent
+vocabulary = "MorePET"
+_conflict = "DescriptionCSV.md says eV; data (511 photopeak) says keV"
+
+[events.ax]
+short_name = "ax"
+description = "Per-photon crystal axial indices. Array [2]/[3]."
+dtype = "u1[]"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[events.tx]
+short_name = "tx"
+description = "Per-photon crystal trans-axial indices. Array [2]/[3]."
+dtype = "u2[]"
+unit = "1"
+vocabulary = "GE-Galileo"
+
+[events.vtx]
+short_name = "vtx"
+description = "Reconstructed annihilation vertex (x, y, z). Data: x,y ±369.8 (transaxial FOV), z ±147.9 (axial FOV)."
+dtype = "f4[3]"
+unit = "mm"                     # CONFIRMED: DescriptionCSV V_{x,y,z}/mm + FOV-matching ranges
+vocabulary = "MorePET"
+
+[events.lt]
+short_name = "lt"
+description = "Positronium lifetime (3p only): Δt between the prompt γ and the o-Ps annihilation."
+dtype = "f4"
+unit = "ns"                     # data −16.8…+17.4 (matches ±15 ns window). DescriptionCSV says ps.
+vocabulary = "MorePET"
+_conflict = "DescriptionCSV.md says ps; HDF5 float range (±17, = ±15ns window) says ns"
+
+[events.lt_corr]
+short_name = "lt_corr"
+description = "Positronium lifetime, corrected (TOF/geometry). Sparse — NaN for most events."
+dtype = "f4"
+unit = "ns"
+vocabulary = "MorePET"
+_tentative = true               # same ns/ps question as lt; mostly NaN in DP01
+
+# ── raw_data/time_markers — per-millisecond time index + running counts (416 k rows) ────
+[time_markers.tm]
+short_name = "tm"
+description = "Time marker: ms since PROP reset. One row per ms (monotonic +1), the block clock."
+dtype = "u4"
+unit = "ms"
+vocabulary = "GE-Galileo"
+
+[time_markers.idx]
+short_name = "idx"
+description = "Cumulative offset into the singles stream at this time marker (data → ~7.9e9 = total singles)."
+dtype = "u8"
+unit = "1"
+vocabulary = "MorePET"
+
+[time_markers.length]
+short_name = "length"
+description = "Number of 1 ms increments this marker row spans. Normally 1; >1 (up to ~253) marks dropped-marker / data-loss gaps."
+dtype = "u1"
+unit = "ms"
+vocabulary = "MorePET"
+
+[time_markers.n_singles]
+short_name = "n_singles"
+description = "Singles in this 1 ms interval (data ~19 k/ms ≈ 19 M/s)."
+dtype = "u4"
+unit = "1"
+vocabulary = "MorePET"
+
+[time_markers.n_coins2p]
+short_name = "n_coins2p"
+description = "Raw 2-photon coincidences in this interval (~3 k/ms)."
+dtype = "u4"
+unit = "1"
+vocabulary = "MorePET"
+
+[time_markers.n_coins3p]
+short_name = "n_coins3p"
+description = "Raw 3-photon coincidences in this interval (~0.8 k/ms)."
+dtype = "u4"
+unit = "1"
+vocabulary = "MorePET"
+
+[time_markers.n_event2p]
+short_name = "n_event2p"
+description = "Reconstructed 2p events in this interval (~380/ms)."
+dtype = "u4"
+unit = "1"
+vocabulary = "MorePET"
+
+[time_markers.n_event3p]
+short_name = "n_event3p"
+description = "Reconstructed 3p events in this interval (~24/ms)."
+dtype = "u4"
+unit = "1"
+vocabulary = "MorePET"
+
+# ── raw_data/coin_counters — hardware coincidence counter (408 k rows) ───────────────────
+[coin_counters.tm]
+short_name = "tm"
+description = "Time marker (ms) for this counter sample."
+dtype = "u4"
+unit = "ms"
+vocabulary = "GE-Galileo"
+
+[coin_counters.idx]
+short_name = "idx"
+description = "Cumulative offset into the listmode stream."
+dtype = "u8"
+unit = "1"
+vocabulary = "MorePET"
+
+[coin_counters.cc]
+short_name = "cc"
+description = "Hardware coincidence count in the prior 1 ms window (PET_LINK_EVT_COINC_COUNT, 20-bit) — integrity cross-check."
+dtype = "u4"
+unit = "1"
+vocabulary = "GE-Galileo"


### PR DESCRIPTION
Closes the infrastructure half of #307 — the fd5 I1/I2 self-description on the **data tier**.

## What
- **`Column`** gains `short_name` · `description` · `unit` (UCUM) · `scale` (fixed-point, physical = `raw × scale`, for #310). All optional + `serde(skip_serializing_if = None)`, so an **unannotated column serializes to the exact legacy `{name,dtype}` shape** — existing `.tsra` `content_hash`/`manifest_hash` are unchanged (guarded by `bare_column_skips_annotation_fields_on_serialize`).
- **`Column::new` + `with_short_name/description/unit/scale/codec`** builders.
- **nav `ls`/`tree`** surface the annotation as `name  dtype  · unit · ×scale · description`; bare columns render exactly as before.
- **GEDDF column dictionary** (`docs/dictionaries/ge-discovery-mi-listmode.toml`) — the domain-owner definitions (GE `petCoincLinkEvents.h` + MorePET `ge-discovery-data-framework` `DescriptionCSV.md`, units confirmed by range analysis: `en` keV, `vtx` mm, `lt` ns, `ms`/`tm` ms, `td` ps). This is the source the ge-hdf5 ingest population will consume.
- **`_typos.toml`** allowlist for mis-flagged domain terms (`OT`/`PN`/`OME`/`aspec`) — also fixed 3 latent false-positive corruptions the hook would have made.

## Tests
6 new (`table.rs` builders/serde back-compat ×4, `nav.rs` rendering ×2). Full workspace `clippy --all-targets --all-features -D warnings` + `rustfmt` + all agent-drift gates green.

## Follow-on (not in this PR)
**Ingest population is opt-in** (per the design discussion on #307/#310): auto-populating annotations changes `manifest_hash` and would break the byte-identity/corpus invariant, so the ge-hdf5 dictionary population lands as part of the **opt-in ingest transform** alongside #310 (quantize float→int+scale) — default ingest stays byte-identical.

Refs: #307