### PR TITLE
feat(ingest): tessera ingest ge-hdf5 --quantize — opt-in float→int16 transform (#310)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
             (craneLib.filterCargoSources path type)
             || (pkgs.lib.hasInfix "/corpus/" path)
             || (pkgs.lib.hasInfix "/docs/examples/" path)
+            || (pkgs.lib.hasInfix "/docs/dictionaries/" path)
             || (pkgs.lib.hasInfix "/tests/cmd/" path);
           name = "source";
         };

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -752,6 +752,11 @@ enum IngestSrc {
         /// Attach metadata `key=value` (value parsed as JSON, else string). Repeatable.
         #[arg(long = "meta", value_name = "KEY=VALUE")]
         meta: Vec<String>,
+        /// Opt-in GEDDF transform (#310): annotate columns (unit/description) + requantize the
+        /// reconstructed float columns (`en`/`vtx`/`lt`) to int16 at the physical resolution
+        /// (physical = raw × scale) — ~2× smaller, physically lossless. Default off → byte-identical.
+        #[arg(long)]
+        quantize: bool,
     },
     /// Preserve an un-parsed file as an opaque `blob` product (the "junk" tier).
     ///
@@ -1569,6 +1574,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
             dataset,
             source_label,
             meta,
+            quantize,
         } => (
             IngestSpec {
                 collection: CollectionMeta {
@@ -1593,6 +1599,7 @@ fn ingest_src_to_spec(src: IngestSrc) -> tessera_core::Result<(ingest_spec::Inge
                         block_prefix: DEFAULT_BLOCK_PREFIX.into(),
                         streaming: StreamingMode::Auto,
                         slab_rows: DEFAULT_SLAB_ROWS,
+                        quantize,
                     },
                 }],
             },
@@ -1811,6 +1818,7 @@ mod tests {
                 dataset: "events_3p".into(),
                 source_label: None,
                 meta: vec![],
+                quantize: false,
             }),
         })
         .unwrap();

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -366,8 +366,12 @@ fn dispatch(
             block_prefix,
             streaming,
             slab_rows,
+            quantize,
         } => {
-            let should_stream = resolve_streaming(*streaming, input, dataset, stream_threshold)?;
+            // The opt-in GEDDF quantize/annotate transform (#310) operates on the whole in-memory
+            // table, so it forces the batch path (the streaming slab writer has no transform seam yet).
+            let should_stream =
+                !*quantize && resolve_streaming(*streaming, input, dataset, stream_threshold)?;
             if should_stream {
                 // Stream straight to disk — the bounded-memory + multi-block path. The output path
                 // is computed BEFORE the seal because the streaming writer writes the .tsra
@@ -411,19 +415,35 @@ fn dispatch(
                 Ok((m, ()))
             } else {
                 // Batch path: read the whole compound, build the in-memory product, pack.
-                let cols = crate::ge_hdf5::read_compound(input, dataset)?;
+                let mut cols = crate::ge_hdf5::read_compound(input, dataset)?;
                 let source = label
                     .map(str::to_string)
                     .unwrap_or_else(|| input.display().to_string());
-                let (m, payloads) = crate::ge_hdf5::to_listmode_product(
-                    &cols,
-                    name,
-                    &timestamp,
-                    &source,
-                    block_prefix,
-                    row_index,
-                    extra_sources,
-                )?;
+                let (m, payloads) = if *quantize {
+                    // Opt-in transform (#310): annotate + requantize float columns to int16 before
+                    // sealing, so both payload and manifest reflect the physical-resolution encoding.
+                    let schema = crate::ge_hdf5::apply_geddf_dictionary(dataset, &mut cols, true);
+                    crate::ge_hdf5::to_listmode_product_with_schema(
+                        &cols,
+                        name,
+                        &timestamp,
+                        &source,
+                        block_prefix,
+                        row_index,
+                        extra_sources,
+                        schema,
+                    )?
+                } else {
+                    crate::ge_hdf5::to_listmode_product(
+                        &cols,
+                        name,
+                        &timestamp,
+                        &source,
+                        block_prefix,
+                        row_index,
+                        extra_sources,
+                    )?
+                };
                 let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
                 Ok((m, ()))
             }

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -793,6 +793,34 @@ pub fn to_listmode_product(
         block_prefix,
         row_index,
         extra_sources,
+        None,
+    )
+}
+
+/// Like [`to_listmode_product`], but the caller supplies the sealed column schema — the
+/// annotated / requantized `Vec<Column>` from the opt-in GEDDF transform ([`apply_geddf_dictionary`],
+/// #310). `columns` MUST match `cols` in count, order, and dtype (the transform guarantees this).
+#[allow(clippy::too_many_arguments)]
+pub fn to_listmode_product_with_schema(
+    cols: &TableData,
+    name: &str,
+    timestamp: &str,
+    source: &str,
+    block_prefix: &str,
+    row_index: &str,
+    extra_sources: &[tessera_core::provenance::Source],
+    columns: Vec<Column>,
+) -> Result<(Manifest, Vec<BlockPayload>)> {
+    to_listmode_product_partitioned(
+        cols,
+        name,
+        timestamp,
+        source,
+        tessera_io::BLOCK_ROWS as u64,
+        block_prefix,
+        row_index,
+        extra_sources,
+        Some(columns),
     )
 }
 
@@ -815,20 +843,25 @@ pub(crate) fn to_listmode_product_partitioned(
     block_prefix: &str,
     row_index: &str,
     extra_sources: &[tessera_core::provenance::Source],
+    // `Some` = caller-supplied sealed column schema (annotated / requantized by the opt-in GEDDF
+    // transform, #310); `None` = build it from `cols` (name + dtype only — the byte-identical
+    // default). The overriding schema MUST match `cols` in count, order, and dtype.
+    column_overrides: Option<Vec<Column>>,
 ) -> Result<(Manifest, Vec<BlockPayload>)> {
     if block_rows == 0 {
         return Err(he("to_listmode_product: block_rows must be positive"));
     }
     let total_rows = u64::try_from(cols.first().map(|(_, c)| c.len()).unwrap_or(0)).map_err(he)?;
-    let columns: Vec<Column> = cols
-        .iter()
-        .map(|(n, c)| Column {
-            name: n.clone(),
-            dtype: c.numpy_code().into(),
-            codec: None,
-            ..Default::default()
-        })
-        .collect();
+    let columns: Vec<Column> = column_overrides.unwrap_or_else(|| {
+        cols.iter()
+            .map(|(n, c)| Column {
+                name: n.clone(),
+                dtype: c.numpy_code().into(),
+                codec: None,
+                ..Default::default()
+            })
+            .collect()
+    });
     // Partition through the format SSoT — every block carries `block_rows` rows except the trailing
     // one (which may be partial). The same helpers the streamed path uses, so the per-block split
     // matches → identical content_hash for the same `block_rows`.
@@ -953,6 +986,42 @@ mod tests {
         assert_eq!(cols[0].dtype, "f4");
         assert!(cols[0].scale.is_none());
         assert_eq!(cols[0].unit.as_deref(), Some("ns"));
+    }
+
+    #[test]
+    fn quantized_product_seals_annotated_int16_columns() {
+        // End-to-end: the opt-in transform's annotated/requantized schema reaches the SEALED
+        // manifest's block spec (this is what the `--quantize` ingest path relies on).
+        let mut data: TableData = vec![
+            ("ms".into(), ColumnData::U32(vec![1, 2])),
+            ("en_0".into(), ColumnData::F32(vec![511.0, 425.0])),
+            ("lt".into(), ColumnData::F32(vec![1.5, -2.0])),
+        ];
+        let schema = apply_geddf_dictionary("events_3p", &mut data, true);
+        let (m, _payloads) = to_listmode_product_with_schema(
+            &data,
+            "DP",
+            "2024-01-01T00:00:00Z",
+            "src.h5",
+            "events",
+            "ms",
+            &[],
+            schema,
+        )
+        .unwrap();
+        let cols = m.blocks[0].spec["columns"].as_array().unwrap();
+        let col = |name: &str| cols.iter().find(|c| c["name"] == name).unwrap();
+        // en_0: float → int16, unit keV, scale 0.1.
+        assert_eq!(col("en_0")["dtype"], "i2");
+        assert_eq!(col("en_0")["unit"], "keV");
+        assert_eq!(col("en_0")["scale"], 0.1);
+        // lt: → int16 at 1 ps.
+        assert_eq!(col("lt")["dtype"], "i2");
+        assert_eq!(col("lt")["scale"], 0.001);
+        // ms: integer column untouched, annotated `ms`.
+        assert_eq!(col("ms")["dtype"], "u4");
+        assert_eq!(col("ms")["unit"], "ms");
+        assert!(col("ms").get("scale").is_none());
     }
 
     // Fixture-write only: writing a synthetic .h5 with a compound dataset legitimately needs a
@@ -1314,6 +1383,7 @@ mod tests {
             "events",
             "ms",
             &[],
+            None,
         )
         .unwrap();
 
@@ -1526,6 +1596,7 @@ mod tests {
             "coin_3p",
             "time_ps",
             &[],
+            None,
         )
         .unwrap();
         assert!(

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -418,6 +418,106 @@ pub fn compound_columns(path: &std::path::Path, dataset: &str) -> Result<Vec<Col
         .collect())
 }
 
+// ── Opt-in GEDDF dictionary transform (#307 column annotation + #310 quantization) ──────────
+// The vendor HDF5 carries no per-column units/descriptions, and stores reconstructed quantities as
+// float32 with ~3 orders of magnitude more precision than the measurement holds (#310 benchmark).
+// This transform is OPT-IN (default off → byte-identical output, so the corpus/manifest_hash
+// invariant is untouched): it annotates columns from the embedded domain-owner dictionary and, when
+// `quantize`, requantizes float columns to int16 at the physical resolution (physical = raw × scale).
+
+/// One column's entry in the embedded GEDDF dictionary (`docs/dictionaries/…toml`). Unknown keys
+/// (`dtype`, `vocabulary`, `_tentative`, `_conflict`, `quantize_dtype`) are ignored by serde.
+#[derive(serde::Deserialize)]
+struct DictCol {
+    #[serde(default)]
+    short_name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    unit: Option<String>,
+    /// Fixed-point scale for the int16 quantization: physical = raw × `quantize_scale`.
+    #[serde(default)]
+    quantize_scale: Option<f64>,
+}
+
+type GeDict = std::collections::BTreeMap<String, std::collections::BTreeMap<String, DictCol>>;
+
+/// Parse the embedded GEDDF listmode column dictionary once. Panics only if the in-tree TOML is
+/// malformed — an invariant guarded by the `geddf_dictionary_parses` test.
+fn geddf_dict() -> &'static GeDict {
+    static DICT: std::sync::OnceLock<GeDict> = std::sync::OnceLock::new();
+    DICT.get_or_init(|| {
+        toml::from_str(include_str!(
+            "../../../docs/dictionaries/ge-discovery-mi-listmode.toml"
+        ))
+        .expect("embedded GEDDF dictionary is valid TOML")
+    })
+}
+
+/// Map an HDF5 dataset name (or block prefix) to its dictionary group: `events_2p`/`events_3p` →
+/// `events`, `coin_2p`/`coin_3p` → `coin`, else the name itself (`singles`, `time_markers`, …).
+fn dataset_group(name: &str) -> &str {
+    if name.starts_with("events") {
+        "events"
+    } else if name.starts_with("coin_2p") || name.starts_with("coin_3p") || name == "coin" {
+        "coin"
+    } else {
+        name
+    }
+}
+
+/// The dictionary base field for an exploded column: `en_0` → `en`, `vtx_2` → `vtx`; scalar and
+/// non-numeric-suffixed names (`ms`, `lt_corr`, `n_singles`) pass through unchanged.
+fn base_field(col: &str) -> &str {
+    if let Some(i) = col.rfind('_') {
+        if i > 0 && col[i + 1..].chars().all(|ch| ch.is_ascii_digit()) {
+            return &col[..i];
+        }
+    }
+    col
+}
+
+/// Opt-in transform: annotate `data`'s columns from the GEDDF dictionary for `group`, and — when
+/// `quantize` — requantize float columns to int16 at the dictionary's `quantize_scale` (physical =
+/// raw × scale). Float columns with any non-finite value (e.g. the mostly-NaN `lt_corr`) are left as
+/// float and only annotated — int16 has no NaN. Returns the annotated [`Column`] schema for the
+/// (possibly requantized) `data`; call BEFORE sealing so payload and manifest reflect the transform.
+pub fn apply_geddf_dictionary(group: &str, data: &mut TableData, quantize: bool) -> Vec<Column> {
+    let group = dataset_group(group);
+    let dict = geddf_dict().get(group);
+    let mut columns = Vec::with_capacity(data.len());
+    for (name, col) in data.iter_mut() {
+        let meta = dict.and_then(|g| g.get(base_field(name)));
+        let mut scale: Option<f64> = None;
+        if quantize {
+            if let (ColumnData::F32(v), Some(qs)) = (&*col, meta.and_then(|m| m.quantize_scale)) {
+                if v.iter().all(|x| x.is_finite()) {
+                    let q: Vec<i16> = v
+                        .iter()
+                        .map(|x| {
+                            (*x as f64 / qs)
+                                .round()
+                                .clamp(i16::MIN as f64, i16::MAX as f64)
+                                as i16
+                        })
+                        .collect();
+                    *col = ColumnData::I16(q);
+                    scale = Some(qs);
+                }
+            }
+        }
+        let mut c = Column::new(name.clone(), col.numpy_code());
+        if let Some(m) = meta {
+            c.short_name = m.short_name.clone();
+            c.description = m.description.clone();
+            c.unit = m.unit.clone();
+        }
+        c.scale = scale;
+        columns.push(c);
+    }
+    columns
+}
+
 /// Read a GE listmode 3-photon dataset (default name `events_3p`) and transpose to flat Tessera
 /// columns: `ms` (u4) · `id_0..2` (u2) · `en_0..2` (f4) · `vtx_0..2` (f4) · `lt` (f4). Thin GE-named
 /// alias for [`read_compound`] — the actual decode is generic.
@@ -783,6 +883,77 @@ pub(crate) fn to_listmode_product_partitioned(
 mod tests {
     use super::*;
     use hdf5::H5Type;
+
+    #[test]
+    fn geddf_dictionary_parses_and_carries_units_and_scales() {
+        let d = geddf_dict();
+        assert!(d.contains_key("events") && d.contains_key("singles") && d.contains_key("coin"));
+        assert_eq!(d["events"]["en"].unit.as_deref(), Some("keV"));
+        assert_eq!(d["events"]["vtx"].unit.as_deref(), Some("mm"));
+        assert_eq!(d["events"]["lt"].unit.as_deref(), Some("ns"));
+        assert_eq!(d["events"]["en"].quantize_scale, Some(0.1));
+        assert_eq!(d["events"]["vtx"].quantize_scale, Some(0.0125));
+    }
+
+    #[test]
+    fn base_field_strips_only_numeric_array_suffix() {
+        assert_eq!(base_field("en_0"), "en");
+        assert_eq!(base_field("vtx_2"), "vtx");
+        assert_eq!(base_field("ms"), "ms");
+        assert_eq!(base_field("lt_corr"), "lt_corr");
+        assert_eq!(base_field("n_singles"), "n_singles");
+    }
+
+    #[test]
+    fn dataset_group_maps_variants() {
+        assert_eq!(dataset_group("events_3p"), "events");
+        assert_eq!(dataset_group("coin_2p"), "coin");
+        assert_eq!(dataset_group("singles"), "singles");
+        assert_eq!(dataset_group("time_markers"), "time_markers");
+    }
+
+    #[test]
+    fn apply_dictionary_annotates_and_quantizes_events() {
+        let mut data: TableData = vec![
+            ("ms".into(), ColumnData::U32(vec![1, 2, 3])),
+            ("en_0".into(), ColumnData::F32(vec![511.0, 425.5, 650.2])),
+            ("vtx_0".into(), ColumnData::F32(vec![100.0, -200.0, 369.5])),
+        ];
+        let cols = apply_geddf_dictionary("events_3p", &mut data, true);
+        // ms: annotated (unit ms), integer column untouched.
+        assert_eq!(cols[0].dtype, "u4");
+        assert_eq!(cols[0].unit.as_deref(), Some("ms"));
+        assert!(cols[0].scale.is_none());
+        // en_0: float → int16, scale 0.1, unit keV.
+        assert_eq!(cols[1].dtype, "i2");
+        assert_eq!(cols[1].unit.as_deref(), Some("keV"));
+        assert_eq!(cols[1].scale, Some(0.1));
+        match &data[1].1 {
+            ColumnData::I16(v) => assert_eq!(v[0], 5110), // round(511.0 / 0.1)
+            other => panic!("expected I16, got {other:?}"),
+        }
+        assert_eq!(cols[2].scale, Some(0.0125)); // vtx
+    }
+
+    #[test]
+    fn annotate_only_leaves_floats_and_hashes_stable() {
+        // Without `quantize`, float columns keep dtype f4 + unit but NO scale (values are physical).
+        let mut data: TableData = vec![("en_0".into(), ColumnData::F32(vec![511.0]))];
+        let cols = apply_geddf_dictionary("events", &mut data, false);
+        assert_eq!(cols[0].dtype, "f4");
+        assert_eq!(cols[0].unit.as_deref(), Some("keV"));
+        assert!(cols[0].scale.is_none());
+    }
+
+    #[test]
+    fn quantize_skips_nonfinite_float_columns() {
+        // int16 has no NaN — the mostly-NaN `lt_corr` stays float, still annotated.
+        let mut data: TableData = vec![("lt".into(), ColumnData::F32(vec![1.0, f32::NAN, 2.0]))];
+        let cols = apply_geddf_dictionary("events", &mut data, true);
+        assert_eq!(cols[0].dtype, "f4");
+        assert!(cols[0].scale.is_none());
+        assert_eq!(cols[0].unit.as_deref(), Some("ns"));
+    }
 
     // Fixture-write only: writing a synthetic .h5 with a compound dataset legitimately needs a
     // compile-time `H5Type` (the `new_dataset::<T>()` builder is generic). The READER under test

--- a/tessera/crates/tessera-ingest/src/spec.rs
+++ b/tessera/crates/tessera-ingest/src/spec.rs
@@ -46,7 +46,7 @@ pub const DEFAULT_BLOCK_PREFIX: &str = "events";
 pub const DEFAULT_ROW_INDEX: &str = "ms";
 
 /// The default per-slab read unit for `hdf-compound` streaming — the GE-HDF5 reader uses the same
-/// constant. Spec-overrideable so wide-row datasets can shrink the per-slab RAM footprint.
+/// constant. Spec-overridable so wide-row datasets can shrink the per-slab RAM footprint.
 pub const DEFAULT_SLAB_ROWS: usize = crate::ge_hdf5::STREAM_SLAB_ROWS;
 
 /// One declarative ingest spec — typically loaded from `.toml` via [`parse`].
@@ -156,6 +156,11 @@ pub enum FormatOptions {
         streaming: StreamingMode,
         #[serde(default = "default_slab_rows")]
         slab_rows: usize,
+        /// Opt-in GEDDF transform (#310): annotate columns (unit/description/short_name) + requantize
+        /// float columns to int16 at the physical resolution (physical = raw × scale). Default off →
+        /// byte-identical output. Forces the batch path (the transform needs the whole table).
+        #[serde(default)]
+        quantize: bool,
     },
     Nifti {
         input: PathBuf,

--- a/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
+++ b/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
@@ -121,6 +121,8 @@ dtype = "f4[]"
 unit = "keV"                    # CONFIRMED by 511 photopeak; DescriptionCSV "eV" is inconsistent
 vocabulary = "MorePET"
 _conflict = "DescriptionCSV.md says eV; data (511 photopeak) says keV"
+quantize_scale = 0.1   # 0.1 keV — 0..1220 keV ×10 fits int16 ±32767
+quantize_dtype = "i2"
 
 [events.ax]
 short_name = "ax"
@@ -142,6 +144,8 @@ description = "Reconstructed annihilation vertex (x, y, z). Data: x,y ±369.8 (t
 dtype = "f4[3]"
 unit = "mm"                     # CONFIRMED: DescriptionCSV V_{x,y,z}/mm + FOV-matching ranges
 vocabulary = "MorePET"
+quantize_scale = 0.0125   # 0.0125 mm — ±370 mm ×80 = ±29600 (int16-safe)
+quantize_dtype = "i2"
 
 [events.lt]
 short_name = "lt"
@@ -150,6 +154,8 @@ dtype = "f4"
 unit = "ns"                     # data −16.8…+17.4 (matches ±15 ns window). DescriptionCSV says ps.
 vocabulary = "MorePET"
 _conflict = "DescriptionCSV.md says ps; HDF5 float range (±17, = ±15ns window) says ns"
+quantize_scale = 0.001   # 1 ps — ±17 ns ×1000 = ±17000 (int16-safe)
+quantize_dtype = "i2"
 
 [events.lt_corr]
 short_name = "lt_corr"
@@ -158,6 +164,8 @@ dtype = "f4"
 unit = "ns"
 vocabulary = "MorePET"
 _tentative = true               # same ns/ps question as lt; mostly NaN in DP01
+quantize_scale = 0.001   # 1 ps, as lt
+quantize_dtype = "i2"
 
 # ── raw_data/time_markers — per-millisecond time index + running counts (416 k rows) ────
 [time_markers.tm]


### PR DESCRIPTION
Implements #310 (and the ge-hdf5 population half of #307) as an **opt-in ingest transform** — default off → byte-identical output, protecting the corpus/`manifest_hash` invariant.

**Stacked on #307 (PR #312)** — needs `Column.scale`. Review/merge #312 first.

## What
`tessera ingest ge-hdf5 <in> <out> --quantize` (also a `quantize` field on the `hdf-compound` spec format):
1. **Annotates** every column with unit/description/short_name from the embedded GEDDF dictionary (#307 population).
2. **Requantizes** the reconstructed float columns (`en`/`vtx`/`lt`) to **int16** at the physical resolution (physical = `raw × scale`): en ×10 (0.1 keV), vtx ×80 (0.0125 mm), lt ×1000 (1 ps). ~2× smaller, physically lossless (600–1000× under measurement resolution — the #310 benchmark).

Non-finite columns (mostly-NaN `lt_corr`) stay float. Integer columns (`ms`/`ax`/`tx`/counts) are annotated but untouched. `--quantize` forces the batch path (the streaming slab writer has no transform seam yet).

## Design
- `apply_geddf_dictionary(group, data, quantize)` — pure, unit-tested transform (annotate + requantize).
- Dictionary embedded via `include_str!` (flake src filter += `/docs/dictionaries/`); `quantize_scale` added to the float entries.
- `to_listmode_product_partitioned` gains an `Option<Vec<Column>>` schema override (None = byte-identical default); `to_listmode_product_with_schema` is the annotated public entry.

## Tests (7 new)
dict-parse, base-field, group-map, annotate+quantize, annotate-only, NaN-skip, and an **end-to-end seal test** proving the annotated int16 schema reaches the manifest. Full `clippy --all-targets --all-features -D warnings` + all gates green.

Refs: #310, #307