### PR TITLE
fix(core): decouple sealed producer from the crate version (ADR-0052 C→A)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,14 +1,18 @@
-# Opens/updates a HELD release PR (workspace version bump + CHANGELOG) on pushes to `dev` — ADR-0052.
-# It does NOT tag or publish; `0.1.0-alpha.1` is cut only by deliberately merging that release PR.
+# Opens/updates a HELD release PR (workspace version bump + CHANGELOG) — ADR-0052. It does NOT tag or
+# publish; the alpha is cut only by deliberately merging that release PR.
+#
+# TRIGGER = manual (workflow_dispatch) while the release is *held*: the crates are `0.0.0` with no
+# published/tagged baseline, so release-plz cannot determine a next version yet ("first-release
+# bootstrap"). Run this manually once the workspace version is bootstrapped to `0.1.0-alpha.1` — the
+# `producer` is now decoupled from the crate version (ADR-0052), so that bump costs no corpus regen.
+# Switch back to `push: [dev]` after the first release, when auto-updating the PR is useful.
 #
 # NOTE: for GITHUB_TOKEN to open the PR, enable Settings → Actions → "Allow GitHub Actions to create and
 # approve pull requests", or add a PAT as secrets.RELEASE_PLZ_TOKEN (used first when present).
 name: release-plz
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - dev
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/docs/adr/0052-versioning-and-release.md
+++ b/docs/adr/0052-versioning-and-release.md
@@ -59,6 +59,20 @@ dev → main                    (distribution: main flips to the tagged release)
 - The Python-template `release.yml` is superseded by `release-plz.yml` (kept or removed separately).
 - Registry publishes stay off until credentials + `publish`-scoping are set — a deliberate, separate step.
 
+## Update (2026-07-03) — producer decoupled from the crate version; trigger held
+
+The first release-plz runs surfaced that the sealed `Manifest.producer` embedded `CARGO_PKG_VERSION`
+(`product.rs`), so *any* crate version bump changed every `manifest_hash` → a full conformance-corpus
+regen per release. **Fixed (C):** the sealed `producer` now stamps the **format** version
+(`TESSERA_VERSION`), not the crate version — byte-identical today (both `0.0.0` → **no regen**), but a
+future crate bump no longer touches the seal. The build/software version stays in the non-sealed
+`aux/provenance.json` (ADR-0042). Software SemVer and format identity are now truly independent.
+
+**Release held (A):** the workflow trigger is `workflow_dispatch` (manual) while the crates are `0.0.0`
+with no baseline (release-plz can't determine a next version pre-first-release). To cut `0.1.0-alpha.1`:
+bootstrap the workspace version (now regen-free), then dispatch release-plz → it opens the held release
+PR. Switch the trigger back to `push: [dev]` after the first release for auto-updating PRs.
+
 ## References
 
 RFC §14 (semver policy / format supersession) · PR #322 (Tessera→dev graduation) · `release-plz.toml`

--- a/tessera/crates/tessera-core/src/product.rs
+++ b/tessera/crates/tessera-core/src/product.rs
@@ -138,11 +138,13 @@ impl ProductBuilder {
                 self.manifest.schema = Some(s.to_value()?);
             }
         }
-        // Sealed provenance: stamp the producing tool/build so a reader knows what wrote the file.
-        // Re-stamped per version (not inherited) — a new version is sealed by *this* tool.
+        // Sealed provenance: stamp the **format version** that wrote the file — identity-relevant and
+        // stable across software/crate version bumps (ADR-0052). The build-tool/*software* version is
+        // non-sealed provenance and lives in `aux/provenance.json` (ADR-0042), so a `cargo` version
+        // bump never changes the seal or forces a conformance-corpus regen. (`TESSERA_VERSION` only
+        // changes on a *deliberate* format revision — where a regen is expected.)
         if self.manifest.producer.is_none() {
-            self.manifest.producer =
-                Some(concat!("tessera/", env!("CARGO_PKG_VERSION")).to_string());
+            self.manifest.producer = Some(format!("tessera/{}", crate::manifest::TESSERA_VERSION));
         }
         // The seal is computed last, over the manifest with `manifest_hash` excluded, so it
         // transitively commits to id_inputs, sources, the producer, the embedded schema, and blocks.


### PR DESCRIPTION
## What

Decouples the sealed `Manifest.producer` from the crate version, and holds the release trigger — implementing the **C→A** resolution of ADR-0052.

### C — decouple producer from crate version
`ProductBuilder::seal()` stamped `producer = "tessera/" + env!("CARGO_PKG_VERSION")` **into the sealed manifest**, so *any* crate version bump changed every `manifest_hash` → a full conformance-corpus regen per release. This is exactly why release-plz couldn't bootstrap a version and why the crates were pinned at `0.0.0`.

Now the sealed producer stamps the **format** version (`crate::manifest::TESSERA_VERSION`), not the crate version:
- **Byte-identical today** — both are `"0.0.0"`, so `"tessera/0.0.0"` is unchanged → **no corpus regen** (verified: all 3 conformance tests pass, `corpus_hashes_match_goldens` + `committed_corpus_files_reproduce_goldens` green).
- A future crate/software bump no longer touches the seal.
- The build/*software* version stays in the non-sealed `aux/provenance.json` (ADR-0042).

Software SemVer and format identity are now truly independent axes.

### A — hold the release
`release-plz.yml` trigger → `workflow_dispatch` (manual). The crates are `0.0.0` with no published/tagged baseline, so release-plz can't determine a next version yet. To cut `0.1.0-alpha.1`: bootstrap the workspace version (now regen-free) + dispatch release-plz. Switch back to `push: [dev]` after the first release.

## Validation
`cargo test -p tessera-io --test conformance` → **3 passed, 0 failed**. No fixture drifted from its golden id/content_hash/manifest_hash.

Refs: #331 · ADR-0052