### PR TITLE
fix(cli): collection verify/ls resolve members by the sanitized name (#323)

### DIFF
--- a/tessera/crates/tessera-cli/src/collection.rs
+++ b/tessera/crates/tessera-cli/src/collection.rs
@@ -14,7 +14,9 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use tessera_core::collection::{Collection, CollectionBuilder, MemberKind, ProductHandle, Role};
+use tessera_core::collection::{
+    member_filename, Collection, CollectionBuilder, MemberKind, ProductHandle, Role,
+};
 use tessera_core::{Error, Result};
 use tessera_io::Reader;
 
@@ -43,15 +45,11 @@ fn load(file: &Path) -> Result<Collection> {
     Collection::from_json(&std::fs::read_to_string(file)?)
 }
 
-/// The on-disk path of a member next to the `collection.json` — resolved by `kind` (ADR-0049 §4): a
-/// product is `<reference>.tsra`, a sub-collection is `<reference>.collection.json`.
+/// The on-disk path of a member next to the `collection.json` — resolved by `kind` (ADR-0049 §4) via
+/// the shared [`member_filename`] SSoT (so the resolved name matches what every writer emits, #323).
 fn member_path(collection_file: &Path, reference: &str, kind: MemberKind) -> PathBuf {
     let dir = collection_file.parent().unwrap_or_else(|| Path::new("."));
-    if kind == MemberKind::Collection {
-        dir.join(format!("{reference}.collection.json"))
-    } else {
-        dir.join(format!("{reference}.tsra"))
-    }
+    dir.join(member_filename(reference, kind))
 }
 
 fn w(out: &mut dyn Write, args: std::fmt::Arguments<'_>) -> Result<()> {
@@ -296,13 +294,14 @@ pub fn new(
     // `project` would reject them — fail-fast before writing anything).
     let sealed = cb.seal()?;
 
-    // Write the self-contained collection dir: collection.json + each member as `<id>.tsra`.
+    // Write the self-contained collection dir: collection.json + each member under the shared
+    // `member_filename` (sanitized `<stem>.tsra`), the same name `verify`/`ls` resolve (#323).
     std::fs::create_dir_all(out)?;
     std::fs::write(out.join("collection.json"), sealed.to_json()?)?;
     for (h, src) in &handles {
-        let dst = out.join(format!("{}.tsra", h.reference()));
+        let dst = out.join(member_filename(h.reference(), MemberKind::Product));
         if src.canonicalize().ok() == dst.canonicalize().ok() {
-            continue; // member already in place as <id>.tsra
+            continue; // member already in place
         }
         let _ = std::fs::remove_file(&dst);
         // Hard-link when same-filesystem (no data copy); fall back to a full copy across mounts.
@@ -345,7 +344,7 @@ mod tests {
             pack(
                 &sealed,
                 &[payload],
-                &dir.join(format!("{}.tsra", sealed.id)),
+                &dir.join(member_filename(&sealed.id, MemberKind::Product)),
             )
             .unwrap();
             cb.add_member(
@@ -391,7 +390,11 @@ mod tests {
             .contains("verified (2 members, recursive)"));
 
         // Remove a member file → verify fails loudly (missing member).
-        std::fs::remove_file(dir.path().join(format!("{}.tsra", c.members[0].reference))).unwrap();
+        std::fs::remove_file(dir.path().join(member_filename(
+            &c.members[0].reference,
+            MemberKind::Product,
+        )))
+        .unwrap();
         assert!(verify(&cf, &mut Vec::new()).is_err());
     }
 
@@ -409,7 +412,7 @@ mod tests {
             pack(
                 &sealed,
                 &[payload],
-                &dir.join(format!("{}.tsra", sealed.id)),
+                &dir.join(member_filename(&sealed.id, MemberKind::Product)),
             )
             .unwrap();
             cb.add_member(
@@ -421,7 +424,7 @@ mod tests {
         }
         let c = cb.seal().unwrap();
         std::fs::write(
-            dir.join(format!("{}.collection.json", c.id)),
+            dir.join(member_filename(&c.id, MemberKind::Collection)),
             c.to_json().unwrap(),
         )
         .unwrap();
@@ -470,10 +473,10 @@ mod tests {
         assert!(s.contains("recursive") && s.contains("3 members"), "{s}");
 
         // Tamper a grandchild product `.tsra` → the recursive verify catches it transitively.
-        std::fs::remove_file(
-            dir.path()
-                .join(format!("{}.tsra", child.members[0].reference)),
-        )
+        std::fs::remove_file(dir.path().join(member_filename(
+            &child.members[0].reference,
+            MemberKind::Product,
+        )))
         .unwrap();
         assert!(verify(&pf, &mut Vec::new()).is_err());
     }
@@ -513,6 +516,21 @@ mod tests {
 
         let cf = out.join("collection.json");
         assert!(cf.exists(), "collection.json written");
+        // #323: each member lands under the sanitized stem (`blake3_….tsra`), NOT the raw
+        // colon-bearing reference — and that is exactly the name `verify` resolves.
+        let c = load(&cf).unwrap();
+        for m in &c.members {
+            assert!(m.reference.contains(':'), "a real blake3 id has a colon");
+            assert!(
+                out.join(member_filename(&m.reference, MemberKind::Product))
+                    .exists(),
+                "member resolves under the sanitized stem"
+            );
+            assert!(
+                !out.join(format!("{}.tsra", m.reference)).exists(),
+                "the raw colon-named file must NOT be the on-disk name (the #323 mismatch)"
+            );
+        }
         // The assembled collection is self-contained + passes recursive verify.
         verify(&cf, &mut Vec::new()).unwrap();
         let mut buf = Vec::new();

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
+use tessera_core::collection::{member_filename, MemberKind};
 use tessera_core::SchemaRegistry;
 use tessera_ingest::{engine, spec as ingest_spec};
 use tessera_io::{pack_dir, parse_byte_size, unpack, Reader, WriteConfig};
@@ -1568,13 +1569,14 @@ fn run_ingest(src: IngestSrc) -> tessera_core::Result<()> {
         &cfg,
         engine::DEFAULT_STREAM_THRESHOLD_BYTES,
     )?;
-    // Move the single produced `.tsra` to the user's `out` path. The engine names files by
-    // sanitized id (`blake3_<hex>.tsra`); we read that name back out of the sealed collection.
+    // Move the single produced `.tsra` to the user's `out` path. The engine names files by the
+    // shared `member_filename` SSoT (`blake3_<hex>.tsra`); resolve that same name here (#323).
     let member = coll.members.first().ok_or_else(|| {
         tessera_core::Error::Invalid("tessera ingest: engine produced no member".into())
     })?;
-    let sanitized = member.reference.replace([':', '/', '\\'], "_");
-    let from = staging.path().join(format!("{sanitized}.tsra"));
+    let from = staging
+        .path()
+        .join(member_filename(&member.reference, MemberKind::Product));
     if let Some(parent) = user_out.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -1801,8 +1803,11 @@ fn run_ingest_spec(opts: IngestSpecOpts) -> tessera_core::Result<()> {
         out_dir.display()
     );
     for m in &coll.members {
-        let sanitized = m.reference.replace([':', '/', '\\'], "_");
-        println!("  - {} -> {sanitized}.tsra", m.reference);
+        println!(
+            "  - {} -> {}",
+            m.reference,
+            member_filename(&m.reference, MemberKind::Product)
+        );
     }
     Ok(())
 }
@@ -2039,7 +2044,7 @@ streaming = "batch"
 
         // 2. every member's .tsra exists + verifies + carries the expected spec edge.
         for m in &coll.members {
-            let p = out_dir.join(format!("{}.tsra", m.reference.replace([':', '/'], "_")));
+            let p = out_dir.join(member_filename(&m.reference, MemberKind::Product));
             assert!(p.exists(), "missing {}", p.display());
             run(Cmd::Verify { file: p.clone() }).unwrap();
             let r = Reader::open(&p).unwrap();
@@ -2050,11 +2055,16 @@ streaming = "batch"
                 .any(|s| s.role == engine::SPEC_PROVENANCE_ROLE));
         }
 
+        // 2b. #323: the COLLECTION-level verb resolves every ingested member by the same sanitized
+        // name the engine wrote — the exact path that used to fail (`blake3:…` resolve vs `blake3_…`
+        // write). This is the ingest --spec → `collection verify` round-trip the bug report asked for.
+        collection::verify(&out_dir.join("collection.json"), &mut Vec::new()).unwrap();
+
         // 3. the derived member's `derived_from` edge pins the raw's manifest_hash → chain verifies.
         let raw_id = &coll.members[0].reference;
         let derived_id = &coll.members[1].reference;
-        let raw_path = out_dir.join(format!("{}.tsra", raw_id.replace([':', '/'], "_")));
-        let derived_path = out_dir.join(format!("{}.tsra", derived_id.replace([':', '/'], "_")));
+        let raw_path = out_dir.join(member_filename(raw_id, MemberKind::Product));
+        let derived_path = out_dir.join(member_filename(derived_id, MemberKind::Product));
         let raw_m = Reader::open(&raw_path).unwrap().manifest().clone();
         let derived_m = Reader::open(&derived_path).unwrap().manifest().clone();
         let mut resolver: std::collections::BTreeMap<String, tessera_core::Manifest> =

--- a/tessera/crates/tessera-core/src/collection.rs
+++ b/tessera/crates/tessera-core/src/collection.rs
@@ -75,6 +75,29 @@ impl MemberKind {
     }
 }
 
+/// Filesystem-safe stem for a member's content-addressed `reference` (a `blake3:<hex>` id): the
+/// single `:` — and any `/` or `\` — becomes `_`. Lossless because the prefix is the fixed
+/// `blake3:`, so `blake3_<hex>` round-trips unambiguously.
+///
+/// This is the **single source of truth** for the on-disk member stem, so every writer (the ingest
+/// engine, `collection new`) and every reader (`collection verify` / `ls`) derive the same name.
+/// Before this existed the ingest engine sanitized (`blake3_…`) while the consumer verbs resolved the
+/// raw reference (`blake3:…`), so `verify`/`ls` could never find an ingested member (#323).
+pub fn sanitize_reference(reference: &str) -> String {
+    reference.replace([':', '/', '\\'], "_")
+}
+
+/// The on-disk filename of a member beside its `collection.json`, resolved by `kind` (ADR-0049 §4): a
+/// product is `<stem>.tsra`, a sub-collection is `<stem>.collection.json`, where `<stem>` is the
+/// [`sanitize_reference`] of the member's `reference`. The one place the member layout is spelled.
+pub fn member_filename(reference: &str, kind: MemberKind) -> String {
+    let stem = sanitize_reference(reference);
+    match kind {
+        MemberKind::Collection => format!("{stem}.collection.json"),
+        _ => format!("{stem}.tsra"),
+    }
+}
+
 /// One member of a [`Collection`]: a flat physical product referenced by its content-addressed `id`
 /// and pinned to its `manifest_hash` (so the collection seal transitively commits to the member).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -933,6 +956,24 @@ mod tests {
         )
         .unwrap();
         assert_eq!(m.kind, MemberKind::Product);
+    }
+
+    /// The member-filename SSoT (#323): a `blake3:<hex>` reference sanitizes its single `:` to `_`
+    /// (lossless) and the extension follows the kind — the one name writers and readers must agree on.
+    #[test]
+    fn member_filename_sanitizes_the_reference_and_picks_the_extension() {
+        let r = "blake3:e4b561abc";
+        assert_eq!(sanitize_reference(r), "blake3_e4b561abc");
+        assert_eq!(
+            member_filename(r, MemberKind::Product),
+            "blake3_e4b561abc.tsra"
+        );
+        assert_eq!(
+            member_filename(r, MemberKind::Collection),
+            "blake3_e4b561abc.collection.json"
+        );
+        // Path-separators are neutralised too, so a reference can never escape the collection dir.
+        assert_eq!(sanitize_reference("a/b\\c"), "a_b_c");
     }
 
     /// A malformed (empty) level tag is refused at seal — structural well-formedness (round-2 review).

--- a/tessera/crates/tessera-ingest/src/engine.rs
+++ b/tessera/crates/tessera-ingest/src/engine.rs
@@ -31,7 +31,9 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use tessera_core::collection::CollectionBuilder;
+use tessera_core::collection::{
+    member_filename, sanitize_reference, CollectionBuilder, MemberKind,
+};
 use tessera_core::manifest::Manifest;
 use tessera_core::provenance::Source;
 use tessera_core::{Error, Result};
@@ -445,8 +447,8 @@ fn dispatch(
                 // Stream straight to disk — the bounded-memory + multi-block path. The output path
                 // is computed BEFORE the seal because the streaming writer writes the .tsra
                 // directly; we then re-open the sealed manifest to record its id.
-                let stage = out_dir.join(format!("__stage_{}", sanitize_filename(name)));
-                let tmp_out = out_dir.join(format!("__pending_{}.tsra", sanitize_filename(name)));
+                let stage = out_dir.join(format!("__stage_{}", sanitize_reference(name)));
+                let tmp_out = out_dir.join(format!("__pending_{}.tsra", sanitize_reference(name)));
                 // Build extra_sources with the canonical `ingested_from` flowing through the
                 // streaming session (it adds its own `ingested_from`); pass `extra_sources` as-is.
                 let m = crate::ge_hdf5::stream_to_listmode_product_2p_to_file(
@@ -466,7 +468,7 @@ fn dispatch(
                 )?;
                 // Rename the pending .tsra to its id-named final path. Same filesystem → rename is
                 // atomic, so a crash here leaves either the old or the new file in place.
-                let final_path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
+                let final_path = out_dir.join(member_filename(&m.id, MemberKind::Product));
                 std::fs::rename(&tmp_out, &final_path).map_err(|e| {
                     Error::Invalid(format!(
                         "ingest-engine: rename {} -> {}: {e}",
@@ -577,7 +579,7 @@ fn seal_to_tsra(
     _timestamp: &str,
 ) -> Result<Manifest> {
     let m = apply_spec_metadata(m, &p.metadata)?;
-    let path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
+    let path = out_dir.join(member_filename(&m.id, MemberKind::Product));
     pack(&m, payloads, &path)?;
     // ADR-0042: stamp `aux/provenance.json` (wall-clock + producer + host) as a non-sealed aux
     // member. The sealed region is byte-identical afterwards (proven by container tests), so this
@@ -602,7 +604,7 @@ fn seal_streaming_to_tsra(
     p: &crate::spec::ProductSpec,
 ) -> Result<Manifest> {
     let m = apply_spec_metadata(m, &p.metadata)?;
-    let path = out_dir.join(format!("{}.tsra", sanitize_filename(&m.id)));
+    let path = out_dir.join(member_filename(&m.id, MemberKind::Product));
     pack_streaming_verified(&m, sources, &path)?;
     // ADR-0042: aux/provenance.json stamp, matching seal_to_tsra above.
     stamp_ingest_provenance(&path, &ProvenanceOptions::default())?;
@@ -626,13 +628,6 @@ fn apply_spec_metadata(
         b.with_field(k, v.clone());
     }
     b.seal()
-}
-
-/// Strip filesystem-hostile chars (`:` / `/` from the blake3-prefixed id) so the member's id
-/// becomes a portable filename. The id is hex + a single `:`; replacing the `:` with `_` is
-/// lossless (the prefix is fixed: `blake3:`).
-fn sanitize_filename(s: &str) -> String {
-    s.replace([':', '/', '\\'], "_")
 }
 
 /// Public seam: re-export so a CLI caller can pre-parse + re-use the same spec without re-reading.
@@ -811,7 +806,7 @@ streaming = "batch"
         // 2. members were written to disk + open.
         let mut by_name: BTreeMap<String, Manifest> = BTreeMap::new();
         for m in &coll.members {
-            let path = out.join(format!("{}.tsra", m.reference.replace([':', '/'], "_")));
+            let path = out.join(member_filename(&m.reference, MemberKind::Product));
             assert!(path.exists(), "missing {}", path.display());
             let r = tessera_io::Reader::open(&path).unwrap();
             by_name.insert(m.reference.clone(), r.manifest().clone());
@@ -906,9 +901,9 @@ streaming = "auto"
         let cfg = tessera_io::WriteConfig::for_system().workers(2);
         let coll = run(&parsed, &PathBuf::from("inline-spec"), &out, &cfg, 1).unwrap();
         assert_eq!(coll.members.len(), 1);
-        let member_path = out.join(format!(
-            "{}.tsra",
-            coll.members[0].reference.replace([':', '/'], "_")
+        let member_path = out.join(member_filename(
+            &coll.members[0].reference,
+            MemberKind::Product,
         ));
         assert!(
             member_path.exists(),
@@ -971,10 +966,7 @@ metadata = {{ coincidence_mode = "singles", site = "anvil" }}
         assert_eq!(coll.members.len(), 2);
 
         for member in &coll.members {
-            let p = out.join(format!(
-                "{}.tsra",
-                member.reference.replace([':', '/'], "_")
-            ));
+            let p = out.join(member_filename(&member.reference, MemberKind::Product));
             let mani = tessera_io::Reader::open(&p).unwrap().manifest().clone();
             if mani.metadata.contains_key("operator") {
                 // batch product: spec overrode the default + added a field


### PR DESCRIPTION
Closes #323.

## Bug
`tessera ingest --spec` mints `collection.json` + members correctly, but `tessera collection verify collection.json` (and `ls`) fail to find any member:
```
error: collection member 'blake3:e4b561…' missing or unreadable at <out>/blake3:e4b561….tsra
```
Found on the DUPLET DP01 two-tier ingest (18 blobs + 14 recons).

## Root cause — sanitization drift
The ingest **engine writes** members with a filesystem-sanitized id (`blake3_<hex>.tsra`, `:`→`_`), but `collection verify`/`ls` **resolved** the raw `reference` (`blake3:<hex>.tsra`). Writer and reader each spelled the filename their own way. `inspect` worked (it never opens members); the member-opening verbs broke. Worse, `collection new` used a *third* convention (the raw colon name), and there were four ad-hoc inline `.replace([':','/'],"_")` copies — two omitting `\\`.

## Fix — one SSoT
New `tessera_core::collection::{sanitize_reference, member_filename}` is the single place the on-disk member layout is spelled (`<stem>.tsra` / `<stem>.collection.json`). Every writer (ingest engine, `collection new`, the `ingest` move-to-out) and every reader (`verify`/`ls`) now derive the same name through it; the four inline copies are gone. Unifies on the sanitized convention the engine already emitted.

**Additive — no sealed bytes touched, conformance corpus unchanged.**

## Tests
- core: `member_filename_sanitizes_the_reference_and_picks_the_extension` (`:`→`_`, extension-by-kind, path-separators neutralised).
- CLI `collection_new_assembles_from_presealed_tsra`: now asserts the member lands under the **sanitized** stem and the **raw colon name does NOT exist** (locks the #323 convention).
- CLI `ingest_spec_seals_a_collection_and_each_member_verifies`: gains a collection-level `collection verify` on the output — the exact `ingest --spec` → `collection verify` round-trip the report asked for.

Refs: #323 · ADR-0049 (member layout)