### PR TITLE
chore(release): bootstrap workspace version 0.0.0 → 0.1.0-alpha.1

### DIFF
--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -6095,7 +6095,7 @@ checksum = "d4d1330fe7f7f872cd05165130b10602d667b205fd85be09be2814b115d4ced9"
 
 [[package]]
 name = "tessera-cli"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "arrow",
  "clap",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "tessera-core"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "blake3",
  "ed25519-dalek",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "tessera-ingest"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "dicom",
  "dicom-transfer-syntax-registry",
@@ -6150,7 +6150,7 @@ dependencies = [
 
 [[package]]
 name = "tessera-io"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "tessera-py"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "tessera-wasm"
-version = "0.0.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "serde_json",
  "tessera-core",

--- a/tessera/Cargo.toml
+++ b/tessera/Cargo.toml
@@ -5,7 +5,10 @@ members = ["crates/tessera-core", "crates/tessera-io", "crates/tessera-cli", "cr
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-version = "0.0.0"
+# Software SemVer (crates/CLI/bindings) — independent of the format-spec version `tessera_version`,
+# which stays `v0`/pre-1.0 (ADR-0052 §1). The sealed producer stamps TESSERA_VERSION, not this, so a
+# software bump costs no conformance-corpus regen (#336). Bootstrap baseline for release-plz (#337).
+version = "0.1.0-alpha.1"
 repository = "https://github.com/vig-os/tessera"
 authors = ["vig-os"]
 


### PR DESCRIPTION
Step 1 of the release cutover (#337): bootstraps the software SemVer baseline so release-plz can determine a next version. It cannot bootstrap a first release from `0.0.0` with no tag.

## Change
- `[workspace.package] version` `0.0.0` → `0.1.0-alpha.1` (all 6 crates inherit via `version.workspace`).
- `Cargo.lock` refreshed to match.

## Regen-free by construction
The sealed `producer` stamps `TESSERA_VERSION` (format), not the crate version (#336), so this bump touches **no** `manifest_hash`. Verified: `cargo test -p tessera-io --test conformance` → **3/3 pass, corpus unchanged**. The non-sealed runtime reporters (`tessera-py.__version__`, `tessera-wasm.version()`) correctly follow the new crate version.

## Version axes (ADR-0052 §1)
This is the **software** version. The **format-spec** version `tessera_version` stays `v0` / pre-1.0 and is deliberately unfrozen — a software alpha does not imply a stable format.

The rest of the cutover (enable Actions-PRs / token, dispatch release-plz, publish credentials, flip `main`) is tracked in #337 and is owner/credential-gated.

Refs: #337 · ADR-0052 · #336