### PR TITLE
feat(cli): --verify deep opt-in on tree/inspect + honest seal-vs-verified badge (#268 part 1)

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -57,7 +57,6 @@ fn open_local_or_url(arg: &std::path::Path) -> tessera_core::Result<Box<dyn Tsra
 /// behind a single boxed handle.
 trait TsraSource {
     fn manifest(&self) -> &tessera_core::Manifest;
-    fn block_names(&self) -> Vec<String>;
     /// Bounded-memory copy of a block's bytes into `w`, digest-verified after the last byte.
     /// Delegates to [`Reader::stream_block`] — preserves the same integrity contract: on
     /// `Err(Integrity)` the writer already saw the unverified bytes, so callers must stage to
@@ -67,14 +66,14 @@ trait TsraSource {
         name: &str,
         w: &mut dyn std::io::Write,
     ) -> tessera_core::Result<u64>;
+    /// Verify every block payload at bounded RSS, returning a typed `BlockIntegrity` (naming
+    /// `label` + the block) on the first corrupt block. Delegates to [`Reader::verify_payloads`].
+    fn verify_payloads(&mut self, label: &str) -> tessera_core::Result<()>;
 }
 
 impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
     fn manifest(&self) -> &tessera_core::Manifest {
         Reader::manifest(self)
-    }
-    fn block_names(&self) -> Vec<String> {
-        Reader::block_names(self)
     }
     fn stream_block_to(
         &mut self,
@@ -85,6 +84,9 @@ impl<R: std::io::Read + std::io::Seek> TsraSource for Reader<R> {
         // trait object as `&mut &mut dyn Write` — the mutable-reference impl of `Write` is itself
         // `Sized`, which keeps the generic happy without changing the underlying writer.
         Reader::stream_block(self, name, &mut w)
+    }
+    fn verify_payloads(&mut self, label: &str) -> tessera_core::Result<()> {
+        Reader::verify_payloads(self, label)
     }
 }
 
@@ -178,6 +180,11 @@ enum Cmd {
         /// path); default collapses a multi-file edge to `<first> (+N more)`.
         #[arg(long)]
         full: bool,
+        /// Deep-verify: also re-hash every block payload (bounded memory), not just the seal that
+        /// `open` already checked. Exits nonzero and names the block on corruption. Slower — it
+        /// reads all payloads; for a huge blob prefer the fast default (seal only) unless auditing.
+        #[arg(long)]
+        verify: bool,
     },
     /// Verify a `.tsra`'s integrity (magic, seal, every block digest).
     ///
@@ -199,6 +206,11 @@ enum Cmd {
         /// Print provenance references in full instead of collapsing a multi-file edge.
         #[arg(long)]
         full: bool,
+        /// Deep-verify: re-hash every block payload (bounded memory) before rendering; the root
+        /// badge becomes `verified✓`, or the command exits nonzero naming the corrupt block. The
+        /// fast default only shows `sealed` (the seal `open` verified), not payload integrity (#268).
+        #[arg(long)]
+        verify: bool,
     },
     /// List one node's children (top level, `meta`, a block, or `sources`).
     ///
@@ -873,8 +885,13 @@ fn main() -> ExitCode {
 
 fn run(cmd: Cmd) -> tessera_core::Result<()> {
     match cmd {
-        Cmd::Inspect { file, full } => {
-            let r = open_local_or_url(&file)?;
+        Cmd::Inspect { file, full, verify } => {
+            let mut r = open_local_or_url(&file)?;
+            // Deep-verify (opt-in): re-hash every payload before rendering, so a corrupt file
+            // errors out here instead of printing a clean-looking summary (#268). Bounded RSS.
+            if verify {
+                r.verify_payloads(&file.display().to_string())?;
+            }
             let m = r.manifest();
             println!("tessera {} · product={}", m.tessera_version, m.product);
             println!("id            {}", m.id);
@@ -891,6 +908,12 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 "manifest_hash {}",
                 m.manifest_hash.as_deref().unwrap_or("-")
             );
+            if verify {
+                println!(
+                    "integrity     verified✓ ({} block payloads re-hashed)",
+                    m.blocks.len()
+                );
+            }
             println!("blocks        {}", m.blocks.len());
             for b in &m.blocks {
                 println!(
@@ -922,27 +945,15 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
         Cmd::Verify { file } => {
             let mut r = open_local_or_url(&file)?; // magic + manifest seal
             let n = r.manifest().blocks.len();
-            // Stream each block's payload through a bounded ring (never buffer the whole block) and
-            // check its digest — so verifying a multi-GB blob stays at a few MiB RSS, not the whole
-            // file (#268 part 3; `stream_block` uses a 64 KiB buffer, same path `extract` uses). On a
-            // failure, name the file + block so the operator sees the locus, not a bare `io:` error
-            // (#268 part 4).
-            let mut sink = std::io::sink();
-            for name in r.block_names() {
-                r.stream_block_to(&name, &mut sink).map_err(|e| {
-                    tessera_core::Error::BlockIntegrity {
-                        file: file.display().to_string(),
-                        block: name.clone(),
-                        detail: e.to_string(),
-                    }
-                })?;
-            }
+            // Payload half of verification: stream every block at bounded RSS + typed, located
+            // errors (#268 parts 3+4). `open` already checked the seal.
+            r.verify_payloads(&file.display().to_string())?;
             println!("OK  {} verified ({n} blocks)", file.display());
             Ok(())
         }
-        Cmd::Tree { file, full } => {
+        Cmd::Tree { file, full, verify } => {
             let mut out = std::io::stdout().lock();
-            nav::tree(&file, full, &mut out)
+            nav::tree(&file, full, verify, &mut out)
         }
         Cmd::Ls { file, path, full } => {
             let mut out = std::io::stdout().lock();
@@ -1865,6 +1876,7 @@ mod tests {
         run(Cmd::Inspect {
             file: tsra.clone(),
             full: false,
+            verify: false,
         })
         .unwrap();
         run(Cmd::Schema {
@@ -1947,6 +1959,57 @@ mod tests {
         }
     }
 
+    /// #268 part 1: the `--verify` deep opt-in on `tree`/`inspect` re-hashes payloads, so a
+    /// payload-corrupt file (whose seal is still valid → the fast default renders it) errors out
+    /// with a typed `BlockIntegrity` instead of showing a clean-looking `sealed` view.
+    #[test]
+    fn deep_verify_flag_rejects_a_corrupt_block_in_tree_and_inspect() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample_tsra(&tsra);
+        let exploded = dir.path().join("exploded");
+        run(Cmd::Unpack {
+            file: tsra,
+            outdir: exploded.clone(),
+        })
+        .unwrap();
+        let block = exploded.join("blocks/volume");
+        let mut bytes = std::fs::read(&block).unwrap();
+        bytes[0] ^= 0xff;
+        std::fs::write(&block, &bytes).unwrap();
+        let bad = dir.path().join("bad.tsra");
+        run(Cmd::Pack {
+            dir: exploded,
+            out: bad.clone(),
+        })
+        .unwrap();
+
+        // Fast default: the seal is valid, so it renders without error (no payload check).
+        run(Cmd::Tree {
+            file: bad.clone(),
+            full: false,
+            verify: false,
+        })
+        .unwrap();
+        // --verify: the payload corruption is caught, typed + located.
+        assert!(matches!(
+            run(Cmd::Tree {
+                file: bad.clone(),
+                full: false,
+                verify: true,
+            }),
+            Err(tessera_core::Error::BlockIntegrity { .. })
+        ));
+        assert!(matches!(
+            run(Cmd::Inspect {
+                file: bad,
+                full: false,
+                verify: true,
+            }),
+            Err(tessera_core::Error::BlockIntegrity { .. })
+        ));
+    }
+
     // Mirrors the GE 3-photon compound record (HDF5 maps by member name on read).
     #[repr(C)]
     #[derive(hdf5_metno::H5Type, Clone, Copy)]
@@ -2008,6 +2071,7 @@ mod tests {
         run(Cmd::Inspect {
             file: out.clone(),
             full: false,
+            verify: false,
         })
         .unwrap();
         let r = Reader::open(&out).unwrap();

--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -229,7 +229,7 @@ fn block_children(kind: &BlockKind, spec: &Value) -> Vec<String> {
 ///
 /// A file is "signed" if it carries **either** an embedded signature (ADR-0042 `aux/signatures/…`)
 /// or a detached `<file>.tsra.sig.json` sidecar.
-fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
+fn status_line(file: &Path, m: &tessera_core::Manifest, verified: bool) -> String {
     let known = m.schema.is_some() || SchemaRegistry::builtin().get(&m.product).is_some();
     let schema = if known {
         match tessera_core::validate_manifest(m) {
@@ -239,10 +239,13 @@ fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
     } else {
         format!("schema={}(open-world)", m.product)
     };
-    let sealed = if m.manifest_hash.is_some() {
-        "sealed"
-    } else {
-        "unsealed"
+    // `open` already re-verified the seal, so a sealed file's seal is valid here. The default badge
+    // is `sealed` (seal only — payloads NOT re-hashed); `--verify` streams every payload first and
+    // upgrades it to `verified✓` (the honest distinction the audit tool owes, #268).
+    let sealed = match (verified, m.manifest_hash.is_some()) {
+        (true, _) => "verified✓",
+        (false, true) => "sealed",
+        (false, false) => "unsealed",
     };
     let has_embedded = tessera_io::has_embedded_signature(file).unwrap_or(false);
     let has_detached = tessera_io::sign::sidecar_path(file).exists();
@@ -256,14 +259,20 @@ fn status_line(file: &Path, m: &tessera_core::Manifest) -> String {
 
 /// `tessera tree FILE` — the whole hierarchy: root status, `meta` fields, every block (with its
 /// columns / array spec), and `sources`, drawn with box characters.
-pub fn tree(file: &Path, full: bool, out: &mut dyn Write) -> Result<()> {
-    let r = Reader::open(file)?;
+pub fn tree(file: &Path, full: bool, verify: bool, out: &mut dyn Write) -> Result<()> {
+    let mut r = Reader::open(file)?;
+    // Deep-verify (opt-in): re-hash every block payload before rendering, so a corrupt file errors
+    // out here rather than drawing a clean tree with a `sealed` badge (#268). Bounded RSS.
+    if verify {
+        r.verify_payloads(&file.display().to_string())?;
+    }
     let m = r.manifest();
     let name = file
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("<tsra>");
-    writeln!(out, "{name}  ·  {}", status_line(file, m)).map_err(tessera_core::Error::from)?;
+    writeln!(out, "{name}  ·  {}", status_line(file, m, verify))
+        .map_err(tessera_core::Error::from)?;
 
     // Build the node list: (header, children). meta · schema · blocks · sources · extra.
     let mut nodes: Vec<(String, Vec<String>)> = Vec::new();
@@ -1516,7 +1525,7 @@ mod tests {
         let p = dir.path().join("p.tsra");
         sample(&p);
         let mut buf = Vec::new();
-        tree(&p, false, &mut buf).unwrap();
+        tree(&p, false, false, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("product=listmode"));
         assert!(s.contains("schema=listmode")); // known schema; ✓/✗ depends on field completeness
@@ -1524,6 +1533,25 @@ mod tests {
         assert!(s.contains("modality"));
         assert!(s.contains("events"));
         assert!(s.contains("ms")); // a column leaf
+    }
+
+    /// #268 part 1: the default `tree` badge is `sealed` (seal only — the seal `open` verified),
+    /// and `--verify` re-hashes every payload and upgrades the badge to `verified✓`.
+    #[test]
+    fn tree_verify_upgrades_the_badge_from_sealed_to_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("p.tsra");
+        sample(&p);
+
+        let mut buf = Vec::new();
+        tree(&p, false, false, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("· sealed") && !s.contains("verified"), "{s}");
+
+        let mut buf = Vec::new();
+        tree(&p, false, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("verified✓"), "{s}");
     }
 
     #[test]
@@ -1652,7 +1680,7 @@ mod tests {
 
         // tree includes the schema + extra sub-trees.
         let mut t = Vec::new();
-        tree(&p, false, &mut t).unwrap();
+        tree(&p, false, false, &mut t).unwrap();
         let t = String::from_utf8(t).unwrap();
         assert!(t.contains("schema  (recon") && t.contains("extra"), "{t}");
     }

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -440,6 +440,26 @@ impl<R: Read + Seek> Reader<R> {
         }
         Ok(total)
     }
+
+    /// Verify every block's stored payload by streaming it through [`Self::stream_block`] (the
+    /// bounded-memory 64 KiB-ring path) into a null sink — so a multi-GB product verifies at a few
+    /// MiB RSS, never buffering a whole block. `open` already checked the seal (manifest); this is
+    /// the payload half. The first corrupt block returns a typed [`Error::BlockIntegrity`] naming
+    /// `label` (the file path or URL) and the block, with the underlying cause in `detail` (the zip
+    /// CRC error, or an `Integrity` mismatch with expected/actual) — never a locus-free `io:` error
+    /// (#268). Shared by `tessera verify` and the `--verify` deep opt-in of the read-side commands.
+    pub fn verify_payloads(&mut self, label: &str) -> Result<()> {
+        let mut sink = std::io::sink();
+        for name in self.block_names() {
+            self.stream_block(&name, &mut sink)
+                .map_err(|e| Error::BlockIntegrity {
+                    file: label.to_string(),
+                    block: name.clone(),
+                    detail: e.to_string(),
+                })?;
+        }
+        Ok(())
+    }
 }
 
 /// One aux member to add to an existing `.tsra` — a name **relative to `aux/`** (so


### PR DESCRIPTION
Closes #268 (final part — 1). Parts 3+4 landed in #340; part 2 was already fixed.

## The reframe (empirically grounded — see [issue triage](https://github.com/vig-os/tessera/issues/268#issuecomment-4879865945))
`tree`/`inspect` go through `Reader::open`, which already re-verifies the seal (id + content_hash + manifest_hash). So a **manifest** tamper fails to open. The reported "tree shows `sealed` on a byte-flipped file" is a **payload** tamper — invisible to open, and *not covered by the seal* (content_hash is an MMR over the recorded block digests, not the payload bytes). So `sealed` is technically true there; the honest fix is to (a) not overclaim, and (b) offer a real payload check.

## Change
- **`tree --verify` / `inspect --verify`** — stream every block payload through the bounded-memory `Reader::verify_payloads` (few-MiB RSS on any size) **before** rendering. A corrupt file now errors out with the typed `BlockIntegrity{file,block}` (parts 3+4) instead of a clean-looking view. The `tree` root badge upgrades `sealed` → `verified✓`; `inspect` adds an `integrity  verified✓` line.
- **Honest default** — unchanged and now correctly scoped: `sealed` = the seal `open` verified (**not** payloads); `--verify` = payloads re-hashed too. Fast default preserved (no forced full-read on every `tree`).
- **DRY** — `Reader::verify_payloads(label)` is the single implementation; the `verify` command's inline loop from #340 now calls it too. Dropped the now-unused `TsraSource::{block_names, read_block_by_name}`.

## Tests
- `tree_verify_upgrades_the_badge_from_sealed_to_verified` — default shows `· sealed`, `--verify` shows `verified✓`.
- `deep_verify_flag_rejects_a_corrupt_block_in_tree_and_inspect` — both verbs error with `BlockIntegrity` on a payload-corrupt file whose seal is still valid (fast default still renders it).
- All trycmd walkthroughs unaffected; no sealed bytes touched, corpus unchanged.

Refs: #268 · #340