### PR TITLE
fix(cli): collection resolves portable blake3_<hash>.tsra members (#344)

### DIFF
--- a/tessera/crates/tessera-cli/src/collection.rs
+++ b/tessera/crates/tessera-cli/src/collection.rs
@@ -43,14 +43,32 @@ fn load(file: &Path) -> Result<Collection> {
     Collection::from_json(&std::fs::read_to_string(file)?)
 }
 
+/// Filesystem-safe stem for a member `reference`/`id`: `blake3:<hex>` → `blake3_<hex>`.
+/// A colon is illegal in Windows paths and trips up some tooling, so the on-disk canonical
+/// member name uses `_`. Resolution still accepts the verbatim `:` form for back-compat.
+pub(crate) fn ref_stem(reference: &str) -> String {
+    reference.replace(':', "_")
+}
+
 /// The on-disk path of a member next to the `collection.json` — resolved by `kind` (ADR-0049 §4): a
-/// product is `<reference>.tsra`, a sub-collection is `<reference>.collection.json`.
+/// product is `<reference>.tsra`, a sub-collection is `<reference>.collection.json`. The `reference`
+/// is `blake3:<hex>`, but a colon is not portable in filenames, so the canonical on-disk name is the
+/// sanitized `blake3_<hex>` (see [`ref_stem`]). We prefer that portable name and fall back to the
+/// verbatim `:` name if that's what's on disk (collections written before this convention). If
+/// neither exists, we return the portable name so a not-found error points at the canonical form.
 fn member_path(collection_file: &Path, reference: &str, kind: MemberKind) -> PathBuf {
     let dir = collection_file.parent().unwrap_or_else(|| Path::new("."));
-    if kind == MemberKind::Collection {
-        dir.join(format!("{reference}.collection.json"))
+    let ext = if kind == MemberKind::Collection {
+        "collection.json"
     } else {
-        dir.join(format!("{reference}.tsra"))
+        "tsra"
+    };
+    let portable = dir.join(format!("{}.{ext}", ref_stem(reference)));
+    let verbatim = dir.join(format!("{reference}.{ext}"));
+    if portable.exists() || !verbatim.exists() {
+        portable
+    } else {
+        verbatim
     }
 }
 
@@ -247,7 +265,8 @@ fn verify_collection(
 /// (which verifies its seal), pins it by `(id, manifest_hash)` via the typed [`ProductHandle`], seals
 /// the catalog under the declared `--schema` (validating its `member_rule`), and writes a
 /// self-contained collection directory: `<out>/collection.json` + each member hard-linked (or copied)
-/// as `<out>/<id>.tsra`, so `collection verify` resolves + checks it in place. The collection's
+/// as `<out>/<ref_stem>.tsra` (portable — colon → `_`), so `collection verify` resolves + checks it
+/// in place cross-platform. The collection's
 /// timestamp defaults to the latest member's (deterministic) unless `--timestamp` is given.
 #[allow(clippy::too_many_arguments)]
 pub fn new(
@@ -296,11 +315,12 @@ pub fn new(
     // `project` would reject them — fail-fast before writing anything).
     let sealed = cb.seal()?;
 
-    // Write the self-contained collection dir: collection.json + each member as `<id>.tsra`.
+    // Write the self-contained collection dir: collection.json + each member as the portable
+    // `<ref_stem>.tsra` (colon → `_`) so `collection verify` resolves it in place cross-platform.
     std::fs::create_dir_all(out)?;
     std::fs::write(out.join("collection.json"), sealed.to_json()?)?;
     for (h, src) in &handles {
-        let dst = out.join(format!("{}.tsra", h.reference()));
+        let dst = out.join(format!("{}.tsra", ref_stem(h.reference())));
         if src.canonicalize().ok() == dst.canonicalize().ok() {
             continue; // member already in place as <id>.tsra
         }
@@ -393,6 +413,67 @@ mod tests {
         // Remove a member file → verify fails loudly (missing member).
         std::fs::remove_file(dir.path().join(format!("{}.tsra", c.members[0].reference))).unwrap();
         assert!(verify(&cf, &mut Vec::new()).is_err());
+    }
+
+    /// Regression (#344): a collection whose members are written with the **portable** `blake3_<hex>`
+    /// name (colon → `_`, as `collection new` and the DUPLET archive generator emit) must resolve.
+    /// Before the fix `member_path` only tried the verbatim `blake3:<hex>.tsra`, so `ls`/`verify`
+    /// reported every member `<member file not found>`.
+    #[test]
+    fn portable_underscore_named_members_resolve() {
+        let src = tempfile::tempdir().unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let mut members = Vec::new();
+        for name in ["ct", "pt"] {
+            let spec = ArraySpec::new(vec![2, 2], "int16");
+            let (bref, payload) =
+                tessera_io::array::array_block("volume", &spec, &ArrayData::I16(vec![0, 1, 2, 3]))
+                    .unwrap();
+            let mut b = ProductBuilder::new("recon", name, "d", "2024-01-01T00:00:00Z");
+            b.add_block_ref(bref);
+            let sealed = b.seal().unwrap();
+            let p = src.path().join(format!("{name}.tsra"));
+            pack(&sealed, &[payload], &p).unwrap();
+            members.push(p);
+        }
+
+        // `collection new` writes each member as the portable `blake3_<hex>.tsra`.
+        new(
+            &members,
+            out.path(),
+            "study",
+            "a CT+PET study",
+            "dataset",
+            Some("DP01"),
+            Some("2024-01-01T00:00:00Z"),
+            Role::Derived,
+            &mut Vec::new(),
+        )
+        .unwrap();
+
+        // No colon-named files on disk; the canonical members are `blake3_<hex>.tsra`.
+        let tsras: Vec<_> = std::fs::read_dir(out.path())
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+            .filter(|n| n.ends_with(".tsra"))
+            .collect();
+        assert_eq!(tsras.len(), 2, "{tsras:?}");
+        assert!(
+            tsras
+                .iter()
+                .all(|n| n.starts_with("blake3_") && !n.contains(':')),
+            "members must be portable underscore names, got {tsras:?}"
+        );
+
+        // ls resolves each member's name (not `<member file not found>`), and verify passes.
+        let cf = out.path().join("collection.json");
+        let mut buf = Vec::new();
+        ls(&cf, false, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(!s.contains("member file not found"), "{s}");
+        assert!(s.contains("ct") && s.contains("pt"), "{s}");
+
+        verify(&cf, &mut Vec::new()).unwrap();
     }
 
     /// Build a child collection on disk written as `<id>.collection.json` (+ its member `.tsra`s).

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -463,12 +463,17 @@ fn geddf_dict() -> &'static GeDict {
 /// Map an HDF5 dataset name (or block prefix) to its dictionary group: `events_2p`/`events_3p` →
 /// `events`, `coin_2p`/`coin_3p` → `coin`, else the name itself (`singles`, `time_markers`, …).
 fn dataset_group(name: &str) -> &str {
-    if name.starts_with("events") {
+    // Accept either a bare dataset name (`events_3p`) or a full HDF5 path (`/proc_data/events_3p`) —
+    // the GEDDF dictionary is keyed on the leaf group, so a spec that passes the nested path (as real
+    // DUPLET specs do) must still resolve. Without the leaf-strip the annotation/quantize silently
+    // no-op'd on every path-qualified dataset.
+    let leaf = name.rsplit('/').next().unwrap_or(name);
+    if leaf.starts_with("events") {
         "events"
-    } else if name.starts_with("coin_2p") || name.starts_with("coin_3p") || name == "coin" {
+    } else if leaf.starts_with("coin_2p") || leaf.starts_with("coin_3p") || leaf == "coin" {
         "coin"
     } else {
-        name
+        leaf
     }
 }
 
@@ -974,6 +979,11 @@ mod tests {
         assert_eq!(dataset_group("coin_2p"), "coin");
         assert_eq!(dataset_group("singles"), "singles");
         assert_eq!(dataset_group("time_markers"), "time_markers");
+        // Full HDF5 paths (what real DUPLET specs pass) resolve on the leaf, not the whole path.
+        assert_eq!(dataset_group("/proc_data/events_3p"), "events");
+        assert_eq!(dataset_group("/proc_data/coin_2p"), "coin");
+        assert_eq!(dataset_group("/raw_data/singles"), "singles");
+        assert_eq!(dataset_group("/raw_data/time_markers"), "time_markers");
     }
 
     #[test]

--- a/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
+++ b/tessera/docs/dictionaries/ge-discovery-mi-listmode.toml
@@ -159,7 +159,7 @@ quantize_dtype = "i2"
 
 [events.lt_corr]
 short_name = "lt_corr"
-description = "Positronium lifetime, corrected (TOF/geometry). Sparse — NaN for most events."
+description = "Positronium lifetime, corrected (TOF/geometry). ~0.7% NaN (correction not computed for this event) → NULL (nullable int16, #330); the rest quantize."
 dtype = "f4"
 unit = "ns"
 vocabulary = "MorePET"


### PR DESCRIPTION
## Bug (both DUPLET reviewers hit it independently)

`tessera collection ls|verify` reported **every member `<member file not found>`** on the real DP01 archive. `member_path` built `<reference>.tsra` where `reference` is `blake3:<hex>` — a **colon**-named file — but colons aren't portable in filenames (illegal on Windows, trip tooling), so the archive generator (and now `collection new`) write the sanitized `blake3_<hex>.tsra`. The resolver never tried that form, so a real catalog could not be integrity-checked end-to-end.

## Fix
- `ref_stem` (`:` → `_`); `member_path` prefers the portable `blake3_<hex>` name and falls back to the verbatim `blake3:<hex>` for older layouts.
- `collection new` now emits portable `<ref_stem>.tsra` members.
- Regression `portable_underscore_named_members_resolve`: `new → ls → verify` round-trip, asserts no colon-named files on disk. All 42 tessera-cli unit tests pass.

## Verified on real data
`collection ls DP01-singles/collection.json` now resolves `dat-raw / singles / coin-2p / coin-3p / events-2p / events-3p / time-markers / coin-counters`; `DP01/collection.json` resolves all 32 `blob-*`/`recon-*` members — previously all `<not found>`.

Refs #344, #272, #304.