### PR TITLE
chore(release): versioning policy + release-plz pipeline (ADR-0052)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,37 @@
+# Opens/updates a HELD release PR (workspace version bump + CHANGELOG) on pushes to `dev` — ADR-0052.
+# It does NOT tag or publish; `0.1.0-alpha.1` is cut only by deliberately merging that release PR.
+#
+# NOTE: for GITHUB_TOKEN to open the PR, enable Settings → Actions → "Allow GitHub Actions to create and
+# approve pull requests", or add a PAT as secrets.RELEASE_PLZ_TOKEN (used first when present).
+name: release-plz
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-plz
+  cancel-in-progress: false
+
+jobs:
+  release-pr:
+    name: release-plz release-pr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: release-plz release-pr (held — no tag/publish)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}

--- a/docs/adr/0052-versioning-and-release.md
+++ b/docs/adr/0052-versioning-and-release.md
@@ -1,0 +1,65 @@
+# ADR-0052 — Versioning policy & release pipeline (release-plz)
+
+**Status:** Accepted (2026-07-03, as-set-up). Process/governance decision (not a feature row → exempt
+from the adr-matrix gate). Relates the Tessera→`dev` graduation (PR #322) and the `dev`=moving-target /
+`main`=distribution branch model.
+
+## Context
+
+At the fd5→Tessera graduation, all crates are `0.0.0`, there is no versioning policy, and the only
+release infra is a Python-template `release.yml` that doesn't understand the Cargo workspace. Before any
+tag we need: (1) a versioning policy, and (2) a pipeline.
+
+## Decision
+
+### 1. Two independent version axes — do not conflate
+
+- **Software version** (the crates / CLI / bindings) — **SemVer**, starting **`0.1.0-alpha.1`**.
+- **Format-spec version** (`tessera_version` in a `.tsra`) — stays **`v0` / pre-1.0**, deliberately
+  *unfrozen* (SPEC self-designates pre-1.0). A software alpha release does **not** imply a stable
+  format; release notes state this explicitly.
+
+These evolve separately: the software can reach `0.3.0` while the format is still `v0`; freezing the
+format to `v1` is its own decision (RFC §14), independent of software SemVer.
+
+### 2. Unified workspace version
+
+All crates share one `[workspace.package] version`, bumped in lockstep. Simpler than per-crate for an
+alpha; `tessera-core`/`io`/`cli`/`ingest`/`py`/`wasm` release together. (`tessera-py`/`tessera-wasm` are
+cdylibs → PyPI/npm, not crates.io; marked `publish = false` for crates.io when publishing is wired.)
+
+### 3. Pipeline = release-plz (Rust-native)
+
+**[release-plz](https://release-plz.dev)** over release-please — it understands the Cargo workspace
+natively (crate versions, inter-crate deps, `cargo publish`), drives versioning + CHANGELOG from
+**conventional commits** (already the repo's commit style), and its release flow is a **release PR** that
+sits until merged. Chosen over release-please (generic + a rust plugin + a bolted-on publish step).
+
+- **`release-plz release-pr`** runs on pushes to `dev`: opens/updates a PR bumping the workspace version
+  + regenerating `CHANGELOG.md`. **Nothing is tagged or published by this.**
+- **The release is *held* by construction** — `0.1.0-alpha.1` only happens when that release PR is
+  **deliberately merged**, then `release-plz release` (a later, gated step) tags + publishes.
+- **`release = false`** in `release-plz.toml` for now → no auto-publish. crates.io publishing is wired
+  when a `CARGO_REGISTRY_TOKEN` is provided (external / owner's call). PyPI (maturin) + binaries
+  (cargo-dist) are complementary, added when the alpha is actually cut.
+
+### 4. Flow
+
+```text
+feature → PR → dev            (moving target; CI per change)
+push to dev → release-plz opens/updates a HELD release PR (version + CHANGELOG)
+merge the release PR → tag 0.1.0-alpha.1 → (later, with token) cargo publish
+dev → main                    (distribution: main flips to the tagged release)
+```
+
+## Consequences
+
+- No hand-tags; the version history is release-plz-owned + conventional-commit-driven.
+- The first alpha is *ready but held* — the release PR is the "cut when you're ready" surface.
+- The Python-template `release.yml` is superseded by `release-plz.yml` (kept or removed separately).
+- Registry publishes stay off until credentials + `publish`-scoping are set — a deliberate, separate step.
+
+## References
+
+RFC §14 (semver policy / format supersession) · PR #322 (Tessera→dev graduation) · `release-plz.toml`
+· `.github/workflows/release-plz.yml` · the `dev`=moving-target / `main`=distribution branch model.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Accepted / Superseded.
 
 | ADR | Decision (register id) | Status |
 |---|---|---|
+| [0052](0052-versioning-and-release.md) | Versioning policy & release pipeline — **two axes** (software SemVer from `0.1.0-alpha.1` vs the format `tessera_version` staying `v0`/pre-1.0); **unified workspace version**; **release-plz** (Rust-native) drives version+CHANGELOG from conventional commits as a **held release PR** (nothing tags/publishes until deliberately merged); crates.io/PyPI/binaries deferred to when creds are set. `dev`=moving-target / `main`=distribution | **Accepted** (process; adr-matrix-exempt) |
 | [0020](0020-canonical-encoding-and-identity.md) | **D4** canonical encoding (RFC 8785 JCS) + **D5** identity model (id / content_hash / manifest_hash) + manifest & BlockRef schema | **Accepted** |
 | [0022](0022-versioning-and-container.md) | **D1** fd5 supersession (done) · versioning DAG · `.tsra` container spec | **Accepted** |
 | [0023](0023-array-block-payload.md) | Array block payload — Zarr v3 + pcodec, serialized as one deterministic blob (P3/S5) | **Accepted** |

--- a/guardrails-adr-exempt.txt
+++ b/guardrails-adr-exempt.txt
@@ -1,4 +1,6 @@
 # ADRs exempt from the guardrails-adr-matrix gate — Accepted decisions that are NOT feature rows.
 # 0002 = concurrency model · 0003 = schema-id (both recorded as-built decisions).
+# 0052 = versioning policy & release pipeline (process/governance, not a feature).
 0002
 0003
+0052

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,8 @@
+# Release pipeline — ADR-0052. release-plz drives the workspace version + CHANGELOG from conventional
+# commits and opens a HELD release PR on pushes to `dev`. Nothing is tagged or published automatically;
+# the first alpha (0.1.0-alpha.1) is cut only by deliberately merging that release PR, then a separate,
+# token-gated `release-plz release`.
+[workspace]
+# No auto-publish / auto-tag. crates.io publishing is wired later, gated on CARGO_REGISTRY_TOKEN;
+# `tessera-py` / `tessera-wasm` are cdylibs (PyPI / npm) → `publish = false` for crates.io when that lands.
+release = false


### PR DESCRIPTION
Sets up the release pipeline for Tessera-on-`dev` — **held** (nothing tags/publishes yet).

- **ADR-0052** — two version axes (software SemVer from `0.1.0-alpha.1` vs the format `tessera_version` staying `v0`/pre-1.0); unified workspace version; **release-plz** (Rust-native) over release-please; `dev`=moving-target / `main`=distribution. Process ADR → adr-matrix-exempt.
- **`release-plz.toml`** — `release = false` (no auto-publish/tag).
- **`.github/workflows/release-plz.yml`** — `release-plz release-pr` on pushes to `dev` → opens/updates a **held release PR** (version bump + CHANGELOG). The alpha is cut only by deliberately merging that PR.

**Caveat (setup, not code):** for the PR to open, enable *Settings → Actions → "Allow GitHub Actions to create and approve pull requests"* or add a `RELEASE_PLZ_TOKEN` PAT. crates.io/PyPI publishing stays off until `CARGO_REGISTRY_TOKEN` + `publish` scoping.

Docs + config + workflow only (no Rust change). Local `nix flake check`: all checks passed.