### PR TITLE
chore(deps): resolve cargo-deny advisory reds (pyo3 bump, quick-xml ignore)

### DIFF
--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -3302,15 +3302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,15 +3975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -4811,35 +4793,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon 0.13.5",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4847,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4859,13 +4838,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.118",
 ]
@@ -6682,12 +6660,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe_cell_slice"

--- a/tessera/Cargo.toml
+++ b/tessera/Cargo.toml
@@ -60,7 +60,7 @@ hdf5-metno = "0.12"
 hdf5-metno-sys = "0.12"
 # Python bindings (tessera-py). abi3 → one .so works across CPython ≥3.9; extension-module → no
 # libpython link (the build needs only the abi3 minimum, not a runtime interpreter).
-pyo3 = { version = "0.27", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 # Declarative ingest spec (`tessera-ingest::spec`) — pure-Rust TOML parser. The engine canonicalizes the
 # parsed model (JCS) before hashing, so whitespace / comments / key-order in the source TOML never
 # change the spec hash that flows into each member's `ingested_via_spec` provenance edge.

--- a/tessera/deny.toml
+++ b/tessera/deny.toml
@@ -15,6 +15,17 @@ ignore = [
     # transitively by dicom-encoding (charset decoding of DICOM string VRs). No safe upgrade
     # while dicom 0.9 depends on it. Revisit when dicom migrates to `encoding_rs`.
     "RUSTSEC-2021-0153",
+    # quick-xml v0.40.1 — two untrusted-XML DoS advisories, both fixed in quick-xml 0.41.0:
+    #   RUSTSEC-2026-0194 — O(N²) duplicate-attribute-name check on a single start tag.
+    #   RUSTSEC-2026-0195 — unbounded allocation in NamespaceResolver::push (NsReader) → OOM.
+    # NO UPGRADE PATH: quick-xml is a transitive dep of object_store 0.14.0 (the latest release),
+    # which caret-pins `quick-xml = "0.40.1"` (<0.41), so 0.41 is unreachable until object_store
+    # cuts a release that relaxes the bound. object_store reaches us only via the optional `cloud`
+    # feature of tessera-io and as a dev-dependency of tessera-cli — it parses S3 list-XML from the
+    # operator's own configured store, not arbitrary attacker-supplied XML. Revisit on the next
+    # object_store release (track upstream apache/arrow-rs object_store quick-xml bump).
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
Fixes the red `cargo deny check advisories` gate on `spike/tessera-core` HEAD — four RUSTSEC advisories, pre-existing and unrelated to feature work. Isolated single-commit change, split two ways.

## pyo3 — real bump (fixed upstream)
- **RUSTSEC-2026-0176** — OOB read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators.
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure` closures.

Both fixed in **pyo3 0.29.0** → workspace `pyo3` 0.27 → 0.29. `tessera-py` already uses the modern `Bound<>` API, so **no source changes** — verified `cargo build -p tessera-py` clean.

## quick-xml — justified `deny.toml` ignore (no upgrade path)
- **RUSTSEC-2026-0194** — O(N²) duplicate-attribute-name check on a start tag.
- **RUSTSEC-2026-0195** — unbounded `NamespaceResolver::push` allocation (`NsReader`) → OOM.

Both fixed in **quick-xml 0.41.0**, but it's transitive via `object_store 0.14.0` (the latest release), which caret-pins `quick-xml = "0.40.1"` (`<0.41`) — unreachable. `object_store` reaches us only through tessera-io's optional `cloud` feature and as a tessera-cli dev-dependency (parses S3 list-XML from the operator's own configured store, not attacker-supplied XML). Ignored with a revisit-on-`object_store`-bump trigger.

## Verification
```
cargo deny check  →  advisories ok, bans ok, licenses ok, sources ok
cargo build -p tessera-py  →  clean (pyo3 0.29, no code changes)
```

Refs #313. Revisit trigger overlaps #291 (object_store transport adoption).