### PR TITLE
feat(ingest): blob-series — multi-file series as one .tsra, a block per file (no tar)

### DIFF
--- a/tessera/crates/tessera-ingest/src/blob.rs
+++ b/tessera/crates/tessera-ingest/src/blob.rs
@@ -50,6 +50,53 @@ pub fn to_blob_product(
     Ok((sealed, vec![payload]))
 }
 
+/// Seal MANY files as ONE `blob` product with a **`Blob` block per file** — the block-per-file "junk"
+/// tier for a multi-file vendor series (e.g. a DICOM series' slices). Each file is preserved
+/// bit-faithfully inside a single `.tsra` container (**no intermediate tar** — the `.tsra` is already a
+/// STORED-zip archive), independently `read`/`extract`-able, and range-readable (O(1) seek regardless of
+/// block count; the only cost is a larger manifest, linear in file count). Block names are `file_NNNN`
+/// in input order; each block's descriptor keeps the source basename (`tessera ls` shows them).
+///
+/// `source_label` overrides the recorded `ingested_from` reference (PHI hygiene). Memory: reads each
+/// file whole in turn (peak RSS ≈ largest single file), so it fits multi-file series of MB-scale slices.
+pub fn to_blob_multi_product(
+    paths: &[std::path::PathBuf],
+    name: &str,
+    timestamp: &str,
+    media_type: Option<&str>,
+    source_label: Option<&str>,
+    extra_sources: &[tessera_core::provenance::Source],
+) -> Result<(Manifest, Vec<BlockPayload>)> {
+    if paths.is_empty() {
+        return Err(Error::Invalid("blob-multi: no input files".into()));
+    }
+    let mut b = ProductBuilder::new(
+        "blob",
+        name,
+        "opaque preserved files (one block per file)",
+        timestamp,
+    );
+    let mut payloads = Vec::with_capacity(paths.len());
+    for (i, p) in paths.iter().enumerate() {
+        let bytes = std::fs::read(p).map_err(Error::from)?;
+        let filename = p.file_name().and_then(|s| s.to_str()).unwrap_or("blob");
+        let block_name = format!("file_{i:04}");
+        let (block_ref, payload) = blob_block(&block_name, filename, media_type, bytes)?;
+        b.add_block_ref(block_ref);
+        payloads.push(payload);
+    }
+    let source_ref = source_label
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{} files", paths.len()));
+    let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
+    b.add_source(crate::provenance::ingested_from(&path_refs, source_ref)?);
+    for s in extra_sources {
+        b.add_source(s.clone());
+    }
+    let sealed = b.seal()?;
+    Ok((sealed, payloads))
+}
+
 /// Like [`to_blob_product`] but **bounded-memory**: streams the file through blake3 (no whole-file
 /// `Vec`) and returns only the sealed manifest — the caller seals it with [`tessera_io::pack_streaming`]
 /// handing the **same `path`** as the `data` block's fragment, so a multi-GB file never enters RAM. The
@@ -115,6 +162,41 @@ mod tests {
             .sources
             .iter()
             .any(|s| s.reference.contains("testscan.l64")));
+    }
+
+    #[test]
+    fn seals_many_files_as_one_blob_product_block_per_file() {
+        // Block-per-file preservation (no tar): N files → one `.tsra`, a Blob block per file,
+        // each bit-faithful.
+        let dir = tempfile::tempdir().unwrap();
+        let mut paths = Vec::new();
+        let mut all_bytes = Vec::new();
+        for i in 0..3u32 {
+            let p = dir.path().join(format!("slice_{i}.img"));
+            let bytes: Vec<u8> = (0..1000u32).map(|k| ((k + i * 7) % 256) as u8).collect();
+            std::fs::write(&p, &bytes).unwrap();
+            paths.push(p);
+            all_bytes.push(bytes);
+        }
+        let (m, payloads) = to_blob_multi_product(
+            &paths,
+            "DP01-series",
+            "2024-01-01T00:00:00Z",
+            Some("application/dicom"),
+            None,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(m.product, "blob");
+        assert_eq!(m.blocks.len(), 3, "one Blob block per file");
+        for (i, blk) in m.blocks.iter().enumerate() {
+            assert_eq!(blk.name, format!("file_{i:04}"));
+            assert_eq!(
+                blk.digest.as_deref(),
+                Some(tessera_core::hash::digest(&all_bytes[i]).as_str())
+            );
+            assert_eq!(payloads[i].bytes, all_bytes[i], "block {i} bit-faithful");
+        }
     }
 
     /// ADR-0040: when `source_label` is given, the recorded `ingested_from` reference is the LABEL,

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -334,6 +334,20 @@ fn dispatch(
                 seal_streaming_to_tsra(m, &[("data".to_string(), input.as_path())], out_dir, p)?;
             Ok((m, ()))
         }
+        FormatOptions::BlobSeries { inputs, media_type } => {
+            // Block-per-file preservation → one `.tsra`, no tar (#301/#329). In-memory seal (each file
+            // read whole in turn); DICOM-series-scale slices fit comfortably.
+            let (m, payloads) = crate::blob::to_blob_multi_product(
+                inputs,
+                name,
+                &timestamp,
+                media_type.as_deref(),
+                label,
+                extra_sources,
+            )?;
+            let m = seal_to_tsra(m, &payloads, out_dir, p, timestamp.as_str())?;
+            Ok((m, ()))
+        }
         FormatOptions::Dicom { input, deidentify } => {
             let img = if *deidentify {
                 crate::dicom::read_image_deidentified(input)?

--- a/tessera/crates/tessera-ingest/src/spec.rs
+++ b/tessera/crates/tessera-ingest/src/spec.rs
@@ -183,6 +183,14 @@ pub enum FormatOptions {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         media_type: Option<String>,
     },
+    /// Multi-file opaque preservation: seal a set of files as ONE `blob` product with a `Blob` block
+    /// **per file** (no tar — the `.tsra` is already a STORED-zip container). The block-per-file cold
+    /// tier for a multi-file vendor series (e.g. a DICOM series' slices). `format = "blob-series"`.
+    BlobSeries {
+        inputs: Vec<PathBuf>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        media_type: Option<String>,
+    },
 }
 
 fn default_row_index() -> String {


### PR DESCRIPTION
Surfaced during the DUPLET run: preserving a multi-file DICOM series as one cold artifact forced an intermediate **tar** → a tar nested inside the `.tsra` (which is *already* a STORED-zip container). Wasteful, and the blob became a *tar-of-files* not the raw files (`extract`→`untar` to recover).

## Fix — `format = "blob-series"`
`to_blob_multi_product` seals N files as **one `blob` product with a `Blob` block per file** (block `file_NNNN`, source basename kept in each descriptor). **No tar.** Each file is independently `read`/`extract`-able and range-readable — the STORED zip means O(1) seek to any file's block *regardless of block count*; the only cost is a larger manifest (linear in file count, ~100 B/block). Bit-faithful per block.

- `to_blob_multi_product` + `FormatOptions::BlobSeries` + engine dispatch.
- Test: 3 files → 3 `Blob` blocks, each `digest = blake3(file)` + payload bit-faithful.

Used to redo the DP01 DICOM cold tier (each series → block-per-file, no tar). Addresses the multi-block-artifact half of #301.

Refs: #301