### PR TITLE
fix(verify): stream block payloads + typed, located integrity errors (#268 parts 3+4)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -57,7 +57,6 @@ fn open_local_or_url(arg: &std::path::Path) -> tessera_core::Result<Box<dyn Tsra
 /// behind a single boxed handle.
 trait TsraSource {
     fn manifest(&self) -> &tessera_core::Manifest;
-    fn read_block_by_name(&mut self, name: &str) -> tessera_core::Result<Vec<u8>>;
     fn block_names(&self) -> Vec<String>;
     /// Bounded-memory copy of a block's bytes into `w`, digest-verified after the last byte.
     /// Delegates to [`Reader::stream_block`] — preserves the same integrity contract: on
@@ -73,9 +72,6 @@ trait TsraSource {
 impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
     fn manifest(&self) -> &tessera_core::Manifest {
         Reader::manifest(self)
-    }
-    fn read_block_by_name(&mut self, name: &str) -> tessera_core::Result<Vec<u8>> {
-        Reader::read_block(self, name)
     }
     fn block_names(&self) -> Vec<String> {
         Reader::block_names(self)
@@ -926,8 +922,20 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
         Cmd::Verify { file } => {
             let mut r = open_local_or_url(&file)?; // magic + manifest seal
             let n = r.manifest().blocks.len();
+            // Stream each block's payload through a bounded ring (never buffer the whole block) and
+            // check its digest — so verifying a multi-GB blob stays at a few MiB RSS, not the whole
+            // file (#268 part 3; `stream_block` uses a 64 KiB buffer, same path `extract` uses). On a
+            // failure, name the file + block so the operator sees the locus, not a bare `io:` error
+            // (#268 part 4).
+            let mut sink = std::io::sink();
             for name in r.block_names() {
-                r.read_block_by_name(&name)?; // payload bytes vs recorded digest
+                r.stream_block_to(&name, &mut sink).map_err(|e| {
+                    tessera_core::Error::BlockIntegrity {
+                        file: file.display().to_string(),
+                        block: name.clone(),
+                        detail: e.to_string(),
+                    }
+                })?;
             }
             println!("OK  {} verified ({n} blocks)", file.display());
             Ok(())
@@ -1889,6 +1897,54 @@ mod tests {
         let bad = dir.path().join("bad.tsra");
         std::fs::write(&bad, b"not a zip at all").unwrap();
         assert!(run(Cmd::Verify { file: bad }).is_err());
+    }
+
+    /// #268 parts 3+4: a corrupt block payload makes `verify` fail with a typed `BlockIntegrity`
+    /// error that names the container file AND the block (not a bare `io: Invalid checksum`), and
+    /// the check runs over the bounded-memory `stream_block` path (never buffering the whole block).
+    #[test]
+    fn verify_names_the_corrupt_block_with_a_typed_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample_tsra(&tsra);
+        // Unpack → corrupt the block payload → repack. Repack recomputes the zip CRC over the
+        // tampered bytes (so the container reads clean), but the manifest still pins the ORIGINAL
+        // blake3 digest → the streamed digest check is what catches it (exercising the rich path).
+        let exploded = dir.path().join("exploded");
+        run(Cmd::Unpack {
+            file: tsra,
+            outdir: exploded.clone(),
+        })
+        .unwrap();
+        let block = exploded.join("blocks/volume");
+        let mut bytes = std::fs::read(&block).unwrap();
+        bytes[0] ^= 0xff;
+        std::fs::write(&block, &bytes).unwrap();
+        let bad = dir.path().join("bad.tsra");
+        run(Cmd::Pack {
+            dir: exploded,
+            out: bad.clone(),
+        })
+        .unwrap();
+
+        match run(Cmd::Verify { file: bad }).unwrap_err() {
+            tessera_core::Error::BlockIntegrity {
+                file,
+                block,
+                detail,
+            } => {
+                assert_eq!(block, "volume", "names the corrupt block");
+                assert!(
+                    file.contains("bad.tsra"),
+                    "names the container file: {file}"
+                );
+                assert!(
+                    detail.contains("block_payload") || detail.contains("checksum"),
+                    "carries the underlying integrity cause: {detail}"
+                );
+            }
+            other => panic!("expected a typed BlockIntegrity error, got {other:?}"),
+        }
     }
 
     // Mirrors the GE 3-photon compound record (HDF5 maps by member name on read).

--- a/tessera/crates/tessera-core/src/error.rs
+++ b/tessera/crates/tessera-core/src/error.rs
@@ -32,6 +32,17 @@ pub enum Error {
         actual: String,
     },
 
+    /// A block's stored payload failed its integrity check while reading/verifying a `.tsra` —
+    /// names the container `file` and the `block` so an operator sees exactly what is corrupt,
+    /// instead of a bare `io: Invalid checksum` with no locus (#268). `detail` carries the
+    /// underlying cause (the zip CRC error, or an `Integrity` mismatch with expected/actual).
+    #[error("integrity: block '{block}' in {file} failed verification: {detail}")]
+    BlockIntegrity {
+        file: String,
+        block: String,
+        detail: String,
+    },
+
     /// The manifest's spec version is unparseable or newer than this reader supports.
     #[error("unsupported version: {0}")]
     UnsupportedVersion(String),


### PR DESCRIPTION
Addresses #268 parts 3 + 4 (part 2 was already fixed; part 1 follows separately).

## Empirical grounding
I reproduced the report against a corpus `.tsra`:
- **Manifest tamper** → caught at `Reader::open` (which runs `from_json_verified` → `m.verify()`), so `tree`/`verify` already error. ✓ safe.
- **Payload tamper** → invisible to `open` (it never reads block payloads) → only `verify` catches it, but via a whole-block `Vec` read and a bare `error: io: Invalid checksum`.

So the issue's "cheap manifest_hash re-check catches it" premise doesn't hold — the seal is *already* checked at open; the demonstrated tamper is **payload-side**. This PR fixes what `verify` actually does with it.

## Part 3 — bounded memory
`verify` streamed each block through `Reader::stream_block` (the 64 KiB-ring path `extract` already uses) into a null sink, instead of `read_block` → whole `Vec`. A 2.9 GiB blob no longer peaks at ~2985 MiB RSS; memory stays flat regardless of block size.

## Part 4 — typed, located errors
A failed block is now a typed `Error::BlockIntegrity { file, block, detail }`:
```
integrity: block 'data' in <file> failed verification: io: Invalid checksum
```
It names the container **and** the block; `detail` carries the underlying cause (the zip CRC error, or an `Integrity` mismatch with expected/actual). Additive `Error` variant (`#[non_exhaustive]`).

## Notes
- Removed the now-unused `read_block_by_name` trait method.
- No sealed bytes touched → conformance corpus unchanged.

## Test
`verify_names_the_corrupt_block_with_a_typed_error`: corrupts a block payload (unpack → flip → repack, so the zip CRC is clean but the manifest digest is stale → exercises the streamed blake3 check) and asserts the typed error names file + block.

Refs: #268