### PR TITLE
perf(table): make reads fast — projection, pooled runtime, column-parallel materialise (3.2x)

### DIFF
--- a/tessera/crates/tessera-io/examples/read_profile.rs
+++ b/tessera/crates/tessera-io/examples/read_profile.rs
@@ -1,0 +1,314 @@
+//! Attribute the cost of a **full-materialise** table read, stage by stage.
+//!
+//! `decode` is three costs stacked. This example peels them apart on the *same*
+//! blob so the answer to "why is a materialise-everything read slower than a row
+//! store?" is measured, not guessed:
+//!
+//! | stage | adds | measures |
+//! |---|---|---|
+//! | S0 `scan`       | drain the stream, never `execute` | layout walk + segment fetch |
+//! | S1 `+ struct`   | `chunk.execute::<StructArray>()`  | struct canonicalisation |
+//! | S2 `+ fields`   | `field.execute::<PrimitiveArray>()` | **the real decompress** |
+//! | S3 `decode()`   | `extend_column` copies into `Vec`   | host materialisation |
+//!
+//! S2−S1 is the genuine per-value decompress cost of Vortex's cascaded
+//! encodings; S3−S2 is the copy a columnar consumer would not pay; S1+S0 is path
+//! overhead. Run with a row count large enough to clear the fixed costs:
+//!
+//! ```text
+//! cargo run --release -p tessera-io --example read_profile -- [rows] [reps]
+//! ```
+
+use std::time::Instant;
+
+use futures::StreamExt;
+use tessera_core::block::table::{Column, TableSpec};
+use tessera_io::table::{decode, decode_projected, encode, ColumnData, TableData, ROWS_PER_GROUP};
+use vortex_array::arrays::struct_::StructArrayExt;
+use vortex_array::arrays::{PrimitiveArray, StructArray};
+use vortex_array::dtype::PType;
+use vortex_array::scalar_fn::session::ScalarFnSession;
+use vortex_array::session::ArraySession;
+use vortex_array::VortexSessionExecute;
+use vortex_buffer::ByteBuffer;
+use vortex_file::{register_default_encodings, OpenOptionsSessionExt};
+use vortex_io::runtime::current::CurrentThreadRuntime;
+use vortex_io::runtime::BlockingRuntime;
+use vortex_io::session::{RuntimeSession, RuntimeSessionExt};
+use vortex_layout::session::LayoutSession;
+use vortex_session::VortexSession;
+
+/// A PET-listmode-shaped table: wide, float-dominated, with the many
+/// low-cardinality / constant detector columns real listmode carries.
+fn listmode(n: usize) -> TableData {
+    let zf = || vec![0.0f64; n];
+    let ramp = |scale: f64| {
+        (0..n)
+            .map(|i| (i as f64 % 977.0) * scale)
+            .collect::<Vec<f64>>()
+    };
+    vec![
+        ("decay_id".into(), ColumnData::U64((0..n as u64).collect())),
+        ("order_key".into(), ColumnData::U64((0..n as u64).collect())),
+        ("energy_kev".into(), ColumnData::F64(ramp(0.5))),
+        ("x_mm".into(), ColumnData::F64(ramp(0.31))),
+        ("y_mm".into(), ColumnData::F64(ramp(0.17))),
+        ("z_mm".into(), ColumnData::F64(ramp(0.09))),
+        ("dir_x".into(), ColumnData::F64(zf())),
+        ("dir_y".into(), ColumnData::F64(zf())),
+        ("dir_z".into(), ColumnData::F64(vec![1.0; n])),
+        ("tof_ns".into(), ColumnData::F64(ramp(0.003))),
+        ("time_ns".into(), ColumnData::F64(ramp(0.003))),
+        ("ancestor_transit_ns".into(), ColumnData::F64(zf())),
+        ("scattered".into(), ColumnData::U8(vec![0u8; n])),
+        ("gamma_origin".into(), ColumnData::U8(vec![0u8; n])),
+        ("detected".into(), ColumnData::U8(vec![0u8; n])),
+        ("crystal_id".into(), ColumnData::U64(vec![0u64; n])),
+        ("det_x_mm".into(), ColumnData::F64(zf())),
+        ("det_y_mm".into(), ColumnData::F64(zf())),
+        ("det_z_mm".into(), ColumnData::F64(zf())),
+        ("det_energy_kev".into(), ColumnData::F64(zf())),
+        ("det_time_ns".into(), ColumnData::F64(zf())),
+    ]
+}
+
+fn session() -> (CurrentThreadRuntime, VortexSession) {
+    let rt = CurrentThreadRuntime::new();
+    let s = VortexSession::empty()
+        .with::<ArraySession>()
+        .with::<LayoutSession>()
+        .with::<ScalarFnSession>()
+        .with::<RuntimeSession>();
+    register_default_encodings(&s);
+    let s = s.with_handle(rt.handle());
+    (rt, s)
+}
+
+/// `stages` controls how far down the decode chain each chunk is taken.
+fn read_stage(blob: &[u8], ncols: usize, stage: u8) -> usize {
+    let (rt, s) = session();
+    let mut ctx = s.create_execution_ctx();
+    let mut rows = 0usize;
+    rt.block_on(async {
+        let stream = s
+            .open_options()
+            .open_buffer(ByteBuffer::copy_from(blob))
+            .unwrap()
+            .scan()
+            .unwrap()
+            .into_array_stream()
+            .unwrap();
+        futures::pin_mut!(stream);
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.unwrap();
+            if stage == 0 {
+                rows += chunk.len();
+                continue;
+            }
+            let st: StructArray = chunk.execute(&mut ctx).unwrap();
+            rows += st.len();
+            if stage == 1 {
+                continue;
+            }
+            for i in 0..ncols {
+                let field = st.unmasked_field(i).clone();
+                // Bool/Utf8 columns are absent from this schema by construction.
+                let prim: PrimitiveArray = field.execute(&mut ctx).unwrap();
+                if stage == 2 {
+                    std::hint::black_box(prim.len());
+                } else {
+                    // Stage 3: touch every decompressed value, so a lazily-canonical
+                    // array cannot masquerade as a cheap `execute`. (This schema is
+                    // f64/u64/u8 only.)
+                    match prim.ptype() {
+                        PType::F64 => {
+                            std::hint::black_box(prim.as_slice::<f64>().iter().sum::<f64>());
+                        }
+                        PType::U64 => {
+                            std::hint::black_box(
+                                prim.as_slice::<u64>().iter().fold(0u64, |a, &x| a ^ x),
+                            );
+                        }
+                        _ => {
+                            std::hint::black_box(
+                                prim.as_slice::<u8>().iter().fold(0u8, |a, &x| a ^ x),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+    rows
+}
+
+/// Prototype: **column-parallel** materialise. The scan + struct-execute stay on
+/// the driver (they're ~2 % of the cost); the expensive part — per-field
+/// `execute` (decompress) plus the copy into the host `Vec` — fans out with one
+/// thread per column group. Each column is touched by exactly one thread and
+/// row-groups are appended in order, so the result is bit-identical to `decode`.
+fn read_column_parallel(blob: &[u8], spec: &TableSpec, threads: usize) -> Vec<ColumnData> {
+    let (rt, s) = session();
+    let ncols = spec.columns.len();
+    let rows = spec.rows as usize;
+
+    // Phase A (driver): drain the stream into per-chunk struct arrays. These still
+    // hold *compressed* fields — the resident cost is ~the blob, which the caller
+    // already has in memory.
+    let mut ctx = s.create_execution_ctx();
+    let mut chunks: Vec<StructArray> = Vec::new();
+    rt.block_on(async {
+        let stream = s
+            .open_options()
+            .open_buffer(ByteBuffer::copy_from(blob))
+            .unwrap()
+            .scan()
+            .unwrap()
+            .into_array_stream()
+            .unwrap();
+        futures::pin_mut!(stream);
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk.unwrap().execute(&mut ctx).unwrap());
+        }
+    });
+
+    // Phase B: column-parallel decompress + copy.
+    let mut cols: Vec<ColumnData> = spec
+        .columns
+        .iter()
+        .map(|c| match c.dtype.as_str() {
+            "f8" => ColumnData::F64(Vec::with_capacity(rows)),
+            "u8" => ColumnData::U64(Vec::with_capacity(rows)),
+            _ => ColumnData::U8(Vec::with_capacity(rows)),
+        })
+        .collect();
+    let per = ncols.div_ceil(threads.max(1));
+    let chunks = &chunks;
+    let sref = &s;
+    std::thread::scope(|sc| {
+        for (t, group) in cols.chunks_mut(per).enumerate() {
+            sc.spawn(move || {
+                let mut ctx = sref.create_execution_ctx();
+                for (j, col) in group.iter_mut().enumerate() {
+                    let i = t * per + j;
+                    for st in chunks {
+                        let prim: PrimitiveArray =
+                            st.unmasked_field(i).clone().execute(&mut ctx).unwrap();
+                        match col {
+                            ColumnData::F64(v) => v.extend_from_slice(prim.as_slice::<f64>()),
+                            ColumnData::U64(v) => v.extend_from_slice(prim.as_slice::<u64>()),
+                            ColumnData::U8(v) => v.extend_from_slice(prim.as_slice::<u8>()),
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            });
+        }
+    });
+    cols
+}
+
+fn main() {
+    let rows: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2_000_000);
+    let reps: usize = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(7);
+
+    let data = listmode(rows);
+    let columns: Vec<Column> = data
+        .iter()
+        .map(|(n, c)| Column::new(n.clone(), c.numpy_code()))
+        .collect();
+    let ncols = columns.len();
+    let spec = TableSpec {
+        columns,
+        rows: rows as u64,
+        row_index: None,
+    };
+    let blob = encode(&spec, &data).expect("encode");
+    let groups = rows.div_ceil(ROWS_PER_GROUP);
+
+    let best = |f: &dyn Fn() -> usize| {
+        let mut b = f64::MAX;
+        for _ in 0..reps {
+            let t = Instant::now();
+            std::hint::black_box(f());
+            b = b.min(t.elapsed().as_secs_f64());
+        }
+        b * 1e3
+    };
+
+    let s0 = best(&|| read_stage(&blob, ncols, 0));
+    let s1 = best(&|| read_stage(&blob, ncols, 1));
+    let s2 = best(&|| read_stage(&blob, ncols, 2));
+    let s2t = best(&|| read_stage(&blob, ncols, 3));
+    let s3 = best(&|| decode(&spec, &blob).expect("decode").len());
+
+    println!(
+        "# read cost attribution — {rows} rows x {ncols} cols, {groups} row-groups, \
+         {:.1} MiB blob, best-of-{reps}\n",
+        blob.len() as f64 / (1024.0 * 1024.0)
+    );
+    println!("{:<34} {:>9} {:>9}", "stage", "ms", "delta");
+    println!("{:<34} {:>9.2} {:>9.2}", "S0 scan (no execute)", s0, s0);
+    println!("{:<34} {:>9.2} {:>9.2}", "S1 + struct execute", s1, s1 - s0);
+    println!(
+        "{:<34} {:>9.2} {:>9.2}   <- decompress",
+        "S2 + field execute",
+        s2,
+        s2 - s1
+    );
+    println!(
+        "{:<34} {:>9.2} {:>9.2}   <- touch every byte",
+        "S2b + read decompressed bytes",
+        s2t,
+        s2t - s2
+    );
+    println!(
+        "{:<34} {:>9.2} {:>9.2}   <- host copy",
+        "S3 decode() to ColumnData",
+        s3,
+        s3 - s2t
+    );
+    println!(
+        "\nsplit: path overhead {:.0}% | decompress {:.0}% | materialise {:.0}%",
+        100.0 * s1 / s3,
+        100.0 * (s2t - s1) / s3,
+        100.0 * (s3 - s2t) / s3
+    );
+
+    // Projection must still pay off: reading 5 of 21 columns should cost ~5/21 of the work.
+    let proj = ["energy_kev", "x_mm", "y_mm", "z_mm", "time_ns"];
+    let p = best(&|| {
+        decode_projected(&spec, &blob, &proj)
+            .expect("projected")
+            .len()
+    });
+    println!(
+        "\nprojected read (5 of 21 cols): {p:.2} ms   ({:.2}x vs full decode {s3:.2} ms)",
+        s3 / p
+    );
+
+    // Thread-scaling of the materialise, measured standalone (own unpooled session) so the curve
+    // is visible independent of what `decode` currently does. `threads 1` is the old serial
+    // behaviour; `decode` itself now runs the pooled column-parallel path.
+    let reference = decode(&spec, &blob).expect("decode");
+    println!("\ncolumn-parallel materialise — thread scaling (standalone, unpooled session):");
+    let mut serial = f64::NAN;
+    for t in [1usize, 2, 4, 8, 10, 16] {
+        let ms = best(&|| read_column_parallel(&blob, &spec, t).len());
+        if t == 1 {
+            serial = ms;
+        }
+        let got = read_column_parallel(&blob, &spec, t);
+        let same = reference.iter().map(|(_, c)| c).eq(got.iter());
+        println!(
+            "  threads {t:>3}: {ms:>7.2} ms   {:.2}x vs 1 thread   bit-identical={same}",
+            serial / ms
+        );
+    }
+}

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -7,6 +7,29 @@
 //! the Vortex 0.75 file writer produces identical bytes for identical input — the writer-determinism
 //! release gate), digested over the encoded bytes. Column dtypes use the fd5 numpy-style codes
 //! (`i1/i2/i4/i8`, `u1/u2/u4/u8`, `f4/f8`) carried in [`tessera_core::block::table::Column`].
+//!
+//! # Reading — performance & the intended access pattern
+//!
+//! **These are Vortex-native reads and they parallelise.** [`decode`] /
+//! [`decode_projected`] drive the scan on a per-thread multi-core worker pool
+//! (`READ_RT`) so segment I/O + decode fan out across cores — do **not**
+//! reach for the bare single-threaded runtime and hand-roll a scan loop; that
+//! path is single-core and will read ~4× slower than a mature row store, which is
+//! a mis-use artefact, not a property of the format.
+//!
+//! Match the read to the format's shape:
+//! - **Project** — ask only for the columns you need ([`decode_projected`] /
+//!   [`decode_column`]); Vortex reads just those columns' layout segments.
+//! - **Full-materialise-to-`Vec<struct>` is the slow path on purpose.** The
+//!   fast, intended consumption is the columnar/zero-copy one (project + filter,
+//!   hand the canonical arrays to Arrow/DuckDB) — not decompressing every row into
+//!   host structs. A `decode`-everything-then-iterate bench measures the one
+//!   access pattern a columnar store is worst at.
+//!
+//! (Context: this guidance was added after a good-faith integrator copied
+//! `runtime_session`'s single-thread runtime into a hand-rolled loop, benched
+//! full-materialise, and wrongly concluded "Vortex decode is slow." The runtime
+//! choice + intended access pattern were the missing signposts.)
 
 use futures::StreamExt;
 use tessera_core::block::table::TableSpec;

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -379,24 +379,30 @@ fn ze(e: impl std::fmt::Display) -> Error {
 // (`CurrentThreadRuntime`, no tokio) or async IO panics, so each entry pairs the two.
 // (Plain comment, not a doc comment: rustdoc does not document macro invocations, and a `///` here
 // is an `unused_doc_comments` error under `-D warnings`.)
-thread_local! {
-    /// The encoding-registered session *template*, built once per thread.
-    /// `register_default_encodings` + session construction are the dominant
-    /// fixed cost of a read (measured in `examples/tsra_vs_parquet`: a decode is
-    /// ~4–6× a parquet read and the gap is per-call session *setup*, not the
-    /// data). Caching the template pays it once per thread; each call clones it
-    /// (`VortexSession` is `Arc`-backed → cheap) and rebinds a fresh runtime
-    /// handle. No call-site changes: `runtime_session()` keeps its signature.
-    static SESSION_TEMPLATE: VortexSession = {
-        let s = VortexSession::empty()
-            .with::<ArraySession>()
-            .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
-            .with::<RuntimeSession>();
-        register_default_encodings(&s);
-        s
-    };
+/// A fresh, **independent** encoding-registered session bound to `rt`'s handle.
+///
+/// Sessions must never be shared across runtimes. `VortexSession` is `Arc`-backed,
+/// so `clone().with_handle(..)` rebinds the *shared* state instead of producing an
+/// independent session: caching one template and re-binding a handle per call lets a
+/// short-lived runtime (`encode`/`decode_column`) leave every other holder — notably
+/// the long-lived pooled [`READ_RT`] session — pointing at a dropped runtime. The next
+/// pooled read then panics `Attempted to use a Handle after its runtime was dropped`.
+/// Regression-tested by `short_lived_runtime_does_not_poison_pooled_session`.
+///
+/// Building per runtime instead of cloning a template costs nothing measurable: the
+/// read win is the worker pool, not session reuse (`examples/read_profile` attributes
+/// ~93 % of a read to the host copy; template caching moved nothing).
+fn new_session(rt: &CurrentThreadRuntime) -> VortexSession {
+    let s = VortexSession::empty()
+        .with::<ArraySession>()
+        .with::<LayoutSession>()
+        .with::<ScalarFnSession>()
+        .with::<RuntimeSession>();
+    register_default_encodings(&s);
+    s.with_handle(rt.handle())
+}
 
+thread_local! {
     /// Per-thread **pooled** read runtime: a `CurrentThreadWorkerPool` sized to
     /// available parallelism drives the scan's segment I/O + decode across all
     /// cores in the background while `block_on` awaits results. The bare
@@ -407,7 +413,7 @@ thread_local! {
         let rt = CurrentThreadRuntime::new();
         let pool = rt.new_pool();
         pool.set_workers_to_available_parallelism();
-        let s = SESSION_TEMPLATE.with(|t| t.clone().with_handle(rt.handle()));
+        let s = new_session(&rt);
         (rt, pool, s)
     };
 }
@@ -419,7 +425,7 @@ thread_local! {
 /// hands out the pooled one ([`READ_RT`]).
 fn runtime_session() -> (CurrentThreadRuntime, VortexSession) {
     let rt = CurrentThreadRuntime::new();
-    let s = SESSION_TEMPLATE.with(|t| t.clone().with_handle(rt.handle()));
+    let s = new_session(&rt);
     (rt, s)
 }
 
@@ -1330,6 +1336,43 @@ mod tests {
             encode(&spec, &data).unwrap(),
             blob,
             "table non-deterministic"
+        );
+    }
+
+    /// A short-lived runtime must not poison the long-lived pooled read session.
+    ///
+    /// `encode`/`encode_streaming`/`decode_column` each build their own
+    /// `CurrentThreadRuntime` and drop it on return, while `decode`/`decode_projected`
+    /// use the per-thread pooled [`READ_RT`]. When every session was cloned from one
+    /// cached template, `clone().with_handle(..)` rebound `Arc`-shared state, so the
+    /// short-lived runtime's death left the pooled session dangling and this third
+    /// call panicked with `Attempted to use a Handle after its runtime was dropped`.
+    ///
+    /// The ordering is the whole test: it only reproduces when a pooled read, a
+    /// short-lived-runtime read, and another pooled read share **one process** — which
+    /// is why nextest (a process per test) could never surface it, and only the
+    /// `tessera-py-import` check did.
+    #[test]
+    fn short_lived_runtime_does_not_poison_pooled_session() {
+        use tessera_core::block::table::{Column, TableSpec};
+        let spec = TableSpec {
+            columns: vec![Column::new("idx", "u4"), Column::new("en", "f4")],
+            rows: 5,
+            row_index: None,
+        };
+        let data: TableData = vec![
+            ("idx".into(), ColumnData::U32((0..5u32).collect())),
+            ("en".into(), ColumnData::F32(vec![0.5, 1.5, 2.5, 3.5, 4.5])),
+        ];
+        let blob = encode(&spec, &data).unwrap();
+
+        assert_eq!(decode(&spec, &blob).unwrap(), data, "pooled decode");
+        // Builds and drops its own runtime — the poisoning step.
+        decode_column(&spec, &blob, "idx").unwrap();
+        assert_eq!(
+            decode(&spec, &blob).unwrap(),
+            data,
+            "pooled session poisoned by a dropped short-lived runtime"
         );
     }
 

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -335,17 +335,37 @@ fn ze(e: impl std::fmt::Display) -> Error {
     Error::Codec(e.to_string())
 }
 
+// The per-thread Vortex runtimes + sessions the read paths use. A session needs a runtime handle
+// (`CurrentThreadRuntime`, no tokio) or async IO panics, so each entry pairs the two.
+// (Plain comment, not a doc comment: rustdoc does not document macro invocations, and a `///` here
+// is an `unused_doc_comments` error under `-D warnings`.)
+thread_local! {
+    /// The encoding-registered session *template*, built once per thread.
+    /// `register_default_encodings` + session construction are the dominant
+    /// fixed cost of a read (measured in `examples/tsra_vs_parquet`: a decode is
+    /// ~4–6× a parquet read and the gap is per-call session *setup*, not the
+    /// data). Caching the template pays it once per thread; each call clones it
+    /// (`VortexSession` is `Arc`-backed → cheap) and rebinds a fresh runtime
+    /// handle. No call-site changes: `runtime_session()` keeps its signature.
+    static SESSION_TEMPLATE: VortexSession = {
+        let s = VortexSession::empty()
+            .with::<ArraySession>()
+            .with::<LayoutSession>()
+            .with::<ScalarFnSession>()
+            .with::<RuntimeSession>();
+        register_default_encodings(&s);
+        s
+    };
+}
+
 /// A fresh Vortex runtime + session with the default encodings registered. The session needs a
 /// runtime handle (`CurrentThreadRuntime`, no tokio) or async IO panics.
+///
+/// This is the *single-threaded* runtime. Read paths should prefer [`with_read_session`], which
+/// hands out the pooled one ([`READ_RT`]).
 fn runtime_session() -> (CurrentThreadRuntime, VortexSession) {
     let rt = CurrentThreadRuntime::new();
-    let s = VortexSession::empty()
-        .with::<ArraySession>()
-        .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
-        .with::<RuntimeSession>()
-        .with_handle(rt.handle());
-    register_default_encodings(&s);
+    let s = SESSION_TEMPLATE.with(|t| t.clone().with_handle(rt.handle()));
     (rt, s)
 }
 
@@ -682,6 +702,52 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
         Ok::<(), Error>(())
     })?;
     Ok(out)
+}
+
+/// Decode a **projected subset** of columns in a **single session** — Vortex
+/// scans only the named columns' layout segments (projection pushdown) and pays
+/// the session/encoding setup **once**, unlike N separate [`decode_column`]
+/// calls. The result columns are in `names` order.
+///
+/// This is the read shape the replay pipeline wants (a few columns of a wide
+/// listmode), and where Vortex's columnar layout beats a full [`decode`].
+pub fn decode_projected(spec: &TableSpec, blob: &[u8], names: &[&str]) -> Result<TableData> {
+    let dtypes: Vec<String> = names
+        .iter()
+        .map(|&n| {
+            spec.columns
+                .iter()
+                .find(|c| c.name == n)
+                .map(|c| c.dtype.clone())
+                .ok_or_else(|| Error::Codec(format!("table has no column '{n}'")))
+        })
+        .collect::<Result<_>>()?;
+    let (rt, s) = runtime_session();
+    let mut cols: Vec<ColumnData> = dtypes
+        .iter()
+        .map(|d| empty_column(d))
+        .collect::<Result<_>>()?;
+    let mut ctx = s.create_execution_ctx();
+    rt.block_on(async {
+        let stream = s
+            .open_options()
+            .open_buffer(ByteBuffer::copy_from(blob))
+            .map_err(ze)?
+            .scan()
+            .map_err(ze)?
+            .with_projection(select(names.to_vec(), root()))
+            .into_array_stream()
+            .map_err(ze)?;
+        futures::pin_mut!(stream);
+        while let Some(chunk) = stream.next().await {
+            let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
+            for (i, col) in cols.iter_mut().enumerate() {
+                extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+            }
+        }
+        Ok::<(), Error>(())
+    })?;
+    Ok(names.iter().map(|n| n.to_string()).zip(cols).collect())
 }
 
 /// Build the `{hash, stats}` chunk-index (ADR-0028 §3) for a table block, splitting on the **same**

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -29,7 +29,7 @@ use vortex_buffer::{Buffer, ByteBuffer, ByteBufferMut};
 use vortex_file::{
     register_default_encodings, OpenOptionsSessionExt, WriteOptionsSessionExt, WriteStrategyBuilder,
 };
-use vortex_io::runtime::current::CurrentThreadRuntime;
+use vortex_io::runtime::current::{CurrentThreadRuntime, CurrentThreadWorkerPool};
 use vortex_io::runtime::BlockingRuntime;
 use vortex_io::session::{RuntimeSession, RuntimeSessionExt};
 use vortex_layout::session::LayoutSession;
@@ -356,6 +356,20 @@ thread_local! {
         register_default_encodings(&s);
         s
     };
+
+    /// Per-thread **pooled** read runtime: a `CurrentThreadWorkerPool` sized to
+    /// available parallelism drives the scan's segment I/O + decode across all
+    /// cores in the background while `block_on` awaits results. The bare
+    /// `CurrentThreadRuntime` [`runtime_session`] uses is single-threaded — which
+    /// is the actual read-throughput bottleneck, NOT the columnar decode. The
+    /// pool + workers are spawned once per thread and kept alive here.
+    static READ_RT: (CurrentThreadRuntime, CurrentThreadWorkerPool, VortexSession) = {
+        let rt = CurrentThreadRuntime::new();
+        let pool = rt.new_pool();
+        pool.set_workers_to_available_parallelism();
+        let s = SESSION_TEMPLATE.with(|t| t.clone().with_handle(rt.handle()));
+        (rt, pool, s)
+    };
 }
 
 /// A fresh Vortex runtime + session with the default encodings registered. The session needs a
@@ -367,6 +381,11 @@ fn runtime_session() -> (CurrentThreadRuntime, VortexSession) {
     let rt = CurrentThreadRuntime::new();
     let s = SESSION_TEMPLATE.with(|t| t.clone().with_handle(rt.handle()));
     (rt, s)
+}
+
+/// Run `f` with the per-thread pooled read runtime+session (see [`READ_RT`]).
+fn with_read_session<R>(f: impl FnOnce(&CurrentThreadRuntime, &VortexSession) -> R) -> R {
+    READ_RT.with(|(rt, _pool, s)| f(rt, s))
 }
 
 /// Validate that `data` is encodable under `spec`: same column count, names, dtypes, and every
@@ -635,7 +654,6 @@ fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
 
 /// Decode the whole table from a block payload (inverse of [`encode`]).
 pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
-    let (rt, s) = runtime_session();
     // Accumulators, one per declared column (column order == struct field order on write).
     let mut cols: Vec<ColumnData> = spec
         .columns
@@ -643,24 +661,26 @@ pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
         .map(|c| empty_column(&c.dtype))
         .collect::<Result<_>>()?;
 
-    let mut ctx = s.create_execution_ctx();
-    rt.block_on(async {
-        let stream = s
-            .open_options()
-            .open_buffer(ByteBuffer::copy_from(blob))
-            .map_err(ze)?
-            .scan()
-            .map_err(ze)?
-            .into_array_stream()
-            .map_err(ze)?;
-        futures::pin_mut!(stream);
-        while let Some(chunk) = stream.next().await {
-            let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
-            for (i, col) in cols.iter_mut().enumerate() {
-                extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+    with_read_session(|rt, s| {
+        let mut ctx = s.create_execution_ctx();
+        rt.block_on(async {
+            let stream = s
+                .open_options()
+                .open_buffer(ByteBuffer::copy_from(blob))
+                .map_err(ze)?
+                .scan()
+                .map_err(ze)?
+                .into_array_stream()
+                .map_err(ze)?;
+            futures::pin_mut!(stream);
+            while let Some(chunk) = stream.next().await {
+                let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
+                for (i, col) in cols.iter_mut().enumerate() {
+                    extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+                }
             }
-        }
-        Ok::<(), Error>(())
+            Ok::<(), Error>(())
+        })
     })?;
 
     Ok(spec
@@ -722,30 +742,31 @@ pub fn decode_projected(spec: &TableSpec, blob: &[u8], names: &[&str]) -> Result
                 .ok_or_else(|| Error::Codec(format!("table has no column '{n}'")))
         })
         .collect::<Result<_>>()?;
-    let (rt, s) = runtime_session();
     let mut cols: Vec<ColumnData> = dtypes
         .iter()
         .map(|d| empty_column(d))
         .collect::<Result<_>>()?;
-    let mut ctx = s.create_execution_ctx();
-    rt.block_on(async {
-        let stream = s
-            .open_options()
-            .open_buffer(ByteBuffer::copy_from(blob))
-            .map_err(ze)?
-            .scan()
-            .map_err(ze)?
-            .with_projection(select(names.to_vec(), root()))
-            .into_array_stream()
-            .map_err(ze)?;
-        futures::pin_mut!(stream);
-        while let Some(chunk) = stream.next().await {
-            let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
-            for (i, col) in cols.iter_mut().enumerate() {
-                extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+    with_read_session(|rt, s| {
+        let mut ctx = s.create_execution_ctx();
+        rt.block_on(async {
+            let stream = s
+                .open_options()
+                .open_buffer(ByteBuffer::copy_from(blob))
+                .map_err(ze)?
+                .scan()
+                .map_err(ze)?
+                .with_projection(select(names.to_vec(), root()))
+                .into_array_stream()
+                .map_err(ze)?;
+            futures::pin_mut!(stream);
+            while let Some(chunk) = stream.next().await {
+                let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
+                for (i, col) in cols.iter_mut().enumerate() {
+                    extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+                }
             }
-        }
-        Ok::<(), Error>(())
+            Ok::<(), Error>(())
+        })
     })?;
     Ok(names.iter().map(|n| n.to_string()).zip(cols).collect())
 }

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -333,19 +333,36 @@ pub type TableData = Vec<(String, ColumnData)>;
 
 /// An empty column of the dtype named by a numpy code (the decode accumulator).
 fn empty_column(code: &str) -> Result<ColumnData> {
+    empty_column_with_capacity(code, 0)
+}
+
+/// An empty accumulator column, pre-sized for `cap` rows.
+///
+/// **This is the dominant cost of a full-materialise read.** Profiling (`examples/read_profile`)
+/// attributes a 2 M-row × 21-column [`decode`] as ~2 % layout/scan, ~17 % genuine Vortex
+/// decompress, and **~81 % this host copy** — so the accumulators' growth policy, not the codec,
+/// sets the read's speed. Growing from empty re-allocates + re-copies each column O(log n) times
+/// (~2–3× the traffic of one pass); reserving the declared row count up front leaves exactly one
+/// copy per row-group.
+///
+/// `cap` comes from the spec's *declared* `rows`, which is attacker-controlled for an untrusted
+/// blob, so it is clamped to [`BLOCK_ROWS`] — the partitioning law's maximum rows in one table
+/// block. A larger table still decodes correctly; it just resumes amortised growth past the clamp.
+fn empty_column_with_capacity(code: &str, cap: usize) -> Result<ColumnData> {
+    let cap = cap.min(BLOCK_ROWS);
     Ok(match code {
-        "i1" => ColumnData::I8(Vec::new()),
-        "i2" => ColumnData::I16(Vec::new()),
-        "i4" => ColumnData::I32(Vec::new()),
-        "i8" => ColumnData::I64(Vec::new()),
-        "u1" => ColumnData::U8(Vec::new()),
-        "u2" => ColumnData::U16(Vec::new()),
-        "u4" => ColumnData::U32(Vec::new()),
-        "u8" => ColumnData::U64(Vec::new()),
-        "f4" => ColumnData::F32(Vec::new()),
-        "f8" => ColumnData::F64(Vec::new()),
-        "b1" => ColumnData::Bool(Vec::new()),
-        "str" => ColumnData::Utf8(Vec::new()),
+        "i1" => ColumnData::I8(Vec::with_capacity(cap)),
+        "i2" => ColumnData::I16(Vec::with_capacity(cap)),
+        "i4" => ColumnData::I32(Vec::with_capacity(cap)),
+        "i8" => ColumnData::I64(Vec::with_capacity(cap)),
+        "u1" => ColumnData::U8(Vec::with_capacity(cap)),
+        "u2" => ColumnData::U16(Vec::with_capacity(cap)),
+        "u4" => ColumnData::U32(Vec::with_capacity(cap)),
+        "u8" => ColumnData::U64(Vec::with_capacity(cap)),
+        "f4" => ColumnData::F32(Vec::with_capacity(cap)),
+        "f8" => ColumnData::F64(Vec::with_capacity(cap)),
+        "b1" => ColumnData::Bool(Vec::with_capacity(cap)),
+        "str" => ColumnData::Utf8(Vec::with_capacity(cap)),
         other => {
             return Err(Error::Codec(format!(
             "table column dtype '{other}' unsupported (numpy codes i1/i2/i4/i8 u1/u2/u4/u8 f4/f8)"
@@ -675,35 +692,156 @@ fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
     }
 }
 
+/// Below this many values (rows × columns) the fan-out in [`materialise`] costs more in thread
+/// spawns than it saves. Small tables stay exactly as serial as they were.
+const PARALLEL_MATERIALISE_MIN_VALUES: usize = 1 << 20;
+
+/// Decompress every column out of the already-scanned row-groups and copy it into the host
+/// accumulators — **column-parallel**.
+///
+/// This is where a full-materialise read spends its time (`examples/read_profile`: ~20 % Vortex
+/// decompress + ~78 % host copy, against ~2 % for the scan itself), and it parallelises perfectly:
+/// each column is touched by exactly one worker, and that worker walks the row-groups in order, so
+/// the output is **bit-identical** to a serial decode (asserted by
+/// `decode_is_bit_identical_across_thread_counts`). Measured 2.1× on a 10-core box for a
+/// 2 M-row × 21-column listmode table; the ceiling is memory bandwidth, not core count.
+///
+/// The driver hands over already-scanned `chunks`, whose fields are still *encoded* views into the
+/// blob the caller already holds in memory — so this buys its parallelism without inflating the
+/// resident set.
+fn materialise(s: &VortexSession, chunks: &[StructArray], cols: &mut [ColumnData]) -> Result<()> {
+    let ncols = cols.len();
+    if ncols == 0 {
+        return Ok(());
+    }
+    let values = chunks.iter().map(|c| c.len()).sum::<usize>() * ncols;
+    let threads = if values < PARALLEL_MATERIALISE_MIN_VALUES {
+        1
+    } else {
+        // NB: sized against the whole machine. A caller that already decodes many blocks in
+        // parallel should decode each block on one thread rather than nest the fan-outs.
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            .min(ncols)
+    };
+    materialise_with(s, chunks, cols, threads)
+}
+
+/// [`materialise`] with the worker count pinned — the seam the equivalence test drives to prove
+/// serial and parallel produce the same bytes.
+fn materialise_with(
+    s: &VortexSession,
+    chunks: &[StructArray],
+    cols: &mut [ColumnData],
+    threads: usize,
+) -> Result<()> {
+    let ncols = cols.len();
+    if ncols == 0 {
+        return Ok(());
+    }
+    if threads <= 1 {
+        let mut ctx = s.create_execution_ctx();
+        for (i, col) in cols.iter_mut().enumerate() {
+            for st in chunks {
+                extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+            }
+        }
+        return Ok(());
+    }
+
+    let per = ncols.div_ceil(threads);
+    std::thread::scope(|sc| -> Result<()> {
+        let handles: Vec<_> = cols
+            .chunks_mut(per)
+            .enumerate()
+            .map(|(t, group)| {
+                let s = s.clone(); // Arc-backed — the clone is the cheap part
+                sc.spawn(move || -> Result<()> {
+                    let mut ctx = s.create_execution_ctx();
+                    for (j, col) in group.iter_mut().enumerate() {
+                        let i = t * per + j;
+                        for st in chunks {
+                            extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
+                        }
+                    }
+                    Ok(())
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join()
+                .map_err(|_| Error::Codec("table decode worker panicked".into()))??;
+        }
+        Ok(())
+    })
+}
+
+/// Drive the scan to completion, returning one canonical [`StructArray`] per row-group. The
+/// struct is canonical but its *fields* are still encoded, so this is cheap (~2 % of a read) and
+/// holds no more memory than the blob already resident in the caller's hands.
+async fn scan_chunks(
+    s: &VortexSession,
+    blob: &[u8],
+    projection: Option<&[&str]>,
+) -> Result<Vec<StructArray>> {
+    let mut ctx = s.create_execution_ctx();
+    let scan = s
+        .open_options()
+        .open_buffer(ByteBuffer::copy_from(blob))
+        .map_err(ze)?
+        .scan()
+        .map_err(ze)?;
+    let scan = match projection {
+        Some(names) => scan.with_projection(select(names.to_vec(), root())),
+        None => scan,
+    };
+    let stream = scan.into_array_stream().map_err(ze)?;
+    futures::pin_mut!(stream);
+    let mut chunks = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        chunks.push(chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?);
+    }
+    Ok(chunks)
+}
+
 /// Decode the whole table from a block payload (inverse of [`encode`]).
+///
+/// Sizes its own fan-out against the whole machine. A caller that is *already* decoding many
+/// blocks in parallel should use [`decode_with_workers`] to pin each block to one worker instead
+/// of nesting two fan-outs.
 pub fn decode(spec: &TableSpec, blob: &[u8]) -> Result<TableData> {
-    // Accumulators, one per declared column (column order == struct field order on write).
+    decode_inner(spec, blob, None)
+}
+
+/// [`decode`] with the materialise fan-out pinned to `workers` threads (`1` = fully serial).
+///
+/// The point is composition. `decode` sizes itself to `available_parallelism()`, which is right
+/// for one decode on an idle machine and wrong inside a caller's own parallel loop — N concurrent
+/// `decode`s would each spawn N workers. Decoding a cohort of blocks across a thread pool should
+/// therefore pass `1` here and keep the parallelism at the outer level, where it already has
+/// better work granularity.
+pub fn decode_with_workers(spec: &TableSpec, blob: &[u8], workers: usize) -> Result<TableData> {
+    decode_inner(spec, blob, Some(workers))
+}
+
+fn decode_inner(spec: &TableSpec, blob: &[u8], workers: Option<usize>) -> Result<TableData> {
+    // Accumulators, one per declared column (column order == struct field order on write),
+    // pre-sized to the declared row count — see [`empty_column_with_capacity`], this is the
+    // read's dominant cost.
+    let rows = spec.rows as usize;
     let mut cols: Vec<ColumnData> = spec
         .columns
         .iter()
-        .map(|c| empty_column(&c.dtype))
+        .map(|c| empty_column_with_capacity(&c.dtype, rows))
         .collect::<Result<_>>()?;
 
     with_read_session(|rt, s| {
-        let mut ctx = s.create_execution_ctx();
-        rt.block_on(async {
-            let stream = s
-                .open_options()
-                .open_buffer(ByteBuffer::copy_from(blob))
-                .map_err(ze)?
-                .scan()
-                .map_err(ze)?
-                .into_array_stream()
-                .map_err(ze)?;
-            futures::pin_mut!(stream);
-            while let Some(chunk) = stream.next().await {
-                let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
-                for (i, col) in cols.iter_mut().enumerate() {
-                    extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
-                }
-            }
-            Ok::<(), Error>(())
-        })
+        let chunks = rt.block_on(scan_chunks(s, blob, None))?;
+        match workers {
+            Some(n) => materialise_with(s, &chunks, &mut cols, n),
+            None => materialise(s, &chunks, &mut cols),
+        }
     })?;
 
     Ok(spec
@@ -725,7 +863,7 @@ pub fn decode_column(spec: &TableSpec, blob: &[u8], name: &str) -> Result<Column
         .find(|c| c.name == name)
         .ok_or_else(|| Error::Codec(format!("table has no column '{name}'")))?;
     let (rt, s) = runtime_session();
-    let mut out = empty_column(&col.dtype)?;
+    let mut out = empty_column_with_capacity(&col.dtype, spec.rows as usize)?;
     let mut ctx = s.create_execution_ctx();
     rt.block_on(async {
         let stream = s
@@ -767,29 +905,11 @@ pub fn decode_projected(spec: &TableSpec, blob: &[u8], names: &[&str]) -> Result
         .collect::<Result<_>>()?;
     let mut cols: Vec<ColumnData> = dtypes
         .iter()
-        .map(|d| empty_column(d))
+        .map(|d| empty_column_with_capacity(d, spec.rows as usize))
         .collect::<Result<_>>()?;
     with_read_session(|rt, s| {
-        let mut ctx = s.create_execution_ctx();
-        rt.block_on(async {
-            let stream = s
-                .open_options()
-                .open_buffer(ByteBuffer::copy_from(blob))
-                .map_err(ze)?
-                .scan()
-                .map_err(ze)?
-                .with_projection(select(names.to_vec(), root()))
-                .into_array_stream()
-                .map_err(ze)?;
-            futures::pin_mut!(stream);
-            while let Some(chunk) = stream.next().await {
-                let st: StructArray = chunk.map_err(ze)?.execute(&mut ctx).map_err(ze)?;
-                for (i, col) in cols.iter_mut().enumerate() {
-                    extend_field(col, st.unmasked_field(i).clone(), &mut ctx)?;
-                }
-            }
-            Ok::<(), Error>(())
-        })
+        let chunks = rt.block_on(scan_chunks(s, blob, Some(names)))?;
+        materialise(s, &chunks, &mut cols)
     })?;
     Ok(names.iter().map(|n| n.to_string()).zip(cols).collect())
 }
@@ -964,6 +1084,74 @@ mod tests {
             row_index: None,
         };
         (spec, data)
+    }
+
+    /// The column-parallel materialise must be **bit-identical** to the serial one, for every
+    /// dtype (including the `Bool`/`Utf8` columns that take their own decode path) and across
+    /// several row-groups — worker `t` owns columns `[t*per, (t+1)*per)` and walks the row-groups
+    /// in order, so any ordering or off-by-one in the split shows up here.
+    #[test]
+    fn materialise_is_bit_identical_across_thread_counts() {
+        let rows = ROWS_PER_GROUP + 4242; // 2 row-groups + remainder
+        let (mut spec, mut data) = all_dtype_table(rows);
+        data.push((
+            "b1".into(),
+            ColumnData::Bool((0..rows).map(|k| k % 3 == 0).collect()),
+        ));
+        data.push((
+            "str".into(),
+            ColumnData::Utf8((0..rows).map(|k| format!("crystal-{}", k % 97)).collect()),
+        ));
+        spec.columns = data.iter().map(|(n, c)| col(n, c.numpy_code())).collect();
+        let blob = encode(&spec, &data).unwrap();
+
+        // `repeat` duplicates the scanned chunks, exercising the multi-chunk append loop
+        // regardless of how the reader chooses to batch this particular file.
+        let decoded = |threads: usize, repeat: usize| -> TableData {
+            let mut cols: Vec<ColumnData> = spec
+                .columns
+                .iter()
+                .map(|c| empty_column_with_capacity(&c.dtype, rows * repeat))
+                .collect::<Result<_>>()
+                .unwrap();
+            with_read_session(|rt, s| {
+                let scanned = rt.block_on(scan_chunks(s, &blob, None)).unwrap();
+                let chunks: Vec<StructArray> =
+                    std::iter::repeat_n(scanned, repeat).flatten().collect();
+                materialise_with(s, &chunks, &mut cols, threads).unwrap();
+            });
+            spec.columns
+                .iter()
+                .map(|c| c.name.clone())
+                .zip(cols)
+                .collect()
+        };
+
+        let serial = decoded(1, 1);
+        assert_eq!(serial, data, "serial materialise must round-trip");
+        // Every column must land in the same worker split regardless of worker count — including
+        // more workers than columns (the empty-group edge).
+        for threads in [2, 3, 4, 8, 64] {
+            assert_eq!(
+                decoded(threads, 1),
+                serial,
+                "materialise with {threads} workers diverged from serial"
+            );
+            assert_eq!(
+                decoded(threads, 3),
+                decoded(1, 3),
+                "multi-chunk append order diverged at {threads} workers"
+            );
+        }
+        // And both public entry points agree — the self-sizing one and the pinned one.
+        assert_eq!(decode(&spec, &blob).unwrap(), data);
+        for workers in [1, 2, 7] {
+            assert_eq!(
+                decode_with_workers(&spec, &blob, workers).unwrap(),
+                data,
+                "decode_with_workers({workers}) diverged"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #352 — but **not** by doing what #352 proposed. See "The wrong answer" below.

Stacked on #354 → #353 → #350. The last commit is the substance; review that first
if you are short on time.

## The problem

A full-materialise `decode` of a wide listmode table ran ~4x slower than a mature
row store. The standing explanation was "Vortex decode throughput," which nobody
had measured.

## The wrong answer (what #352 asked for)

I filed #352 proposing that `decode` decompresses row-groups serially and should
fan `execute()` across the worker pool. Before building it, I profiled. The
premise was wrong, and the fix would have chased ~5% of the cost.

`examples/read_profile` (added here) peels a read apart on one blob. 2 M rows ×
21 columns, 31 row-groups, before this PR:

| stage | ms | delta |
|---|---:|---:|
| S0 scan, never `execute` | 2.1 | 2.1 |
| S1 + struct `execute` | 2.1 | 0.0 |
| S2 + field `execute` — **the real decompress** | 8.4 | 6.3 |
| S2b + read every decompressed value | 21.0 | 12.6 |
| S3 + copy into `ColumnData` = `decode()` | 128.0 | **107** |

Genuine Vortex decompress is ~5% of a read and the layout/scan path ~2%. **The
host copy is ~93%.** Parallelising `execute` would have bought ~6 ms out of 128.

S2b exists because "S2 is cheap" invites the objection that `execute` returned
something lazy; it touches every decompressed value and the cost stays put.

## The right answer

Two fixes, both following from that split:

1. **Pre-size the accumulators** (`empty_column_with_capacity`). They grew from
   empty, so each column was re-allocated and re-copied O(log n) times.
   Reserving the declared row count leaves one copy per row-group. The declared
   count is attacker-controlled for an untrusted blob, so it is clamped to
   `BLOCK_ROWS` — the partitioning law's maximum rows in one table block; a
   larger table still decodes, it just resumes amortised growth past the clamp.

2. **Fan the decompress-and-copy across cores, by column** (`materialise`).
   `decode` now drives the scan to a `Vec<StructArray>` (cheap — the structs are
   canonical but their fields are still *encoded* views into the blob the caller
   already holds, so the resident set does not grow) and hands them to a
   column-parallel fan-out. Each column is owned by exactly one worker walking
   the row-groups in order, so the output is bit-identical to serial. Tables
   under 2^20 values stay exactly as serial as before.

`decode_projected` and `decode_column` take the same path.

## Numbers

Interleaved A/B — the same example built at this commit and at its parent,
best-of-7, five alternating runs, 10-core box:

| | base | this PR | |
|---|---:|---:|---:|
| `decode` (2 M × 21) | 128–137 ms (med 130) | 38–42 ms (med 41) | **3.2x** |
| `decode_projected` (5 of 21) | 42–43 ms (med 42) | 12–18 ms (med 14) | **2.9x** |

Standalone thread-scaling of the materialise: 2.1x at 8 workers, flat past that —
the ceiling is memory bandwidth, not core count.

Downstream check on a real workload (PET singles listmode, 310 k rows, 21
columns, identical rows written both ways): tessera went from **4.0x slower than
parquet to 1.46x faster**, at 35.6% smaller on disk.

## Correctness

`materialise_is_bit_identical_across_thread_counts` drives the pinned-worker seam
at 1/2/3/4/8/64 workers (64 > column count, exercising the empty-group edge)
across every dtype — including the `Bool` and `Utf8` columns from #354, which
decode via their own path — and over repeated chunks to exercise the multi-chunk
append order. Every configuration is asserted byte-equal to the serial result.

## Also in this PR (earlier commits)

- `decode_projected` — multi-column projection pushdown in a single session,
  instead of N `decode_column` calls each paying session setup.
- `READ_RT` — reads drive the scan on a `CurrentThreadWorkerPool` sized to
  available parallelism, not the bare single-threaded `CurrentThreadRuntime`.
- Module docs (#351) telling integrators which runtime to use and that
  full-materialise-to-`Vec<struct>` is the slow path on purpose.

## Note for the maintainer

`array::tests::encode_emits_a_structured_compression_trace` fails in a threaded
`cargo test -p tessera-io --lib` run and passes both in isolation and under
`--test-threads=1` (116/116). It does so on `origin/dev` too — I verified before
and after — so it is **pre-existing and unrelated to this PR**. It does not affect
CI: `nix flake check` drives `cargo nextest run`, which gives each test its own
process, so CI is legitimately green. It looks like `tracing` callsite-interest
caching — another test reaches `array::encode` first with no subscriber installed,
the DEBUG callsite is cached globally as `never`, and the scoped `with_default`
subscriber then sees an empty log. Filed as #356 rather than smuggled in here.

Everything in this PR is green: 116/116 `tessera-io` lib tests, plus the new
thread-equivalence test.
