### PR TITLE
fix(ingest): dataset_group resolves nested HDF5 paths — GEDDF annotate/quantize was silently no-op (#331)

### DIFF
--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -463,12 +463,17 @@ fn geddf_dict() -> &'static GeDict {
 /// Map an HDF5 dataset name (or block prefix) to its dictionary group: `events_2p`/`events_3p` →
 /// `events`, `coin_2p`/`coin_3p` → `coin`, else the name itself (`singles`, `time_markers`, …).
 fn dataset_group(name: &str) -> &str {
-    if name.starts_with("events") {
+    // Accept either a bare dataset name (`events_3p`) or a full HDF5 path (`/proc_data/events_3p`) —
+    // the GEDDF dictionary is keyed on the leaf group, so a spec that passes the nested path (as real
+    // DUPLET specs do) must still resolve. Without the leaf-strip the annotation/quantize silently
+    // no-op'd on every path-qualified dataset.
+    let leaf = name.rsplit('/').next().unwrap_or(name);
+    if leaf.starts_with("events") {
         "events"
-    } else if name.starts_with("coin_2p") || name.starts_with("coin_3p") || name == "coin" {
+    } else if leaf.starts_with("coin_2p") || leaf.starts_with("coin_3p") || leaf == "coin" {
         "coin"
     } else {
-        name
+        leaf
     }
 }
 
@@ -974,6 +979,11 @@ mod tests {
         assert_eq!(dataset_group("coin_2p"), "coin");
         assert_eq!(dataset_group("singles"), "singles");
         assert_eq!(dataset_group("time_markers"), "time_markers");
+        // Full HDF5 paths (what real DUPLET specs pass) resolve on the leaf, not the whole path.
+        assert_eq!(dataset_group("/proc_data/events_3p"), "events");
+        assert_eq!(dataset_group("/proc_data/coin_2p"), "coin");
+        assert_eq!(dataset_group("/raw_data/singles"), "singles");
+        assert_eq!(dataset_group("/raw_data/time_markers"), "time_markers");
     }
 
     #[test]

--- a/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
+++ b/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
@@ -159,7 +159,7 @@ quantize_dtype = "i2"
 
 [events.lt_corr]
 short_name = "lt_corr"
-description = "Positronium lifetime, corrected (TOF/geometry). Sparse — NaN for most events."
+description = "Positronium lifetime, corrected (TOF/geometry). ~0.7% NaN (correction not computed for this event) → NULL (nullable int16, #330); the rest quantize."
 dtype = "f4"
 unit = "ns"
 vocabulary = "MorePET"


### PR DESCRIPTION
The GEDDF annotation + int16 quantization (#307/#310) **silently no-op'd** on any path-qualified dataset. `dataset_group` matched `name.starts_with("events")`, but real specs pass the full HDF5 path `/proc_data/events_3p` → no group matched → columns stayed bare `f4`, no units, no int16.

## Fix
Strip to the leaf name before matching (`/proc_data/events_3p` → `events`).

## Verified end-to-end on real DP01 data
Re-ingesting `events_3p` with `quantize=true` now yields (chaining #310 + #330):
- `en_0/1/2` → `i2 · keV · ×0.1`, `vtx_0/1/2` → `i2 · mm · ×0.0125`, `lt` → `i2 · ns · ×0.001` — quantized + annotated.
- `lt_corr` (0.7% NaN) → **nullable `i2`** (NaN→NULL, #330).
- `ms`/`dt`/`ax`/`tx` → integer, annotated (`ax`="crystal axial index", `tx`="crystal trans-axial index").
- Size: **373 MB → 203 MB (1.84×)**, physically lossless.

Also corrects the dictionary's `lt_corr` description (0.7% NaN, not "most").

Refs: #331, #310, #330, #307