### PR TITLE
fix(ci): point release-plz at the nested tessera/ workspace manifest

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,5 +33,7 @@ jobs:
         uses: release-plz/action@v0.5
         with:
           command: release-pr
+          # The Cargo workspace is nested under `tessera/`, not the repo root.
+          manifest_path: tessera/Cargo.toml
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The first release-plz run failed: `manifest path .../Cargo.toml does not exist` — it looked at the repo root, but the Cargo workspace is nested under `tessera/`. Adds `manifest_path: tessera/Cargo.toml`. Still `release-pr` only (held; no tag/publish). Workflow-only change.