### PR TITLE
fix(ci): release-plz — drop 'release = false' (it hid all packages)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,12 @@
 # Release pipeline — ADR-0052. release-plz drives the workspace version + CHANGELOG from conventional
-# commits and opens a HELD release PR on pushes to `dev`. Nothing is tagged or published automatically;
-# the first alpha (0.1.0-alpha.1) is cut only by deliberately merging that release PR, then a separate,
-# token-gated `release-plz release`.
+# commits. The workflow runs ONLY `release-plz release-pr`, which opens/updates a HELD release PR
+# (version bump + CHANGELOG); it never tags or publishes. The first alpha (0.1.0-alpha.1) is cut only by
+# deliberately merging that PR — then a separate, token-gated `release-plz release` (not wired here).
+#
+# NB: do NOT set `release = false` here — that removes every package from release-plz's view
+# ("no public packages found") and breaks `release-pr` too. The HOLD comes from running only
+# `release-pr`, not from disabling release. When crates.io publishing is wired (CARGO_REGISTRY_TOKEN),
+# set `publish = false` on `tessera-py` / `tessera-wasm` (cdylibs → PyPI / npm) to keep them off crates.io.
 [workspace]
-# No auto-publish / auto-tag. crates.io publishing is wired later, gated on CARGO_REGISTRY_TOKEN;
-# `tessera-py` / `tessera-wasm` are cdylibs (PyPI / npm) → `publish = false` for crates.io when that lands.
-release = false
+# Intentionally minimal — defaults are correct for a held `release-pr` flow. Tag naming + single-vs-
+# per-crate tags + crates.io `publish` scoping are release-time concerns, decided when the alpha is cut.


### PR DESCRIPTION
Second release-plz run: `no public packages found`. `release = false` at [workspace] excludes every package (breaks `release-pr`). Removed it — the hold is from running only `release-pr`, not disabling release. Config-only.