### PR TITLE
feat(io): nullable table columns (Arrow validity bitmap) — NaN to NULL on ingest (#330)

### DIFF
--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -1403,6 +1403,9 @@ fn csv_cell(v: &Value) -> String {
 /// Convert a (sliced) numeric column to per-row JSON values. Floats render via their **native**
 /// shortest round-trip `Display` (so an `f32` shows `0.01`, not its widened-`f64` expansion);
 /// non-finite floats (NaN/±inf) have no JSON encoding → null (CSV shows `nan`, ndjson `null`).
+/// Nullable columns (#330) forward valid rows to the inner variant and surface `Value::Null` for
+/// NULL rows — ndjson consumers see proper `null` instead of a misleading finite value; CSV keeps
+/// the existing `nan` cell (consistent with how it already renders non-finite floats).
 fn col_to_values(col: &ColumnData) -> Vec<Value> {
     fn floats<T: std::fmt::Display + Copy>(v: &[T]) -> Vec<Value> {
         v.iter()
@@ -1424,6 +1427,14 @@ fn col_to_values(col: &ColumnData) -> Vec<Value> {
         ColumnData::U64(v) => v.iter().map(|x| Value::from(*x)).collect(),
         ColumnData::F32(v) => floats(v),
         ColumnData::F64(v) => floats(v),
+        ColumnData::Nullable { values, validity } => {
+            let inner = col_to_values(values);
+            inner
+                .into_iter()
+                .zip(validity.iter())
+                .map(|(v, &ok)| if ok { v } else { Value::Null })
+                .collect()
+        }
     }
 }
 

--- a/tessera/crates/tessera-cli/src/sql.rs
+++ b/tessera/crates/tessera-cli/src/sql.rs
@@ -37,6 +37,10 @@ use crate::nav::Format;
 /// (`ColumnData` is a closed enum, so every variant is covered exhaustively). Small vectors go
 /// through `.clone()`; f32/f64 are copied verbatim (no NaN canonicalisation — DataFusion honours
 /// IEEE-754 comparison semantics the same way the tests below assert).
+///
+/// Nullable columns (#330) build the Arrow array via `from_iter(Option<T>)` so DataFusion sees the
+/// standard Arrow validity bitmap — `WHERE col IS NULL` / `AVG(col)` / etc. treat missing rows
+/// correctly out of the box, no tessera sentinel to translate.
 fn column_to_array(col: ColumnData) -> ArrayRef {
     match col {
         ColumnData::I8(v) => Arc::new(Int8Array::from(v)) as ArrayRef,
@@ -49,6 +53,36 @@ fn column_to_array(col: ColumnData) -> ArrayRef {
         ColumnData::U64(v) => Arc::new(UInt64Array::from(v)) as ArrayRef,
         ColumnData::F32(v) => Arc::new(Float32Array::from(v)) as ArrayRef,
         ColumnData::F64(v) => Arc::new(Float64Array::from(v)) as ArrayRef,
+        ColumnData::Nullable { values, validity } => nullable_to_array(*values, &validity),
+    }
+}
+
+/// Build an Arrow array carrying its validity bitmap from a tessera nullable column. One arm per
+/// inner numeric dtype — the nested `Nullable` case can't occur (validity is on the outer wrapper
+/// only, enforced by `validate`).
+fn nullable_to_array(values: ColumnData, validity: &[bool]) -> ArrayRef {
+    fn zip_opt<T: Copy>(values: &[T], validity: &[bool]) -> Vec<Option<T>> {
+        values
+            .iter()
+            .zip(validity.iter())
+            .map(|(&v, &ok)| ok.then_some(v))
+            .collect()
+    }
+    match values {
+        ColumnData::I8(v) => Arc::new(Int8Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::I16(v) => Arc::new(Int16Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::I32(v) => Arc::new(Int32Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::I64(v) => Arc::new(Int64Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::U8(v) => Arc::new(UInt8Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::U16(v) => Arc::new(UInt16Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::U32(v) => Arc::new(UInt32Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::U64(v) => Arc::new(UInt64Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::F32(v) => Arc::new(Float32Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::F64(v) => Arc::new(Float64Array::from_iter(zip_opt(&v, validity))) as ArrayRef,
+        ColumnData::Nullable { .. } => {
+            // The validate() pass rejects Nullable-inside-Nullable, so this arm is unreachable.
+            unreachable!("nested Nullable inside a nullable ColumnData is rejected by validate")
+        }
     }
 }
 
@@ -126,7 +160,13 @@ pub fn run_with(
     let mut arrays: Vec<ArrayRef> = Vec::with_capacity(columns.len());
     for col in &columns {
         let data = view.column(&mut r, &col.name)?;
-        fields.push(Field::new(&col.name, numpy_to_arrow(&col.dtype)?, false));
+        // #330: the Arrow field is `nullable` iff the tessera column is — DataFusion honours the
+        // schema's nullability + the array's validity bitmap in aggregate semantics.
+        fields.push(Field::new(
+            &col.name,
+            numpy_to_arrow(&col.dtype)?,
+            col.nullable,
+        ));
         arrays.push(column_to_array(data));
     }
     let schema = Arc::new(Schema::new(fields));
@@ -312,6 +352,92 @@ mod tests {
             msg.contains("no_such_column") || msg.contains("Schema") || msg.contains("plan"),
             "expected a schema/plan error naming the missing column, got: {msg}"
         );
+    }
+
+    /// #330: a nullable column decoded from a sealed `.tsra` reaches DataFusion with an Arrow
+    /// validity bitmap, so `IS NULL` / `AVG(col)` behave correctly (SQL-standard: nulls skipped in
+    /// aggregates, `IS NULL` matches missing rows). This is the "does the DUPLET `lt_corr` shape
+    /// query correctly?" guard.
+    #[test]
+    fn sql_over_nullable_column_honours_null_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("nullable.tsra");
+        // Sealed sample: 4 rows, `lt_corr` = [NULL, 10, 20, NULL] (int16 quantized).
+        let spec = TableSpec {
+            columns: vec![
+                Column {
+                    name: "ms".into(),
+                    dtype: "u4".into(),
+                    ..Default::default()
+                },
+                Column {
+                    name: "lt_corr".into(),
+                    dtype: "i2".into(),
+                    nullable: true,
+                    ..Default::default()
+                },
+            ],
+            rows: 4,
+            row_index: None,
+        };
+        let data: TableData = vec![
+            ("ms".into(), ColumnData::U32(vec![1, 2, 3, 4])),
+            (
+                "lt_corr".into(),
+                ColumnData::Nullable {
+                    values: Box::new(ColumnData::I16(vec![0, 10, 20, 0])),
+                    validity: vec![false, true, true, false],
+                },
+            ),
+        ];
+        let (block_ref, payload) = table_block("events", &spec, &data).unwrap();
+        let mut b = ProductBuilder::new("listmode", "DP", "d", "2024-01-01T00:00:00Z");
+        b.add_block_ref(block_ref);
+        b.with_field("modality", serde_json::json!("PT"));
+        let sealed = b.seal().unwrap();
+        pack(&sealed, &[payload], &tsra).unwrap();
+
+        // WHERE lt_corr IS NULL → rows 1 and 4.
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT ms FROM events WHERE lt_corr IS NULL ORDER BY ms",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "ms\n1\n4\n");
+
+        // AVG(lt_corr) skips NULLs → (10 + 20) / 2 = 15.
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT AVG(lt_corr) AS avg_lt FROM events",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.starts_with("avg_lt\n15"),
+            "expected AVG=15 (nulls skipped), got: {text:?}"
+        );
+
+        // COUNT(*) counts all rows; COUNT(lt_corr) counts only non-NULL — the SQL-standard split.
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT COUNT(*), COUNT(lt_corr) FROM events",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        let text = String::from_utf8(out).unwrap();
+        // csv writer prints these as `count(*)` / `count(events.lt_corr)` etc — assert the row.
+        assert!(text.contains("4,2\n"), "expected 4,2 row, got: {text:?}");
     }
 
     /// `--format ndjson` is explicitly rejected today (arrow-csv is the writer) — proves the

--- a/tessera/crates/tessera-core/src/block/table.rs
+++ b/tessera/crates/tessera-core/src/block/table.rs
@@ -31,6 +31,19 @@ pub struct Column {
     /// physical (no quantization). Carried so the read/compute path recovers physical units.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scale: Option<f64>,
+    /// Nullability marker (#330): when `true`, the column carries a validity bitmap alongside its
+    /// values (Arrow/Vortex native nullness), and `NaN`/`None` values are stored as **NULL** rather
+    /// than a float sentinel. Default `false`, skipped on serialize when unset — so a legacy column
+    /// (or any non-null column) serializes byte-identical to today, preserving on-disk content
+    /// hashes and the conformance corpus.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub nullable: bool,
+}
+
+/// Serde helper: skip a `bool` field when it's `false` (the null default), so an unannotated
+/// column round-trips byte-identical through JSON.
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl Column {
@@ -66,6 +79,12 @@ impl Column {
     /// Builder: fixed-point scale (physical = raw × scale).
     pub fn with_scale(mut self, scale: f64) -> Self {
         self.scale = Some(scale);
+        self
+    }
+    /// Builder: mark the column nullable (#330 — values carry a validity bitmap; missing rows
+    /// serialize as NULL rather than a float sentinel). Idempotent.
+    pub fn with_nullable(mut self) -> Self {
+        self.nullable = true;
         self
     }
 }
@@ -140,12 +159,16 @@ mod tests {
 
     #[test]
     fn bare_column_skips_annotation_fields_on_serialize() {
-        // Back-compat: an unannotated column serializes to exactly the legacy shape (name+dtype),
-        // so existing on-disk `.tsra` specs and content hashes are unaffected.
+        // Back-compat: an unannotated column serializes to exactly the legacy shape (name+dtype
+        // only), so existing on-disk `.tsra` specs and content hashes are unaffected. Order-
+        // agnostic: `serde_json`'s Map iterates alphabetically without the `preserve_order`
+        // feature — the invariant is the KEY SET, not its iteration order.
         let bare = Column::new("ms", "u4");
         let v = serde_json::to_value(&bare).unwrap();
         let obj = v.as_object().unwrap();
-        assert_eq!(obj.keys().collect::<Vec<_>>(), vec!["name", "dtype"]);
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["dtype", "name"]);
     }
 
     #[test]
@@ -161,5 +184,30 @@ mod tests {
         let c: Column = serde_json::from_str(r#"{"name":"t","dtype":"u8"}"#).unwrap();
         assert_eq!(c.name, "t");
         assert!(c.unit.is_none() && c.scale.is_none() && c.description.is_none());
+        assert!(!c.nullable, "legacy column defaults to non-nullable");
+    }
+
+    #[test]
+    fn nullable_flag_round_trips_and_skips_when_false() {
+        // #330 back-compat: `nullable: false` is the default, MUST NOT appear on serialize (so a
+        // non-null column is byte-identical to today's on-disk shape and content hashes are
+        // preserved). A nullable column round-trips through JSON with the flag set.
+        let bare = Column::new("t", "u8");
+        let v = serde_json::to_value(&bare).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(
+            !obj.contains_key("nullable"),
+            "unset `nullable` MUST be skipped — content-hash stability"
+        );
+
+        let n = Column::new("lt_corr", "i2")
+            .with_unit("ns")
+            .with_scale(0.001)
+            .with_nullable();
+        assert!(n.nullable);
+        let v2 = serde_json::to_value(&n).unwrap();
+        assert_eq!(v2["nullable"], true);
+        let back: Column = serde_json::from_value(v2).unwrap();
+        assert_eq!(back, n);
     }
 }

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -156,6 +156,12 @@ fn slab_to_columns(bytes: &[u8], c: &CompoundType, n_rows: usize) -> Result<Tabl
             ColumnData::U64(v) => v.reserve_exact(n_rows),
             ColumnData::F32(v) => v.reserve_exact(n_rows),
             ColumnData::F64(v) => v.reserve_exact(n_rows),
+            // Raw HDF5 compounds decode to plain non-null columns; `apply_geddf_dictionary` is
+            // what folds a partial-NaN float into a nullable int16 downstream. So the accumulator
+            // seed here is always non-Nullable.
+            ColumnData::Nullable { .. } => {
+                unreachable!("HDF5 raw decode never seeds a Nullable accumulator")
+            }
         }
     }
 
@@ -479,9 +485,18 @@ fn base_field(col: &str) -> &str {
 
 /// Opt-in transform: annotate `data`'s columns from the GEDDF dictionary for `group`, and — when
 /// `quantize` — requantize float columns to int16 at the dictionary's `quantize_scale` (physical =
-/// raw × scale). Float columns with any non-finite value (e.g. the mostly-NaN `lt_corr`) are left as
-/// float and only annotated — int16 has no NaN. Returns the annotated [`Column`] schema for the
-/// (possibly requantized) `data`; call BEFORE sealing so payload and manifest reflect the transform.
+/// raw × scale).
+///
+/// **Nullable int16 for partial-NaN floats (#330).** A float column that has any non-finite value
+/// (e.g. `events_3p.lt_corr`, 0.7% NaN in the DUPLET dataset) becomes a **nullable int16**: NaN
+/// rows are stored as NULL via a validity bitmap, the finite rows are quantized to int16 at the
+/// dictionary's `quantize_scale`. Byte-savings: ~2× on 99.3% good data + 1 bit/row for the
+/// validity bitmap (compresses to near nothing on a mostly-finite column) vs. the pre-#330
+/// force-to-`f4` fallback. Fully-finite columns still take the non-nullable int16 path (a
+/// `ColumnData::I16(_)`, byte-identical to pre-#330 output — no corpus regen).
+///
+/// Returns the annotated [`Column`] schema for the (possibly requantized) `data`; call BEFORE
+/// sealing so payload and manifest reflect the transform.
 pub fn apply_geddf_dictionary(group: &str, data: &mut TableData, quantize: bool) -> Vec<Column> {
     let group = dataset_group(group);
     let dict = geddf_dict().get(group);
@@ -489,20 +504,35 @@ pub fn apply_geddf_dictionary(group: &str, data: &mut TableData, quantize: bool)
     for (name, col) in data.iter_mut() {
         let meta = dict.and_then(|g| g.get(base_field(name)));
         let mut scale: Option<f64> = None;
+        let mut nullable = false;
         if quantize {
             if let (ColumnData::F32(v), Some(qs)) = (&*col, meta.and_then(|m| m.quantize_scale)) {
+                let quant = |x: f32| -> i16 {
+                    (x as f64 / qs)
+                        .round()
+                        .clamp(i16::MIN as f64, i16::MAX as f64) as i16
+                };
                 if v.iter().all(|x| x.is_finite()) {
-                    let q: Vec<i16> = v
-                        .iter()
-                        .map(|x| {
-                            (*x as f64 / qs)
-                                .round()
-                                .clamp(i16::MIN as f64, i16::MAX as f64)
-                                as i16
-                        })
-                        .collect();
+                    // Fully finite → the pre-#330 non-nullable int16 path, byte-identical to
+                    // what today's corpus/manifest_hash records.
+                    let q: Vec<i16> = v.iter().map(|x| quant(*x)).collect();
                     *col = ColumnData::I16(q);
                     scale = Some(qs);
+                } else {
+                    // #330: NaN → NULL, finite → int16 quantized. Placeholder for null slots is
+                    // the deterministic `0` (never observed by callers — validity says NULL) so
+                    // encode remains a pure function of input.
+                    let validity: Vec<bool> = v.iter().map(|x| x.is_finite()).collect();
+                    let q: Vec<i16> = v
+                        .iter()
+                        .map(|x| if x.is_finite() { quant(*x) } else { 0 })
+                        .collect();
+                    *col = ColumnData::Nullable {
+                        values: Box::new(ColumnData::I16(q)),
+                        validity,
+                    };
+                    scale = Some(qs);
+                    nullable = true;
                 }
             }
         }
@@ -513,6 +543,7 @@ pub fn apply_geddf_dictionary(group: &str, data: &mut TableData, quantize: bool)
             c.unit = m.unit.clone();
         }
         c.scale = scale;
+        c.nullable = nullable;
         columns.push(c);
     }
     columns
@@ -979,13 +1010,33 @@ mod tests {
     }
 
     #[test]
-    fn quantize_skips_nonfinite_float_columns() {
-        // int16 has no NaN — the mostly-NaN `lt_corr` stays float, still annotated.
-        let mut data: TableData = vec![("lt".into(), ColumnData::F32(vec![1.0, f32::NAN, 2.0]))];
+    fn quantize_partial_nan_float_becomes_nullable_int16() {
+        // #330: a float column with any NaN becomes a **nullable int16** — NaN → NULL (validity
+        // bit = false), finite → int16 quantized at the dictionary scale. The DUPLET
+        // `events_3p.lt_corr` case (0.7% NaN over 158M rows) now saves ~2× on the 99.3% good data
+        // instead of forcing the whole column back to `f4` (the pre-#330 path).
+        let mut data: TableData = vec![("lt".into(), ColumnData::F32(vec![1.5, f32::NAN, 2.0]))];
         let cols = apply_geddf_dictionary("events", &mut data, true);
-        assert_eq!(cols[0].dtype, "f4");
-        assert!(cols[0].scale.is_none());
+        assert_eq!(cols[0].dtype, "i2");
+        assert!(cols[0].nullable, "partial-NaN → nullable int16");
+        assert_eq!(cols[0].scale, Some(0.001)); // `lt` scale = 1 ps (from GEDDF)
         assert_eq!(cols[0].unit.as_deref(), Some("ns"));
+        // The wrapped values quantize finite rows and use 0 as a deterministic placeholder for
+        // the NaN slot (never observed — validity says NULL).
+        match &data[0].1 {
+            ColumnData::Nullable { values, validity } => {
+                assert_eq!(validity, &vec![true, false, true]);
+                match values.as_ref() {
+                    ColumnData::I16(v) => {
+                        assert_eq!(v[0], 1500); // round(1.5 / 0.001)
+                        assert_eq!(v[1], 0); // deterministic NULL placeholder
+                        assert_eq!(v[2], 2000); // round(2.0 / 0.001)
+                    }
+                    other => panic!("expected inner I16, got {other:?}"),
+                }
+            }
+            other => panic!("expected Nullable, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tessera/crates/tessera-io/src/accumulate.rs
+++ b/tessera/crates/tessera-io/src/accumulate.rs
@@ -28,14 +28,16 @@ use crate::table::{
 };
 
 /// An empty buffer (one empty column per spec column). Spec dtypes are validated in
-/// [`TableStreamWriter::new`], so the empty construction can't fail afterwards.
+/// [`TableStreamWriter::new`], so the empty construction can't fail afterwards. Nullable columns
+/// (#330) get a `ColumnData::Nullable` wrapper with an empty inner + empty validity — so the
+/// staging accumulator's variant matches the sealed spec through the whole push/flush lifecycle.
 fn empty_cols(columns: &[Column]) -> TableData {
     columns
         .iter()
         .map(|c| {
             (
                 c.name.clone(),
-                ColumnData::from_le_bytes(&c.dtype, &[]).expect("validated dtype"),
+                ColumnData::empty_for(c).expect("validated dtype"),
             )
         })
         .collect()
@@ -61,6 +63,10 @@ pub(crate) fn write_fragment(path: &Path, group: &TableData) -> Result<()> {
 /// Read one fragment back into a [`TableData`] of `columns` (inverse of [`write_fragment`]). The
 /// fragment format is internal; this is the only reader. `pub(crate)` so [`crate::stream`] can lazily
 /// pull fragments inside a per-block encode job.
+///
+/// A nullable column (#330) is serialized by [`write_fragment`] as `values ‖ validity` (see
+/// [`ColumnData::to_le_bytes`]), so on read we skip both the value bytes AND the trailing
+/// `ceil(rows / 8)` validity bytes.
 pub(crate) fn read_fragment(path: &Path, columns: &[Column]) -> Result<TableData> {
     let bytes = fs::read(path)?;
     let head = bytes
@@ -74,12 +80,17 @@ pub(crate) fn read_fragment(path: &Path, columns: &[Column]) -> Result<TableData
     let mut off = 8usize;
     let mut out = Vec::with_capacity(columns.len());
     for c in columns {
-        let len = n_rows * ColumnData::dtype_size(&c.dtype)?;
+        let value_len = n_rows * ColumnData::dtype_size(&c.dtype)?;
+        let validity_len = if c.nullable { n_rows.div_ceil(8) } else { 0 };
+        let total_len = value_len + validity_len;
         let raw = bytes
-            .get(off..off + len)
+            .get(off..off + total_len)
             .ok_or_else(|| Error::Codec(format!("fragment: truncated column '{}'", c.name)))?;
-        out.push((c.name.clone(), ColumnData::from_le_bytes(&c.dtype, raw)?));
-        off += len;
+        out.push((
+            c.name.clone(),
+            ColumnData::from_column_bytes(c, raw, n_rows)?,
+        ));
+        off += total_len;
     }
     Ok(out)
 }

--- a/tessera/crates/tessera-io/src/multiblock.rs
+++ b/tessera/crates/tessera-io/src/multiblock.rs
@@ -109,8 +109,11 @@ impl LogicalTableView {
     /// For very large columns prefer [`Self::column_blocks`] — it yields one block's worth at a
     /// time so callers can stream the column without materialising it all.
     pub fn column<R: Read + Seek>(&self, reader: &mut Reader<R>, name: &str) -> Result<ColumnData> {
-        let code = self.column_dtype(name)?;
-        let mut out = ColumnData::from_le_bytes(code, &[])?;
+        // `empty_for(col)` respects the schema's `nullable` flag so a nullable column concatenates
+        // into a `ColumnData::Nullable` accumulator (extend on the outer wrapper appends both
+        // values and validity in lock-step).
+        let col = self.column_spec(name)?;
+        let mut out = ColumnData::empty_for(col)?;
         for (bname, spec) in self.block_names.iter().zip(&self.specs) {
             let blob = reader.read_block(bname)?;
             let chunk = decode_column(spec, &blob, name)?;
@@ -171,7 +174,7 @@ impl LogicalTableView {
         // Build output columns in spec order; gather one row at a time in caller order.
         let mut out: TableData = Vec::with_capacity(columns.len());
         for (col_idx, col) in columns.iter().enumerate() {
-            let mut typed = ColumnData::from_le_bytes(&col.dtype, &[])?;
+            let mut typed = ColumnData::empty_for(col)?;
             for &(b, l) in &mapping {
                 let src = decoded.get(&b).ok_or_else(|| {
                     Error::Codec(format!("take: missing decoded cache for block {b}"))
@@ -228,10 +231,13 @@ impl LogicalTableView {
     }
 
     fn column_dtype(&self, name: &str) -> Result<&str> {
+        self.column_spec(name).map(|c| c.dtype.as_str())
+    }
+
+    fn column_spec(&self, name: &str) -> Result<&Column> {
         self.specs
             .first()
             .and_then(|s| s.columns.iter().find(|c| c.name == name))
-            .map(|c| c.dtype.as_str())
             .ok_or_else(|| {
                 Error::Codec(format!(
                     "logical_table('{}'): no column '{name}'",
@@ -654,6 +660,80 @@ mod tests {
         assert!(view
             .select_blocks_overlapping(&mut rdr, "e", 0, 100)
             .is_err());
+    }
+
+    #[test]
+    fn nullable_column_round_trips_through_sealed_multi_block_container() {
+        // #330 end-to-end: a nullable int16 column (the DUPLET `lt_corr` shape — partial-NaN
+        // ingest → nullable int16) survives the SEAL: streaming write → pack → open → logical
+        // read → values + validity byte-exact against the input. Multi-block partition too, so
+        // the validity concatenates correctly across `events_NNNN` shards.
+        let dir = tempfile::tempdir().unwrap();
+        let block_rows = ROWS_PER_GROUP as u64;
+        let rows = (block_rows as usize) * 2 + 555;
+
+        // The nullable column: values pinned to a deterministic sequence, ~10% NULL in a striped
+        // pattern (mixes null/non-null within a row-group and across blocks).
+        let mut values: Vec<i16> = (0..rows).map(|k| (k as i16).wrapping_mul(11)).collect();
+        let validity: Vec<bool> = (0..rows).map(|k| k % 10 != 3).collect();
+        for (i, ok) in validity.iter().enumerate() {
+            if !ok {
+                values[i] = 0;
+            }
+        }
+
+        let columns = vec![
+            col("t", "u8"),
+            Column {
+                name: "lt_corr".into(),
+                dtype: "i2".into(),
+                nullable: true,
+                unit: Some("ns".into()),
+                scale: Some(0.001),
+                ..Default::default()
+            },
+        ];
+        let ws = WriteSession::create(&dir.path().join("ws"), "listmode", "p", "d", TS).unwrap();
+        let mut sw = StreamWriter::new(ws, 2, 4);
+        {
+            let mut sink = crate::accumulate::TableMultiBlockSink::with_block_rows(
+                columns,
+                "events",
+                &dir.path().join("sink"),
+                &mut sw,
+                block_rows,
+            )
+            .unwrap()
+            .with_row_index("t");
+            let batch: TableData = vec![
+                ("t".into(), ColumnData::U64((0..rows as u64).collect())),
+                (
+                    "lt_corr".into(),
+                    ColumnData::Nullable {
+                        values: Box::new(ColumnData::I16(values.clone())),
+                        validity: validity.clone(),
+                    },
+                ),
+            ];
+            sink.push(batch).unwrap();
+            sink.finish().unwrap();
+        }
+        let path = dir.path().join("nullable.tsra");
+        sw.finish(&path).unwrap();
+
+        // Read back via the logical view — spans every `events_NNNN` shard.
+        let mut rdr = Reader::open(&path).unwrap();
+        let view = rdr.logical_table("events").unwrap();
+        assert!(view.block_count() >= 3, "need multi-block partition");
+        let column_back = view.column(&mut rdr, "lt_corr").unwrap();
+        let expected = ColumnData::Nullable {
+            values: Box::new(ColumnData::I16(values)),
+            validity,
+        };
+        assert_eq!(
+            column_back, expected,
+            "sealed multi-block nullable column lost values or validity"
+        );
     }
 
     #[test]

--- a/tessera/crates/tessera-io/src/stream.rs
+++ b/tessera/crates/tessera-io/src/stream.rs
@@ -127,8 +127,7 @@ pub fn table_job_from_fragments(
                 .map(|c| {
                     (
                         c.name.clone(),
-                        crate::table::ColumnData::from_le_bytes(&c.dtype, &[])
-                            .expect("validated dtype"),
+                        crate::table::ColumnData::empty_for(c).expect("validated dtype"),
                     )
                 })
                 .collect::<crate::table::TableData>()

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -9,7 +9,7 @@
 //! (`i1/i2/i4/i8`, `u1/u2/u4/u8`, `f4/f8`) carried in [`tessera_core::block::table::Column`].
 
 use futures::StreamExt;
-use tessera_core::block::table::TableSpec;
+use tessera_core::block::table::{Column, TableSpec};
 use tessera_core::block::{BlockKind, BlockRef};
 use tessera_core::chunk_index::{ChunkIndex, ChunkStats};
 use tessera_core::hash::digest;
@@ -20,9 +20,11 @@ use vortex_array::expr::{root, select};
 use vortex_array::iter::{ArrayIteratorAdapter, ArrayIteratorExt};
 use vortex_array::scalar_fn::session::ScalarFnSession;
 use vortex_array::session::ArraySession;
-use vortex_array::{ArrayRef, IntoArray, VortexSessionExecute};
+use vortex_array::validity::Validity;
+use vortex_array::{ArrayRef, ExecutionCtx, IntoArray, VortexSessionExecute};
 use vortex_btrblocks::schemes::float::{ALPRDScheme, ALPScheme};
 use vortex_btrblocks::{BtrBlocksCompressorBuilder, SchemeExt};
+use vortex_buffer::BitBuffer;
 use vortex_buffer::{Buffer, ByteBuffer, ByteBufferMut};
 use vortex_file::{
     register_default_encodings, OpenOptionsSessionExt, WriteOptionsSessionExt, WriteStrategyBuilder,
@@ -37,6 +39,24 @@ use crate::BlockPayload;
 
 /// One column's typed values (C order). Covers the numeric dtypes Vortex stores natively; the fd5
 /// numpy code (`i2`, `u4`, `f4`, …) names the dtype in the [`TableSpec`].
+///
+/// # Nullable columns (#330)
+///
+/// The [`ColumnData::Nullable`] wrapper attaches a per-row validity bitmap to any inner numeric
+/// variant (Arrow/Vortex native nullness): `validity[i] == true` means the row is valid; `false`
+/// means the row is NULL (the placeholder value at `values[i]` is meaningless — readers MUST
+/// consult `validity` first). This is the missing-data primitive the ingest quantizer uses to turn
+/// a mostly-finite float column with occasional `NaN` (e.g. GE listmode `events_3p.lt_corr`) into a
+/// **nullable int16** (`NaN → NULL`, finite → int16 at physical resolution), rather than forcing
+/// the column to stay `f4` to carry the NaNs (#310 background).
+///
+/// Wrapper (not per-variant validity) so:
+/// - Every existing dtype method transparently forwards through the wrapper (one recursive arm per
+///   method — no cross-product of dtypes × nullability);
+/// - A non-null column is byte-identical to today's [`Nullable`]-free variant (no encode-path
+///   regression on the conformance corpus / any pre-#330 `.tsra`);
+/// - Vortex validity plugs in exactly once, in [`Self::to_vortex`] / [`extend_column`], so the
+///   Arrow-native validity bitmap is the sealed representation, not a tessera-side sentinel.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ColumnData {
     I8(Vec<i8>),
@@ -49,10 +69,20 @@ pub enum ColumnData {
     U64(Vec<u64>),
     F32(Vec<f32>),
     F64(Vec<f64>),
+    /// Nullable wrapper (#330): inner numeric column + one validity bit per row. `validity.len()
+    /// == values.len()` — invariant, checked in every constructor. A row where `validity[i] ==
+    /// false` is NULL; the placeholder value at `values[i]` is stored (deterministically, so
+    /// encode is a pure function of input) but semantically undefined for callers.
+    Nullable {
+        values: Box<ColumnData>,
+        validity: Vec<bool>,
+    },
 }
 
 impl ColumnData {
-    /// The fd5 numpy-style dtype code (matches [`tessera_core::block::table::Column::dtype`]).
+    /// The fd5 numpy-style dtype code (matches [`tessera_core::block::table::Column::dtype`]). The
+    /// nullable wrapper is transparent — a nullable `i2` reports `"i2"`, and the [`Column`] carries
+    /// the separate `nullable: bool` flag.
     pub fn numpy_code(&self) -> &'static str {
         match self {
             ColumnData::I8(_) => "i1",
@@ -65,7 +95,13 @@ impl ColumnData {
             ColumnData::U64(_) => "u8",
             ColumnData::F32(_) => "f4",
             ColumnData::F64(_) => "f8",
+            ColumnData::Nullable { values, .. } => values.numpy_code(),
         }
+    }
+
+    /// Whether this column carries per-row null information (a [`ColumnData::Nullable`] wrapper).
+    pub fn is_nullable(&self) -> bool {
+        matches!(self, ColumnData::Nullable { .. })
     }
 
     pub fn len(&self) -> usize {
@@ -80,6 +116,8 @@ impl ColumnData {
             ColumnData::U64(v) => v.len(),
             ColumnData::F32(v) => v.len(),
             ColumnData::F64(v) => v.len(),
+            // Invariant: validity.len() == values.len() (constructors enforce it).
+            ColumnData::Nullable { validity, .. } => validity.len(),
         }
     }
 
@@ -90,7 +128,9 @@ impl ColumnData {
     /// The column's values as `i64` for chunk-statistics (ADR-0028 §3), if it is an integer column that
     /// fits losslessly: `i1/i2/i4/i8`, `u1/u2/u4` always, and `u8` (u64) only when every value ≤
     /// `i64::MAX` (a monotonic cast → `min`/`max` stay exact). Float columns return `None` (they need
-    /// canonical reduction before stats — ADR-0024).
+    /// canonical reduction before stats — ADR-0024). Nullable integer columns return only the
+    /// **valid** rows' values (nulls skipped) — matches SQL aggregate semantics; count-of-nulls is
+    /// not folded into `[min, max]` stats.
     pub fn as_i64(&self) -> Option<Vec<i64>> {
         match self {
             ColumnData::I8(v) => Some(v.iter().map(|&x| x as i64).collect()),
@@ -105,11 +145,26 @@ impl ColumnData {
                 .all(|&x| x <= i64::MAX as u64)
                 .then(|| v.iter().map(|&x| x as i64).collect()),
             ColumnData::F32(_) | ColumnData::F64(_) => None,
+            ColumnData::Nullable { values, validity } => {
+                // Filter to valid rows only — nulls don't contribute to integer min/max.
+                values.as_i64().map(|all| {
+                    all.into_iter()
+                        .zip(validity.iter())
+                        .filter_map(|(x, &ok)| ok.then_some(x))
+                        .collect()
+                })
+            }
         }
     }
 
     /// Flatten the column to little-endian bytes for zero-copy reconstruction in another runtime —
     /// e.g. `numpy.frombuffer(buf, "<" + numpy_code)`.
+    ///
+    /// Nullable columns append the validity bitmap after the values as packed bytes (LSB-first,
+    /// ceil(rows / 8) bytes) — so the per-row-group content digest ([`table_chunk_index`]) covers
+    /// both values AND null pattern. Two decoded columns with the same values but different
+    /// nullness produce **different** digests, which is required for determinism (#330 §"Tests
+    /// (must add)": back-compat + round-trip).
     pub fn to_le_bytes(&self) -> Vec<u8> {
         use crate::array::le_bytes;
         match self {
@@ -123,11 +178,18 @@ impl ColumnData {
             ColumnData::U64(v) => le_bytes(v, u64::to_le_bytes),
             ColumnData::F32(v) => le_bytes(v, f32::to_le_bytes),
             ColumnData::F64(v) => le_bytes(v, f64::to_le_bytes),
+            ColumnData::Nullable { values, validity } => {
+                let mut out = values.to_le_bytes();
+                out.extend_from_slice(&pack_validity(validity));
+                out
+            }
         }
     }
 
     /// Build a [`ColumnData`] from a little-endian buffer + numpy code (`i1/i2/i4/i8`, `u1/u2/u4/u8`,
-    /// `f4/f8`) — the inverse of [`Self::to_le_bytes`] + [`Self::numpy_code`].
+    /// `f4/f8`) — the inverse of [`Self::to_le_bytes`] + [`Self::numpy_code`] on the **non-null** path.
+    /// For a nullable column, use [`Self::from_column_bytes`] (needs `n_rows` + the [`Column`]'s
+    /// `nullable` flag to know how many trailing validity bytes to consume).
     pub fn from_le_bytes(numpy_code: &str, bytes: &[u8]) -> Result<ColumnData> {
         use crate::array::from_le;
         Ok(match numpy_code {
@@ -149,6 +211,55 @@ impl ColumnData {
         })
     }
 
+    /// Rebuild a [`ColumnData`] from a little-endian buffer that matches the [`Column`]'s spec —
+    /// values + (if `col.nullable`) trailing packed-validity bytes. Inverse of [`Self::to_le_bytes`]
+    /// for BOTH the non-null and nullable paths. Used by the internal fragment (streaming stage)
+    /// format so a nullable column round-trips through the on-disk fragment before sealing.
+    pub fn from_column_bytes(col: &Column, bytes: &[u8], n_rows: usize) -> Result<ColumnData> {
+        let value_bytes = n_rows
+            .checked_mul(dtype_size(&col.dtype)?)
+            .ok_or_else(|| Error::Codec("column bytes overflow usize".into()))?;
+        if bytes.len() < value_bytes {
+            return Err(Error::Codec(format!(
+                "column '{}': expected ≥ {value_bytes} value bytes, got {}",
+                col.name,
+                bytes.len()
+            )));
+        }
+        let values = Self::from_le_bytes(&col.dtype, &bytes[..value_bytes])?;
+        if !col.nullable {
+            return Ok(values);
+        }
+        let validity_bytes = validity_pack_len(n_rows);
+        let end = value_bytes + validity_bytes;
+        if bytes.len() < end {
+            return Err(Error::Codec(format!(
+                "column '{}': expected {validity_bytes} validity bytes after values, got {}",
+                col.name,
+                bytes.len() - value_bytes
+            )));
+        }
+        let validity = unpack_validity(&bytes[value_bytes..end], n_rows);
+        Ok(ColumnData::Nullable {
+            values: Box::new(values),
+            validity,
+        })
+    }
+
+    /// Build an empty (0-row) [`ColumnData`] matching `col`'s dtype + `nullable` flag — the
+    /// accumulator seed the streaming staging / decode paths append into.
+    pub fn empty_for(col: &Column) -> Result<ColumnData> {
+        let values = empty_column(&col.dtype)?;
+        Ok(if col.nullable {
+            ColumnData::Nullable {
+                values: Box::new(values),
+                validity: Vec::new(),
+            }
+        } else {
+            values
+        })
+    }
+
     /// The `[start, end)` row sub-range of this column — used to slice a table into row-groups.
     pub fn slice(&self, start: usize, end: usize) -> ColumnData {
         macro_rules! sl {
@@ -167,6 +278,10 @@ impl ColumnData {
             ColumnData::U64(v) => sl!(v, U64),
             ColumnData::F32(v) => sl!(v, F32),
             ColumnData::F64(v) => sl!(v, F64),
+            ColumnData::Nullable { values, validity } => ColumnData::Nullable {
+                values: Box::new(values.slice(start, end)),
+                validity: validity[start..end].to_vec(),
+            },
         }
     }
 
@@ -197,22 +312,37 @@ impl ColumnData {
             ColumnData::U64(v) => ext!(v, U64),
             ColumnData::F32(v) => ext!(v, F32),
             ColumnData::F64(v) => ext!(v, F64),
+            ColumnData::Nullable { values, validity } => match other {
+                ColumnData::Nullable {
+                    values: ov,
+                    validity: ovv,
+                } => {
+                    values.extend(ov)?;
+                    validity.extend_from_slice(ovv);
+                }
+                _ => {
+                    return Err(Error::Codec(format!(
+                        "extend: expected nullable {}, got non-nullable {}",
+                        self.numpy_code(),
+                        other.numpy_code()
+                    )))
+                }
+            },
         }
         Ok(())
     }
 
-    /// Bytes per element of the numpy dtype code (`i1`=1 … `f8`=8).
+    /// Bytes per element of the numpy dtype code (`i1`=1 … `f8`=8). Nullable columns still report
+    /// the value-cell width — the trailing validity bitmap is a separate `ceil(rows / 8)` bytes,
+    /// accounted for in the fragment/read paths that consume it.
     pub fn dtype_size(code: &str) -> Result<usize> {
-        Ok(match code {
-            "i1" | "u1" => 1,
-            "i2" | "u2" => 2,
-            "i4" | "u4" | "f4" => 4,
-            "i8" | "u8" | "f8" => 8,
-            other => return Err(Error::Codec(format!("unknown dtype code '{other}'"))),
-        })
+        dtype_size(code)
     }
 
     fn to_vortex(&self) -> ArrayRef {
+        // Non-nullable path: unchanged from pre-#330. Byte-identical PrimitiveArray construction
+        // (`NonNullable` dtype), so a non-null column encodes byte-identical to today — critical
+        // for the conformance corpus + any pre-#330 `.tsra`'s `content_hash`.
         match self {
             ColumnData::I8(v) => Buffer::copy_from(v.as_slice()).into_array(),
             ColumnData::I16(v) => Buffer::copy_from(v.as_slice()).into_array(),
@@ -224,6 +354,101 @@ impl ColumnData {
             ColumnData::U64(v) => Buffer::copy_from(v.as_slice()).into_array(),
             ColumnData::F32(v) => Buffer::copy_from(v.as_slice()).into_array(),
             ColumnData::F64(v) => Buffer::copy_from(v.as_slice()).into_array(),
+            ColumnData::Nullable { values, validity } => {
+                // Nullable path: build a Nullable-dtype PrimitiveArray with Vortex-native
+                // Validity (Arrow validity bitmap) — the sealed representation is the same one
+                // Arrow/DataFusion/Vortex understand end-to-end, not a tessera sentinel.
+                let val = validity_to_vortex(validity);
+                nullable_primitive(values, val)
+            }
+        }
+    }
+}
+
+/// Bytes per element of the numpy dtype code (`i1`=1 … `f8`=8). Free function so
+/// [`ColumnData::from_column_bytes`] and the streaming staging code can call it without going
+/// through the associated fn (which is what public API callers use).
+fn dtype_size(code: &str) -> Result<usize> {
+    Ok(match code {
+        "i1" | "u1" => 1,
+        "i2" | "u2" => 2,
+        "i4" | "u4" | "f4" => 4,
+        "i8" | "u8" | "f8" => 8,
+        other => return Err(Error::Codec(format!("unknown dtype code '{other}'"))),
+    })
+}
+
+/// Pack a boolean validity vector into LSB-first bytes (`ceil(len / 8)` bytes). Mirrors Arrow's
+/// packed-boolean convention so the digest bytes and the fragment bytes agree on the layout.
+fn pack_validity(validity: &[bool]) -> Vec<u8> {
+    let mut out = vec![0u8; validity_pack_len(validity.len())];
+    for (i, &b) in validity.iter().enumerate() {
+        if b {
+            out[i / 8] |= 1u8 << (i % 8);
+        }
+    }
+    out
+}
+
+/// Inverse of [`pack_validity`]: read `n_rows` bits from `bytes` (LSB-first) into a `Vec<bool>`.
+fn unpack_validity(bytes: &[u8], n_rows: usize) -> Vec<bool> {
+    (0..n_rows)
+        .map(|i| (bytes[i / 8] >> (i % 8)) & 1 == 1)
+        .collect()
+}
+
+/// Byte count of a packed validity buffer for `n_rows` rows.
+fn validity_pack_len(n_rows: usize) -> usize {
+    n_rows.div_ceil(8)
+}
+
+/// Turn a `Vec<bool>` validity into the Vortex [`Validity`] enum, collapsing the constant cases
+/// (all-true / all-false) to their compact representations — the sealed bytes then don't carry a
+/// per-row validity buffer when they don't have to. Deterministic in `validity`.
+fn validity_to_vortex(validity: &[bool]) -> Validity {
+    Validity::from(BitBuffer::from_iter(validity.iter().copied()))
+}
+
+/// Build a nullable [`PrimitiveArray`] from an inner [`ColumnData`] variant + a [`Validity`]. One
+/// arm per primitive dtype — the `Nullable` recursive arm is unreachable (validity is on the outer
+/// wrapper, not nested).
+fn nullable_primitive(values: &ColumnData, validity: Validity) -> ArrayRef {
+    match values {
+        ColumnData::I8(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::I16(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::I32(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::I64(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::U8(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::U16(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::U32(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::U64(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::F32(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::F64(v) => {
+            PrimitiveArray::new(Buffer::copy_from(v.as_slice()), validity).into_array()
+        }
+        ColumnData::Nullable { .. } => {
+            // Nested Nullable is a builder-side bug (never emitted by any public constructor); we
+            // panic with a clear message so the diagnostic is obvious in tests rather than
+            // silently corrupting the encoded output.
+            panic!("ColumnData::Nullable inside Nullable — validity is on the outer wrapper")
         }
     }
 }
@@ -272,7 +497,9 @@ fn runtime_session() -> (CurrentThreadRuntime, VortexSession) {
 }
 
 /// Validate that `data` is encodable under `spec`: same column count, names, dtypes, and every
-/// column the same length == `rows`.
+/// column the same length == `rows`. The `nullable` flag on the [`Column`] MUST agree with the
+/// runtime variant — a `nullable: true` spec expects a [`ColumnData::Nullable`] wrapper (and vice
+/// versa), so encode never silently drops or invents nullness.
 fn validate(spec: &TableSpec, data: &TableData) -> Result<()> {
     if data.len() != spec.columns.len() {
         return Err(Error::Codec(format!(
@@ -295,12 +522,30 @@ fn validate(spec: &TableSpec, data: &TableData) -> Result<()> {
                 col.dtype
             )));
         }
+        if col.nullable != cd.is_nullable() {
+            return Err(Error::Codec(format!(
+                "column '{name}': spec nullable={} but data variant nullable={} — nullness \
+                 must be declared on the Column and carried on the ColumnData",
+                col.nullable,
+                cd.is_nullable()
+            )));
+        }
         if cd.len() as u64 != spec.rows {
             return Err(Error::Codec(format!(
                 "column '{name}': {} rows != spec rows {}",
                 cd.len(),
                 spec.rows
             )));
+        }
+        // Nullable invariant: inner values and validity share the same length.
+        if let ColumnData::Nullable { values, validity } = cd {
+            if values.len() != validity.len() {
+                return Err(Error::Codec(format!(
+                    "column '{name}': nullable values.len()={} != validity.len()={}",
+                    values.len(),
+                    validity.len()
+                )));
+            }
         }
     }
     Ok(())
@@ -447,10 +692,13 @@ where
     I::IntoIter: Send + 'static,
 {
     let (rt, s) = runtime_session();
-    // The struct dtype, taken from an empty struct of the declared columns.
+    // The struct dtype, taken from an empty struct of the declared columns. `empty_for(col)`
+    // respects `nullable` so the derived Vortex dtype is Nullable-primitive when needed — the
+    // chunked writer requires every chunk's dtype match the seed's, so a nullable staging seed
+    // is required for a nullable column.
     let mut empty: TableData = Vec::with_capacity(spec.columns.len());
     for c in &spec.columns {
-        empty.push((c.name.clone(), empty_column(&c.dtype)?));
+        empty.push((c.name.clone(), ColumnData::empty_for(c)?));
     }
     let efields: Vec<(&str, ArrayRef)> = empty
         .iter()
@@ -488,7 +736,11 @@ where
 }
 
 /// Append a decoded (canonicalized) Vortex column's values onto the matching output (bit-exact).
-fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
+fn extend_column(
+    col: &mut ColumnData,
+    prim: &PrimitiveArray,
+    ctx: &mut ExecutionCtx,
+) -> Result<()> {
     match col {
         ColumnData::I8(v) => v.extend_from_slice(prim.as_slice::<i8>()),
         ColumnData::I16(v) => v.extend_from_slice(prim.as_slice::<i16>()),
@@ -500,17 +752,39 @@ fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
         ColumnData::U64(v) => v.extend_from_slice(prim.as_slice::<u64>()),
         ColumnData::F32(v) => v.extend_from_slice(prim.as_slice::<f32>()),
         ColumnData::F64(v) => v.extend_from_slice(prim.as_slice::<f64>()),
+        ColumnData::Nullable { values, validity } => {
+            // Values append via the same non-nullable arm (recurse with the wrapper stripped).
+            extend_column(values, prim, ctx)?;
+            // Validity: materialise the primitive's [`Validity`] to a `Mask` and iterate it as
+            // per-row `bool`s. `execute_mask` resolves the `Array` variant (a `Values(...)` mask
+            // needs the execution ctx); the constant variants (`AllTrue` / `AllFalse` / bare
+            // NonNullable / AllValid) short-circuit without touching ctx. That's Vortex's native
+            // validity plumbing — no tessera sentinel, no per-element compute.
+            //
+            // `.validity()` on the vtable path returns `Result<Validity>` (validity live-decoded
+            // from the array's children); the `?` propagates a Vortex error as a tessera `Codec`
+            // error via `map_err(ze)`.
+            let mask = prim
+                .validity()
+                .map_err(ze)?
+                .execute_mask(prim.len(), ctx)
+                .map_err(ze)?;
+            validity.extend(mask.iter());
+        }
     }
+    Ok(())
 }
 
-/// Decode the whole table from a block payload (inverse of [`encode`]).
+/// Decode the whole table from a block payload (inverse of [`encode`]). The accumulator seed
+/// respects each [`Column`]'s `nullable` flag so a nullable column decodes back into a
+/// [`ColumnData::Nullable`] wrapper carrying the round-tripped validity bitmap.
 pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
     let (rt, s) = runtime_session();
     // Accumulators, one per declared column (column order == struct field order on write).
     let mut cols: Vec<ColumnData> = spec
         .columns
         .iter()
-        .map(|c| empty_column(&c.dtype))
+        .map(ColumnData::empty_for)
         .collect::<Result<_>>()?;
 
     let mut ctx = s.create_execution_ctx();
@@ -529,7 +803,7 @@ pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
             for (i, col) in cols.iter_mut().enumerate() {
                 let prim: PrimitiveArray =
                     st.unmasked_field(i).clone().execute(&mut ctx).map_err(ze)?;
-                extend_column(col, &prim);
+                extend_column(col, &prim, &mut ctx)?;
             }
         }
         Ok::<(), Error>(())
@@ -554,7 +828,7 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
         .find(|c| c.name == name)
         .ok_or_else(|| Error::Codec(format!("table has no column '{name}'")))?;
     let (rt, s) = runtime_session();
-    let mut out = empty_column(&col.dtype)?;
+    let mut out = ColumnData::empty_for(col)?;
     let mut ctx = s.create_execution_ctx();
     rt.block_on(async {
         let stream = s
@@ -571,7 +845,7 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
             let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
             let prim: PrimitiveArray =
                 st.unmasked_field(0).clone().execute(&mut ctx).map_err(ze)?;
-            extend_column(&mut out, &prim);
+            extend_column(&mut out, &prim, &mut ctx)?;
         }
         Ok::<(), Error>(())
     })?;
@@ -1021,6 +1295,251 @@ mod tests {
         assert_eq!(block_name("events", 0, 2), "events_0000");
         assert_eq!(block_name("events", 7, 8), "events_0007");
         assert_eq!(block_name("events", 1234, 9999), "events_1234");
+    }
+
+    // ── #330 Nullable columns ───────────────────────────────────────────────────────
+
+    fn nullable_col(name: &str, dtype: &str) -> Column {
+        Column {
+            name: name.into(),
+            dtype: dtype.into(),
+            nullable: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn nullable_column_round_trips_through_encode_decode() {
+        // #330 core invariant: a nullable column serialises through the Vortex encoder + Arrow
+        // validity bitmap and decodes back with values + null pattern preserved bit-exact.
+        let rows = ROWS_PER_GROUP + 137; // spans a row-group boundary — checks per-chunk validity
+        let mut values: Vec<i16> = (0..rows).map(|k| (k as i16).wrapping_mul(7)).collect();
+        // Sprinkle nulls in a deterministic-but-non-trivial pattern (every 13th row + rows 0/1/last).
+        let mut validity: Vec<bool> = (0..rows).map(|k| k % 13 != 0).collect();
+        validity[0] = false;
+        validity[1] = true;
+        *validity.last_mut().unwrap() = false;
+        // Rows marked NULL carry a deterministic placeholder (0) so encode is a pure function of
+        // input — required for determinism (the release-gate invariant).
+        for (i, ok) in validity.iter().enumerate() {
+            if !ok {
+                values[i] = 0;
+            }
+        }
+
+        let spec = TableSpec {
+            columns: vec![
+                Column::new("t", "u8"),
+                nullable_col("lt_corr", "i2")
+                    .with_unit("ns")
+                    .with_scale(0.001),
+            ],
+            rows: rows as u64,
+            row_index: Some("t".into()),
+        };
+        let data: TableData = vec![
+            ("t".into(), ColumnData::U64((0..rows as u64).collect())),
+            (
+                "lt_corr".into(),
+                ColumnData::Nullable {
+                    values: Box::new(ColumnData::I16(values.clone())),
+                    validity: validity.clone(),
+                },
+            ),
+        ];
+
+        // Round-trip: values + validity preserved end-to-end.
+        let blob = encode(&spec, &data).unwrap();
+        let back = decode(&spec, &blob).unwrap();
+        assert_eq!(back, data, "nullable round-trip lost values/validity");
+
+        // Determinism: same input → same bytes (the release gate — Vortex writer + our validity
+        // packing are both deterministic on this path).
+        assert_eq!(
+            encode(&spec, &data).unwrap(),
+            blob,
+            "nullable encode non-deterministic"
+        );
+
+        // Projection reads only that column and returns the same nullable structure.
+        let projected = decode_column(&spec, &blob, "lt_corr").unwrap();
+        assert_eq!(projected, data[1].1);
+    }
+
+    #[test]
+    fn no_null_column_encodes_byte_identical_to_pre_330_path() {
+        // Back-compat: a spec whose columns all set `nullable: false` (or leave it unset — same
+        // thing) MUST produce the same bytes it did before #330. That guarantees the conformance
+        // corpus + every pre-#330 `.tsra` keeps its content_hash. The path check: a Column with
+        // `nullable` default false serialises to JSON without the `nullable` key, and the encode
+        // produces exactly the pre-#330 (NonNullable primitive) Vortex bytes.
+
+        let (spec, data) = all_dtype_table(257);
+        // Confirm the schema is byte-identical to what it was pre-#330 (no `nullable` key).
+        for c in &spec.columns {
+            let v = serde_json::to_value(c).unwrap();
+            let obj = v.as_object().unwrap();
+            assert!(
+                !obj.contains_key("nullable"),
+                "column '{}' emitted `nullable` key — corpus/hash regression",
+                c.name
+            );
+        }
+        // The bytes themselves are what the pre-#330 test `roundtrip_every_dtype_and_deterministic`
+        // covered. Re-encode + verify the payload roundtrips (idempotent) and that no column ends
+        // up in the Nullable variant on decode.
+        let blob = encode(&spec, &data).unwrap();
+        let back = decode(&spec, &blob).unwrap();
+        for (name, cd) in &back {
+            assert!(
+                !cd.is_nullable(),
+                "column '{name}' decoded as Nullable but spec is nullable=false"
+            );
+        }
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn digest_bytes_change_when_nullness_changes_but_values_match() {
+        // The row-group content digest ([`table_chunk_index`]) folds `to_le_bytes` — so the
+        // validity bitmap is part of the digest. Two columns with the same values but different
+        // null pattern MUST produce different `to_le_bytes`; otherwise the sub-block MMR would
+        // conflate distinct logical columns.
+        let values = ColumnData::I16(vec![10, 20, 30, 40]);
+        let a = ColumnData::Nullable {
+            values: Box::new(values.clone()),
+            validity: vec![true, true, true, true],
+        };
+        let b = ColumnData::Nullable {
+            values: Box::new(values.clone()),
+            validity: vec![true, false, true, true],
+        };
+        assert_ne!(
+            a.to_le_bytes(),
+            b.to_le_bytes(),
+            "validity MUST participate in the digest bytes"
+        );
+        // …and a nullable-all-valid column's `to_le_bytes` is NOT identical to the plain
+        // non-null column's (nullability IS a distinct logical property, encoded in the digest).
+        assert_ne!(
+            a.to_le_bytes(),
+            values.to_le_bytes(),
+            "nullable-all-valid MUST digest differently than the non-null variant"
+        );
+    }
+
+    #[test]
+    fn nullable_streaming_matches_batch_encode() {
+        // Streaming a nullable column row-group at a time produces the same bytes as the batch
+        // encoder — one encoder, streaming == batch (the SSoT proof for #330 too).
+        let rows = ROWS_PER_GROUP + 4321;
+        let mut values: Vec<i16> = (0..rows).map(|k| (k as i16).wrapping_mul(3)).collect();
+        let validity: Vec<bool> = (0..rows).map(|k| k % 7 != 3).collect();
+        for (i, ok) in validity.iter().enumerate() {
+            if !ok {
+                values[i] = 0;
+            }
+        }
+
+        let spec = TableSpec {
+            columns: vec![Column::new("t", "u8"), nullable_col("v", "i2")],
+            rows: rows as u64,
+            row_index: Some("t".into()),
+        };
+        let full: TableData = vec![
+            ("t".into(), ColumnData::U64((0..rows as u64).collect())),
+            (
+                "v".into(),
+                ColumnData::Nullable {
+                    values: Box::new(ColumnData::I16(values.clone())),
+                    validity: validity.clone(),
+                },
+            ),
+        ];
+        let n = rows.div_ceil(ROWS_PER_GROUP);
+        let groups: Vec<TableData> = (0..n)
+            .map(|g| {
+                let (st, en) = (g * ROWS_PER_GROUP, ((g + 1) * ROWS_PER_GROUP).min(rows));
+                full.iter()
+                    .map(|(name, c)| (name.clone(), c.slice(st, en)))
+                    .collect()
+            })
+            .collect();
+        let streamed = encode_streaming(&spec, groups).unwrap();
+        let batch = encode(&spec, &full).unwrap();
+        assert_eq!(streamed, batch, "streaming nullable != batch nullable");
+        assert_eq!(decode(&spec, &streamed).unwrap(), full);
+    }
+
+    #[test]
+    fn validate_rejects_nullability_mismatch() {
+        // Spec says nullable, but data provides a plain (non-Nullable) variant → typed error.
+        let spec = TableSpec {
+            columns: vec![nullable_col("v", "i2")],
+            rows: 3,
+            row_index: None,
+        };
+        let bad: TableData = vec![("v".into(), ColumnData::I16(vec![1, 2, 3]))];
+        assert!(matches!(encode(&spec, &bad), Err(Error::Codec(_))));
+
+        // Reverse: spec says non-null, data provides Nullable.
+        let spec2 = TableSpec {
+            columns: vec![col("v", "i2")],
+            rows: 3,
+            row_index: None,
+        };
+        let bad2: TableData = vec![(
+            "v".into(),
+            ColumnData::Nullable {
+                values: Box::new(ColumnData::I16(vec![1, 2, 3])),
+                validity: vec![true; 3],
+            },
+        )];
+        assert!(matches!(encode(&spec2, &bad2), Err(Error::Codec(_))));
+    }
+
+    #[test]
+    fn nullable_column_bytes_round_trip() {
+        // The staging fragment format serializes column bytes via `to_le_bytes` and reads them
+        // back via `from_column_bytes` — check the pair round-trips for a nullable column.
+        let col = nullable_col("v", "i2");
+        let cd = ColumnData::Nullable {
+            values: Box::new(ColumnData::I16(vec![10, 0, 30, 0, 50])),
+            validity: vec![true, false, true, false, true],
+        };
+        let bytes = cd.to_le_bytes();
+        let back = ColumnData::from_column_bytes(&col, &bytes, 5).unwrap();
+        assert_eq!(back, cd);
+
+        // A non-null Column with the same underlying values decodes as the non-Nullable variant.
+        let plain_col = Column {
+            name: "v".into(),
+            dtype: "i2".into(),
+            ..Default::default()
+        };
+        let plain = ColumnData::I16(vec![10, 20, 30]);
+        let plain_bytes = plain.to_le_bytes();
+        let plain_back = ColumnData::from_column_bytes(&plain_col, &plain_bytes, 3).unwrap();
+        assert_eq!(plain_back, plain);
+    }
+
+    #[test]
+    fn nullable_as_i64_skips_nulls_for_stats() {
+        // Nullable integer columns feed stats (min/max) from valid rows only — nulls don't
+        // contribute to the pruning range, matching SQL aggregate semantics.
+        let cd = ColumnData::Nullable {
+            values: Box::new(ColumnData::I16(vec![-3, 0, 7, 0, 42])),
+            validity: vec![true, false, true, false, true],
+        };
+        assert_eq!(cd.as_i64(), Some(vec![-3, 7, 42]));
+
+        // A Nullable-around-float column still returns None (floats need canonicalisation, per
+        // ADR-0024) — nullability doesn't change that.
+        let cd_f = ColumnData::Nullable {
+            values: Box::new(ColumnData::F32(vec![1.0, 0.0, 2.0])),
+            validity: vec![true, false, true],
+        };
+        assert_eq!(cd_f.as_i64(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #330 — adds nullable table columns backed by an Arrow/Vortex validity bitmap, so a mostly-finite float column with occasional NaN (e.g. GE listmode `events_3p.lt_corr`, 0.7% NaN) can seal as a **nullable int16** (NaN → NULL, finite → int16 at physical resolution) instead of forcing the whole column back to `f4` to carry the NaNs.

Wired to #310 (int16 quantize) and #307 (column annotation).

## Design

**Wrapper** (not per-variant `Option<BitVec>`):
```rust
pub enum ColumnData {
    I8(Vec<i8>), … F64(Vec<f64>),
    Nullable { values: Box<ColumnData>, validity: Vec<bool> },
}
```
+ a per-column `Column.nullable: bool` marker (`#[serde(default, skip_serializing_if = is_false)]`).

Why wrapper:
- Every existing dtype method transparently forwards through it (one recursive arm per method — no `dtype × nullability` cross-product).
- Vortex validity plugs in exactly once — `to_vortex`/`extend_column` — via `PrimitiveArray::new(buf, Validity::from(BitBuffer))`; on decode, `prim.validity().execute_mask(len, ctx).iter()` yields the per-row bools.
- The sealed representation IS the Arrow validity bitmap, not a tessera sentinel.

## Back-compat (release-gate invariant)

`Column.nullable` skips serialisation when false, so an unannotated column serialises to exactly the pre-#330 shape. A non-null column encodes byte-identical to today's `NonNullable`-primitive Vortex bytes — the conformance corpus, every pre-#330 `.tsra`, and every `content_hash` stay untouched. Guarded by `no_null_column_encodes_byte_identical_to_pre_330_path`.

## Determinism

- Nullable columns store `0` as a deterministic placeholder at null slots (never observed — validity says NULL) — encode is a pure function of input.
- `to_le_bytes` appends the packed validity bitmap after the values, so the ADR-0028 §3 chunk-index digest folds both. Different null patterns → different digests. Guarded by `digest_bytes_change_when_nullness_changes_but_values_match`.
- Streaming == batch on the nullable path (`nullable_streaming_matches_batch_encode`).

## Ingest

`apply_geddf_dictionary` (tessera-ingest/src/ge_hdf5.rs): a float column with any non-finite value now becomes a nullable int16 (NaN → NULL, validity = `is_finite`, finite → int16 quantized) instead of the pre-#330 skip-and-stay-float path. Fully-finite float columns still take the non-nullable int16 path — byte-identical to today, no corpus regen.

## Read surface

- `tessera sql` (DataFusion): Arrow arrays built via `from_iter(Option<T>)` + schema `Field.nullable = col.nullable`, so `WHERE lt_corr IS NULL`, `AVG(lt_corr)`, `COUNT(lt_corr)` follow SQL-standard null semantics out of the box. Guarded by `sql_over_nullable_column_honours_null_semantics`.
- `tessera read` JSON/ndjson: NULL rows surface as `Value::Null`. CSV keeps today's `nan` cell (consistent with how it already renders non-finite floats). Ideal "empty CSV cell for NULL vs `nan` for finite-NaN" is a follow-up upgrade.

## Tests

All added and passing:

**tessera-io/src/table.rs**
- `nullable_column_round_trips_through_encode_decode` — values + validity survive encode → decode bit-exact, deterministic re-encode, projection reads the same nullable structure.
- `no_null_column_encodes_byte_identical_to_pre_330_path` — back-compat (no `nullable` key; decode never invents Nullable).
- `digest_bytes_change_when_nullness_changes_but_values_match` — validity is part of the digest.
- `nullable_streaming_matches_batch_encode` — streaming == batch.
- `validate_rejects_nullability_mismatch` — spec/data nullability must agree.
- `nullable_column_bytes_round_trip` — staging fragment format.
- `nullable_as_i64_skips_nulls_for_stats` — chunk stats over valid rows only.

**tessera-io/src/multiblock.rs**
- `nullable_column_round_trips_through_sealed_multi_block_container` — full write-session + multi-block partition + Reader roundtrip.

**tessera-ingest/src/ge_hdf5.rs**
- `quantize_partial_nan_float_becomes_nullable_int16` — the DUPLET `lt_corr` case: NaN rows null, finite quantized.

**tessera-core/src/block/table.rs**
- `nullable_flag_round_trips_and_skips_when_false` — spec serialisation.

**tessera-cli/src/sql.rs**
- `sql_over_nullable_column_honours_null_semantics` — `IS NULL` / `AVG` / `COUNT` end-to-end.

Additionally fixes a pre-existing key-order-sensitive test in `tessera-core::block::table::bare_column_skips_annotation_fields_on_serialize` (was failing on `origin/spike/tessera-core` too — `serde_json::Map` iterates alphabetically without `preserve_order`).

## Gates

- `cargo test -p tessera-io -p tessera-ingest -p tessera-core --lib` → 281 tests, all pass.
- `cargo test -p tessera-cli --bin tessera --features sql` → 47 tests, all pass.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- prek pre-commit gates all green (branch-name, typos, no-fake-impl, no-debug-leftovers, no-commented-code, rustfmt, clippy).

## Follow-ups (not in this PR)

- Empty CSV cell for NULL rows (distinct from `nan` for finite-NaN floats) — spec upgrade, not a regression.
- Python API for constructing nullable columns from `tessera-py` (today's public API takes `(name, code, bytes)` tuples — non-null only).
- Sparse (ADR-0031) integration — the *other* missing-data axis; deferred (#330 is dense-with-holes; sparse is mostly-empty).

## Test plan

- [x] `cargo test -p tessera-io --lib` (122 pass, incl. 8 new nullable tests)
- [x] `cargo test -p tessera-ingest --lib` (46 pass, incl. new NaN → nullable int16)
- [x] `cargo test -p tessera-core --lib` (113 pass)
- [x] `cargo test -p tessera-cli --bin tessera --features sql` (47 pass, incl. new SQL nullable test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Conformance corpus unchanged (no-null path guarded byte-identical)
