### PR TITLE
feat(table): Bool + Utf8 ColumnData — first-class boolean & string columns

### DIFF
--- a/tessera/crates/tessera-cli/src/nav.rs
+++ b/tessera/crates/tessera-cli/src/nav.rs
@@ -1409,9 +1409,10 @@ fn csv_cell(v: &Value) -> String {
     }
 }
 
-/// Convert a (sliced) numeric column to per-row JSON values. Floats render via their **native**
+/// Convert a (sliced) column to per-row JSON values. Floats render via their **native**
 /// shortest round-trip `Display` (so an `f32` shows `0.01`, not its widened-`f64` expansion);
 /// non-finite floats (NaN/±inf) have no JSON encoding → null (CSV shows `nan`, ndjson `null`).
+/// Bool columns render as JSON `true`/`false`, Utf8 as JSON strings.
 fn col_to_values(col: &ColumnData) -> Vec<Value> {
     fn floats<T: std::fmt::Display + Copy>(v: &[T]) -> Vec<Value> {
         v.iter()
@@ -1433,6 +1434,8 @@ fn col_to_values(col: &ColumnData) -> Vec<Value> {
         ColumnData::U64(v) => v.iter().map(|x| Value::from(*x)).collect(),
         ColumnData::F32(v) => floats(v),
         ColumnData::F64(v) => floats(v),
+        ColumnData::Bool(v) => v.iter().map(|x| Value::from(*x)).collect(),
+        ColumnData::Utf8(v) => v.iter().map(|x| Value::from(x.as_str())).collect(),
     }
 }
 
@@ -1931,5 +1934,28 @@ mod tests {
         assert_eq!(s.lines().count(), 4);
         assert!(s.contains("\"ms\":10"));
         assert!(s.contains("\"en\":0.5"));
+    }
+
+    /// `b1`/`str` columns (#354) render as JSON booleans and strings — not as 0/1 or a debug
+    /// string — and `csv_cell` passes them through so the CSV path shows `true` / `annih511`.
+    #[test]
+    fn bool_and_utf8_render_as_json_bool_and_string() {
+        let flags = col_to_values(&ColumnData::Bool(vec![true, false]));
+        assert_eq!(flags, vec![Value::Bool(true), Value::Bool(false)]);
+        assert_eq!(csv_cell(&flags[0]), "true");
+
+        let origins = col_to_values(&ColumnData::Utf8(vec![
+            "annih511".to_string(),
+            "prompt_nuclear".to_string(),
+        ]));
+        assert_eq!(
+            origins,
+            vec![
+                Value::String("annih511".into()),
+                Value::String("prompt_nuclear".into())
+            ]
+        );
+        // csv_cell goes through `Value::to_string()` for non-numbers → JSON-quoted.
+        assert_eq!(csv_cell(&origins[0]), "\"annih511\"");
     }
 }

--- a/tessera/crates/tessera-cli/src/sql.rs
+++ b/tessera/crates/tessera-cli/src/sql.rs
@@ -22,8 +22,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-    RecordBatch, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+    Int8Array, RecordBatch, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow::csv::WriterBuilder;
 use arrow::datatypes::{DataType, Field, Schema};
@@ -33,10 +33,11 @@ use tessera_io::{ColumnData, Reader};
 
 use crate::nav::Format;
 
-/// Convert one Tessera [`ColumnData`] to an Arrow [`ArrayRef`] — one branch per numeric dtype
+/// Convert one Tessera [`ColumnData`] to an Arrow [`ArrayRef`] — one branch per dtype
 /// (`ColumnData` is a closed enum, so every variant is covered exhaustively). Small vectors go
 /// through `.clone()`; f32/f64 are copied verbatim (no NaN canonicalisation — DataFusion honours
-/// IEEE-754 comparison semantics the same way the tests below assert).
+/// IEEE-754 comparison semantics the same way the tests below assert). `Bool`/`Utf8` map to
+/// Arrow `Boolean`/`Utf8`; every column is non-nullable, so no null buffer is built.
 fn column_to_array(col: ColumnData) -> ArrayRef {
     match col {
         ColumnData::I8(v) => Arc::new(Int8Array::from(v)) as ArrayRef,
@@ -49,11 +50,15 @@ fn column_to_array(col: ColumnData) -> ArrayRef {
         ColumnData::U64(v) => Arc::new(UInt64Array::from(v)) as ArrayRef,
         ColumnData::F32(v) => Arc::new(Float32Array::from(v)) as ArrayRef,
         ColumnData::F64(v) => Arc::new(Float64Array::from(v)) as ArrayRef,
+        ColumnData::Bool(v) => Arc::new(BooleanArray::from(v)) as ArrayRef,
+        ColumnData::Utf8(v) => Arc::new(StringArray::from(v)) as ArrayRef,
     }
 }
 
-/// Map an fd5 numpy-style dtype code (`i2`/`u4`/`f4`/…) to its Arrow [`DataType`]. Same closed
-/// mapping the encoder writes; a code outside the table's supported set is a typed schema error.
+/// Map an fd5 numpy-style dtype code (`i2`/`u4`/`f4`/`b1`/`str`/…) to its Arrow [`DataType`]. Same
+/// closed mapping the encoder writes — it must stay in lockstep with [`column_to_array`], since the
+/// declared field type and the built array are paired into one `RecordBatch`. A code outside the
+/// table's supported set is a typed schema error.
 fn numpy_to_arrow(code: &str) -> tessera_core::Result<DataType> {
     Ok(match code {
         "i1" => DataType::Int8,
@@ -66,9 +71,12 @@ fn numpy_to_arrow(code: &str) -> tessera_core::Result<DataType> {
         "u8" => DataType::UInt64,
         "f4" => DataType::Float32,
         "f8" => DataType::Float64,
+        "b1" => DataType::Boolean,
+        "str" => DataType::Utf8,
         other => {
             return Err(tessera_core::Error::Invalid(format!(
-                "tessera sql: unsupported column dtype '{other}' (table cols are numeric)"
+                "tessera sql: unsupported column dtype '{other}' \
+                 (table cols are numeric, b1 or str)"
             )))
         }
     })
@@ -334,6 +342,84 @@ mod tests {
         assert!(
             format!("{err}").contains("ndjson"),
             "typed rejection expected"
+        );
+    }
+
+    /// Seal a tiny `b1` + `str` table — the non-numeric column types (#354).
+    fn sample_bool_utf8(path: &std::path::Path) {
+        let spec = TableSpec {
+            columns: vec![Column::new("flag", "b1"), Column::new("origin", "str")],
+            rows: 4,
+            row_index: None,
+        };
+        let data: TableData = vec![
+            (
+                "flag".into(),
+                ColumnData::Bool(vec![true, false, true, false]),
+            ),
+            (
+                "origin".into(),
+                ColumnData::Utf8(
+                    ["annih511", "prompt_nuclear", "annih511", "other"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
+            ),
+        ];
+        let (block_ref, payload) = table_block("events", &spec, &data).unwrap();
+        let mut b = ProductBuilder::new("listmode", "DP", "d", "2024-01-01T00:00:00Z");
+        b.add_block_ref(block_ref);
+        let sealed = b.seal().unwrap();
+        pack(&sealed, &[payload], path).unwrap();
+    }
+
+    /// `b1`/`str` columns survive the whole SQL path: `numpy_to_arrow` declares Boolean/Utf8,
+    /// `column_to_array` builds the matching arrays (a mismatch would fail `RecordBatch::try_new`),
+    /// and DataFusion filters on both — a boolean predicate and a string equality.
+    #[test]
+    fn bool_and_utf8_columns_query_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample_bool_utf8(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT origin FROM events WHERE flag AND origin = 'annih511'",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        // Rows: (true,"annih511"), (false,"prompt_nuclear"), (true,"annih511"), (false,"other")
+        // → both `flag`-true rows carry origin "annih511".
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "origin\nannih511\nannih511\n"
+        );
+    }
+
+    /// The whole b1/str table renders — proves the Boolean array reaches the CSV writer as
+    /// `true`/`false` rather than erroring or coming back numeric.
+    #[test]
+    fn bool_column_renders_as_true_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsra = dir.path().join("p.tsra");
+        sample_bool_utf8(&tsra);
+
+        let mut out = Vec::<u8>::new();
+        run_with(
+            &tsra,
+            "events",
+            "SELECT flag, origin FROM events WHERE origin = 'other'",
+            Format::Csv,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "flag,origin\nfalse,other\n"
         );
     }
 }

--- a/tessera/crates/tessera-ingest/src/ge_hdf5.rs
+++ b/tessera/crates/tessera-ingest/src/ge_hdf5.rs
@@ -145,18 +145,7 @@ fn slab_to_columns(bytes: &[u8], c: &CompoundType, n_rows: usize) -> Result<Tabl
         .map(|(_, code)| empty_for(code))
         .collect::<Result<_>>()?;
     for col in &mut cols {
-        match col {
-            ColumnData::I8(v) => v.reserve_exact(n_rows),
-            ColumnData::I16(v) => v.reserve_exact(n_rows),
-            ColumnData::I32(v) => v.reserve_exact(n_rows),
-            ColumnData::I64(v) => v.reserve_exact(n_rows),
-            ColumnData::U8(v) => v.reserve_exact(n_rows),
-            ColumnData::U16(v) => v.reserve_exact(n_rows),
-            ColumnData::U32(v) => v.reserve_exact(n_rows),
-            ColumnData::U64(v) => v.reserve_exact(n_rows),
-            ColumnData::F32(v) => v.reserve_exact(n_rows),
-            ColumnData::F64(v) => v.reserve_exact(n_rows),
-        }
+        col.reserve_exact(n_rows);
     }
 
     // For each record, walk the field plan and push each (sub-)scalar.

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -14,12 +14,14 @@ use tessera_core::block::{BlockKind, BlockRef};
 use tessera_core::chunk_index::{ChunkIndex, ChunkStats};
 use tessera_core::hash::digest;
 use tessera_core::{Error, Result};
+use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::struct_::StructArrayExt;
-use vortex_array::arrays::{ChunkedArray, PrimitiveArray, StructArray};
+use vortex_array::arrays::{BoolArray, ChunkedArray, PrimitiveArray, StructArray, VarBinViewArray};
 use vortex_array::expr::{root, select};
 use vortex_array::iter::{ArrayIteratorAdapter, ArrayIteratorExt};
 use vortex_array::scalar_fn::session::ScalarFnSession;
 use vortex_array::session::ArraySession;
+use vortex_array::ExecutionCtx;
 use vortex_array::{ArrayRef, IntoArray, VortexSessionExecute};
 use vortex_btrblocks::schemes::float::{ALPRDScheme, ALPScheme};
 use vortex_btrblocks::{BtrBlocksCompressorBuilder, SchemeExt};
@@ -49,6 +51,14 @@ pub enum ColumnData {
     U64(Vec<u64>),
     F32(Vec<f32>),
     F64(Vec<f64>),
+    /// Boolean column (dtype code `b1`). Bit-packed on the wire (Vortex
+    /// `BoolArray`); this in-memory form is a plain `Vec<bool>`.
+    Bool(Vec<bool>),
+    /// UTF-8 string column (dtype code `str`). Genuine variable/high-cardinality
+    /// text; Vortex picks FSST/dictionary automatically for low-cardinality
+    /// repeats. (For *known* small enums prefer an integer code column + a
+    /// categorical descriptor — a schema choice, not a `ColumnData` variant.)
+    Utf8(Vec<String>),
 }
 
 impl ColumnData {
@@ -65,6 +75,8 @@ impl ColumnData {
             ColumnData::U64(_) => "u8",
             ColumnData::F32(_) => "f4",
             ColumnData::F64(_) => "f8",
+            ColumnData::Bool(_) => "b1",
+            ColumnData::Utf8(_) => "str",
         }
     }
 
@@ -80,6 +92,8 @@ impl ColumnData {
             ColumnData::U64(v) => v.len(),
             ColumnData::F32(v) => v.len(),
             ColumnData::F64(v) => v.len(),
+            ColumnData::Bool(v) => v.len(),
+            ColumnData::Utf8(v) => v.len(),
         }
     }
 
@@ -104,7 +118,9 @@ impl ColumnData {
                 .iter()
                 .all(|&x| x <= i64::MAX as u64)
                 .then(|| v.iter().map(|&x| x as i64).collect()),
-            ColumnData::F32(_) | ColumnData::F64(_) => None,
+            ColumnData::F32(_) | ColumnData::F64(_) | ColumnData::Bool(_) | ColumnData::Utf8(_) => {
+                None
+            }
         }
     }
 
@@ -123,6 +139,16 @@ impl ColumnData {
             ColumnData::U64(v) => le_bytes(v, u64::to_le_bytes),
             ColumnData::F32(v) => le_bytes(v, f32::to_le_bytes),
             ColumnData::F64(v) => le_bytes(v, f64::to_le_bytes),
+            ColumnData::Bool(v) => v.iter().map(|&b| b as u8).collect(),
+            // length-prefixed: [u32 LE len | utf8 bytes] per string.
+            ColumnData::Utf8(v) => {
+                let mut out = Vec::new();
+                for s in v {
+                    out.extend_from_slice(&(s.len() as u32).to_le_bytes());
+                    out.extend_from_slice(s.as_bytes());
+                }
+                out
+            }
         }
     }
 
@@ -141,6 +167,27 @@ impl ColumnData {
             "u8" => ColumnData::U64(from_le(bytes, u64::from_le_bytes)?),
             "f4" => ColumnData::F32(from_le(bytes, f32::from_le_bytes)?),
             "f8" => ColumnData::F64(from_le(bytes, f64::from_le_bytes)?),
+            "b1" => ColumnData::Bool(bytes.iter().map(|&b| b != 0).collect()),
+            // inverse of the Utf8 length-prefixed encoding: [u32 LE len | bytes]*.
+            "str" => {
+                let mut v = Vec::new();
+                let mut i = 0usize;
+                while i + 4 <= bytes.len() {
+                    let len =
+                        u32::from_le_bytes([bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]])
+                            as usize;
+                    i += 4;
+                    let end = i
+                        .checked_add(len)
+                        .filter(|&e| e <= bytes.len())
+                        .ok_or_else(|| {
+                            Error::Codec("truncated utf8 length-prefixed column".to_string())
+                        })?;
+                    v.push(String::from_utf8_lossy(&bytes[i..end]).into_owned());
+                    i = end;
+                }
+                ColumnData::Utf8(v)
+            }
             other => {
                 return Err(Error::Codec(format!(
                     "unsupported column dtype code '{other}'"
@@ -167,6 +214,8 @@ impl ColumnData {
             ColumnData::U64(v) => sl!(v, U64),
             ColumnData::F32(v) => sl!(v, F32),
             ColumnData::F64(v) => sl!(v, F64),
+            ColumnData::Bool(v) => sl!(v, Bool),
+            ColumnData::Utf8(v) => sl!(v, Utf8),
         }
     }
 
@@ -197,6 +246,8 @@ impl ColumnData {
             ColumnData::U64(v) => ext!(v, U64),
             ColumnData::F32(v) => ext!(v, F32),
             ColumnData::F64(v) => ext!(v, F64),
+            ColumnData::Bool(v) => ext!(v, Bool),
+            ColumnData::Utf8(v) => ext!(v, Utf8),
         }
         Ok(())
     }
@@ -224,6 +275,10 @@ impl ColumnData {
             ColumnData::U64(v) => Buffer::copy_from(v.as_slice()).into_array(),
             ColumnData::F32(v) => Buffer::copy_from(v.as_slice()).into_array(),
             ColumnData::F64(v) => Buffer::copy_from(v.as_slice()).into_array(),
+            ColumnData::Bool(v) => v.iter().copied().collect::<BoolArray>().into_array(),
+            ColumnData::Utf8(v) => {
+                VarBinViewArray::from_iter_str(v.iter().map(|s| s.as_str())).into_array()
+            }
         }
     }
 }
@@ -245,6 +300,8 @@ fn empty_column(code: &str) -> Result<ColumnData> {
         "u8" => ColumnData::U64(Vec::new()),
         "f4" => ColumnData::F32(Vec::new()),
         "f8" => ColumnData::F64(Vec::new()),
+        "b1" => ColumnData::Bool(Vec::new()),
+        "str" => ColumnData::Utf8(Vec::new()),
         other => {
             return Err(Error::Codec(format!(
             "table column dtype '{other}' unsupported (numpy codes i1/i2/i4/i8 u1/u2/u4/u8 f4/f8)"
@@ -488,6 +545,35 @@ where
 }
 
 /// Append a decoded (canonicalized) Vortex column's values onto the matching output (bit-exact).
+/// Execute one struct field into its declared `ColumnData` type and append it.
+/// Numeric columns canonicalize to `PrimitiveArray`; `Bool` → `BoolArray`,
+/// `Utf8` → `VarBinViewArray` (the compressor's chosen scheme is transparent
+/// here — canonicalization undoes FSST/dict/bit-packing).
+fn extend_field(col: &mut ColumnData, field: ArrayRef, ctx: &mut ExecutionCtx) -> Result<()> {
+    match col {
+        ColumnData::Bool(v) => {
+            let b: BoolArray = field.execute(ctx).map_err(ze)?;
+            v.extend(b.into_bit_buffer().iter());
+        }
+        ColumnData::Utf8(v) => {
+            let s: VarBinViewArray = field.execute(ctx).map_err(ze)?;
+            s.with_iterator(|it| {
+                for opt in it {
+                    v.push(
+                        opt.map(|b| String::from_utf8_lossy(b).into_owned())
+                            .unwrap_or_default(),
+                    );
+                }
+            });
+        }
+        _ => {
+            let prim: PrimitiveArray = field.execute(ctx).map_err(ze)?;
+            extend_column(col, &prim);
+        }
+    }
+    Ok(())
+}
+
 fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
     match col {
         ColumnData::I8(v) => v.extend_from_slice(prim.as_slice::<i8>()),
@@ -500,6 +586,9 @@ fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
         ColumnData::U64(v) => v.extend_from_slice(prim.as_slice::<u64>()),
         ColumnData::F32(v) => v.extend_from_slice(prim.as_slice::<f32>()),
         ColumnData::F64(v) => v.extend_from_slice(prim.as_slice::<f64>()),
+        ColumnData::Bool(_) | ColumnData::Utf8(_) => {
+            unreachable!("bool/utf8 columns are handled in extend_field, not as primitives")
+        }
     }
 }
 
@@ -527,9 +616,7 @@ pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
         while let Some(chunk) = stream.next().await {
             let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
             for (i, col) in cols.iter_mut().enumerate() {
-                let prim: PrimitiveArray =
-                    st.unmasked_field(i).clone().execute(&mut ctx).map_err(ze)?;
-                extend_column(col, &prim);
+                extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
             }
         }
         Ok::<(), Error>(())
@@ -569,9 +656,7 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
         futures::pin_mut!(stream);
         while let Some(chunk) = stream.next().await {
             let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
-            let prim: PrimitiveArray =
-                st.unmasked_field(0).clone().execute(&mut ctx).map_err(ze)?;
-            extend_column(&mut out, &prim);
+            extend_field(&mut out, st.unmasked_field(0).clone(), &mut ctx)?;
         }
         Ok::<(), Error>(())
     })?;
@@ -926,6 +1011,65 @@ mod tests {
             encode(&spec, &data).unwrap(),
             blob,
             "table non-deterministic"
+        );
+    }
+
+    #[test]
+    fn bool_and_utf8_columns_roundtrip() {
+        use tessera_core::block::table::{Column, TableSpec};
+        let n = 300usize;
+        let flags: Vec<bool> = (0..n).map(|k| k % 3 == 0).collect();
+        let origins: Vec<String> = (0..n)
+            .map(|k| ["annih511", "prompt_nuclear", "other"][k % 3].to_string())
+            .collect();
+        let data: TableData = vec![
+            ("flag".into(), ColumnData::Bool(flags.clone())),
+            ("origin".into(), ColumnData::Utf8(origins.clone())),
+        ];
+        let spec = TableSpec {
+            columns: vec![Column::new("flag", "b1"), Column::new("origin", "str")],
+            rows: n as u64,
+            row_index: None,
+        };
+        // Vortex round-trip (bit-packed bool + FSST/dict-chosen strings).
+        let blob = encode(&spec, &data).unwrap();
+        assert_eq!(
+            decode(&spec, &blob).unwrap(),
+            data,
+            "bool/utf8 vortex roundtrip"
+        );
+        assert_eq!(
+            encode(&spec, &data).unwrap(),
+            blob,
+            "bool/utf8 non-deterministic"
+        );
+        // The low-cardinality origin column compresses: encoding the *same shape* with unique
+        // strings instead is materially bigger, i.e. the compressor exploited the repeats
+        // (dict/FSST). Comparing against the raw string bytes would be unfair — a Vortex file
+        // carries a fixed footer/metadata cost that dwarfs 300 short strings.
+        let unique: Vec<String> = (0..n).map(|k| format!("origin-{k:07}")).collect();
+        let hi_card: TableData = vec![
+            ("flag".into(), ColumnData::Bool(flags.clone())),
+            ("origin".into(), ColumnData::Utf8(unique)),
+        ];
+        let hi_blob = encode(&spec, &hi_card).unwrap();
+        assert!(
+            blob.len() < hi_blob.len(),
+            "expected the repeated-string column to compress below the unique-string one: \
+             {} vs {}",
+            blob.len(),
+            hi_blob.len()
+        );
+        // LE-bytes round-trip (cross-runtime path).
+        let b = ColumnData::Bool(flags.clone());
+        assert_eq!(
+            ColumnData::from_le_bytes("b1", &b.to_le_bytes()).unwrap(),
+            b
+        );
+        let u = ColumnData::Utf8(origins);
+        assert_eq!(
+            ColumnData::from_le_bytes("str", &u.to_le_bytes()).unwrap(),
+            u
         );
     }
 

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -101,6 +101,27 @@ impl ColumnData {
         self.len() == 0
     }
 
+    /// Reserve capacity for exactly `additional` more rows in the backing `Vec` — the
+    /// accumulator pre-size used by the slab decoders. Lives here (rather than as a
+    /// per-variant `match` at each call site) so adding a variant can't leave a downstream
+    /// pre-size loop silently unhandled.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        match self {
+            ColumnData::I8(v) => v.reserve_exact(additional),
+            ColumnData::I16(v) => v.reserve_exact(additional),
+            ColumnData::I32(v) => v.reserve_exact(additional),
+            ColumnData::I64(v) => v.reserve_exact(additional),
+            ColumnData::U8(v) => v.reserve_exact(additional),
+            ColumnData::U16(v) => v.reserve_exact(additional),
+            ColumnData::U32(v) => v.reserve_exact(additional),
+            ColumnData::U64(v) => v.reserve_exact(additional),
+            ColumnData::F32(v) => v.reserve_exact(additional),
+            ColumnData::F64(v) => v.reserve_exact(additional),
+            ColumnData::Bool(v) => v.reserve_exact(additional),
+            ColumnData::Utf8(v) => v.reserve_exact(additional),
+        }
+    }
+
     /// The column's values as `i64` for chunk-statistics (ADR-0028 §3), if it is an integer column that
     /// fits losslessly: `i1/i2/i4/i8`, `u1/u2/u4` always, and `u8` (u64) only when every value ≤
     /// `i64::MAX` (a monotonic cast → `min`/`max` stay exact). Float columns return `None` (they need


### PR DESCRIPTION
Stacked on #353 → #350. Review those first.

`table::ColumnData` covered `I8…F64` only — no booleans, no strings. Any real
listmode table has both, so integrators encode them by convention: a bool becomes a
`u1` column, a small categorical becomes a `u1` dictionary code, and the convention
itself gets written into the product's sealed `extra`. That convention is invisible to
every other reader of the file, which defeats the point of a self-describing format.

Adds:

- `ColumnData::Bool(Vec<bool>)` — dtype code `b1`, stored bit-packed as a Vortex
  `BoolArray`.
- `ColumnData::Utf8(Vec<String>)` — dtype code `str`, stored as a Vortex
  `VarBinViewArray`.

Both are wired through every `ColumnData` site (`numpy_code`, `len`, `as_i64`,
`to_le_bytes`/`from_le_bytes`, `empty_column`, `slice`, `extend`, `to_vortex`, and the
decode dispatch), so they work in batch encode, streaming encode, chunk-index
construction, and the LE-bytes cross-runtime path alike.

**On strings and dictionaries:** raw `Utf8` with repeats is not wasteful — the
BtrBlocks compressor picks FSST/dictionary for a low-cardinality column on its own.
The test asserts this rather than assuming it: the same schema encoded with 300
repeated strings comes out smaller than with 300 unique ones. For a *known* small enum
the better schema is still an integer code column plus a code→label descriptor (the
string analogue of `Transform::Lookup`) — integer filtering, explicit enum-ness — but
that is a schema choice layered on these primitives, not a reason to withhold them.