### PR TITLE
perf(io): random take reads only the selected rows (Vortex row-index pushdown)

### DIFF
--- a/tessera/crates/tessera-io/src/multiblock.rs
+++ b/tessera/crates/tessera-io/src/multiblock.rs
@@ -19,7 +19,7 @@ use tessera_core::{Error, Result};
 
 use crate::chunk_index::cidx_name;
 use crate::container::Reader;
-use crate::table::{decode, decode_column, ColumnData, TableData};
+use crate::table::{decode_column, decode_rows, ColumnData, TableData};
 
 /// A logical view over the partitioned table named by `prefix`: the ordered concatenation of every
 /// block in [`Reader::block_group`]'s result. Cheap to build (manifest-only; no block bytes read)
@@ -159,21 +159,34 @@ impl LogicalTableView {
         for &g in global_rows {
             mapping.push(self.locate(g)?);
         }
-        // Decode each touched block exactly once (BTreeMap keeps the keyed cache simple).
-        let mut decoded: BTreeMap<usize, TableData> = BTreeMap::new();
-        for &(b, _) in &mapping {
-            if let std::collections::btree_map::Entry::Vacant(e) = decoded.entry(b) {
-                let blob = reader.read_block(&self.block_names[b])?;
-                e.insert(decode(&self.specs[b], &blob)?);
-            }
+        // Per touched block, decode ONLY the requested rows — Vortex row-index pushdown, so a
+        // scattered take reads just the covering segments instead of materialising whole blocks.
+        // `decode_rows` requires sorted-unique indices and returns them in that order, so the
+        // per-block row list is deduped here and mapped back to caller order below.
+        let mut wanted: BTreeMap<usize, Vec<u64>> = BTreeMap::new();
+        for &(b, l) in &mapping {
+            wanted.entry(b).or_default().push(l as u64);
+        }
+        let mut decoded: BTreeMap<usize, (Vec<u64>, TableData)> = BTreeMap::new();
+        for (&b, rows) in wanted.iter_mut() {
+            rows.sort_unstable();
+            rows.dedup();
+            let blob = reader.read_block(&self.block_names[b])?;
+            let sub = decode_rows(&self.specs[b], &blob, rows)?;
+            decoded.insert(b, (std::mem::take(rows), sub));
         }
         // Build output columns in spec order; gather one row at a time in caller order.
         let mut out: TableData = Vec::with_capacity(columns.len());
         for (col_idx, col) in columns.iter().enumerate() {
             let mut typed = ColumnData::empty_for(col)?;
             for &(b, l) in &mapping {
-                let src = decoded.get(&b).ok_or_else(|| {
+                let (rows, src) = decoded.get(&b).ok_or_else(|| {
                     Error::Codec(format!("take: missing decoded cache for block {b}"))
+                })?;
+                // Position of this row within the block's sorted-unique selection. A duplicate
+                // request resolves to the same position, so asking for a row twice is free.
+                let pos = rows.binary_search(&(l as u64)).map_err(|_| {
+                    Error::Codec(format!("take: row {l} missing from block {b}'s selection"))
                 })?;
                 let cell = src
                     .get(col_idx)
@@ -184,7 +197,7 @@ impl LogicalTableView {
                         ))
                     })?
                     .1
-                    .slice(l, l + 1);
+                    .slice(pos, pos + 1);
                 typed.extend(&cell)?;
             }
             out.push((col.name.clone(), typed));

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -862,6 +862,54 @@ pub fn encode(spec: &TableSpec, data: &TableData) -> Result<Vec<u8>> {
     Ok(payload)
 }
 
+/// Decode ONLY the rows at `rows` from a table block, via Vortex **row-index pushdown**.
+///
+/// `rows` are block-local indices; they must be sorted and unique, and the result is in that same
+/// order. Only the segments covering the selected rows are read and decoded, so a scattered take
+/// of a few rows does not pay for materialising the whole block — the random-access property the
+/// table backend was chosen for.
+///
+/// Bit-exact with slicing the corresponding rows out of [`decode`]'s output.
+pub fn decode_rows(spec: &TableSpec, blob: &[u8], rows: &[u64]) -> Result<TableData> {
+    if let Some(w) = rows.windows(2).find(|w| w[0] >= w[1]) {
+        return Err(Error::Codec(format!(
+            "decode_rows: indices must be sorted and unique (got {} then {})",
+            w[0], w[1]
+        )));
+    }
+    if let Some(&last) = rows.last() {
+        if last >= spec.rows {
+            return Err(Error::Codec(format!(
+                "decode_rows: index {last} is out of range for a {}-row table",
+                spec.rows
+            )));
+        }
+    }
+    let mut cols: Vec<ColumnData> = spec
+        .columns
+        .iter()
+        .map(|c| empty_column_for(c, rows.len()))
+        .collect::<Result<_>>()?;
+    if rows.is_empty() {
+        return Ok(spec
+            .columns
+            .iter()
+            .map(|c| c.name.clone())
+            .zip(cols)
+            .collect());
+    }
+    with_read_session(|rt, s| {
+        let chunks = rt.block_on(scan_chunks_at(s, blob, None, Some(rows)))?;
+        materialise(s, &chunks, &mut cols)
+    })?;
+    Ok(spec
+        .columns
+        .iter()
+        .map(|c| c.name.clone())
+        .zip(cols)
+        .collect())
+}
+
 /// **Bounded-memory / >RAM variant of [`encode`]**: consume row-group [`TableData`] chunks from a
 /// *lazy* iterator (each ≤ [`ROWS_PER_GROUP`] rows) and write the chunked Vortex bytes **without ever
 /// holding the whole table** — the DAQ / streaming-compaction path. The iterator is pulled one chunk
@@ -1073,6 +1121,21 @@ async fn scan_chunks(
     blob: &[u8],
     projection: Option<&[&str]>,
 ) -> Result<Vec<StructArray>> {
+    scan_chunks_at(s, blob, projection, None).await
+}
+
+/// [`scan_chunks`] with an optional **row selection** pushed into the scan.
+///
+/// `rows` must be sorted and unique; Vortex's `Selection::IncludeByIndex` is defined over sorted
+/// indices and yields the selected rows in index order, not in the order they were requested.
+/// Pushing the selection down means only the segments covering those rows are read and decoded —
+/// as opposed to materialising the block and indexing it afterwards.
+async fn scan_chunks_at(
+    s: &VortexSession,
+    blob: &[u8],
+    projection: Option<&[&str]>,
+    rows: Option<&[u64]>,
+) -> Result<Vec<StructArray>> {
     let mut ctx = s.create_execution_ctx();
     let scan = s
         .open_options()
@@ -1082,6 +1145,10 @@ async fn scan_chunks(
         .map_err(ze)?;
     let scan = match projection {
         Some(names) => scan.with_projection(select(names.to_vec(), root())),
+        None => scan,
+    };
+    let scan = match rows {
+        Some(idx) => scan.with_row_indices(Buffer::copy_from(idx)),
         None => scan,
     };
     let stream = scan.into_array_stream().map_err(ze)?;
@@ -1616,6 +1683,69 @@ mod tests {
         assert_eq!(a, c, "bytes changed with the filler under nulls");
         // ...and the decode is the canonical form regardless of which one was written.
         assert_eq!(decode(&spec, &c).unwrap(), build(0));
+    }
+
+    /// Row-index pushdown must be BIT-EXACT with decoding the block and slicing the same rows.
+    ///
+    /// This is the correctness contract for `decode_rows`: pushing the selection into Vortex reads
+    /// different segments than a full scan, so the two paths could diverge (wrong rows, wrong
+    /// order, or a chunk-boundary off-by-one) without anything else failing.
+    #[test]
+    fn decode_rows_matches_decode_then_slice() {
+        let rows = ROWS_PER_GROUP + 3000; // spans a row-group boundary
+        let (spec, data) = all_dtype_table(rows);
+        let blob = encode(&spec, &data).unwrap();
+        let full = decode(&spec, &blob).unwrap();
+
+        let cases: Vec<Vec<u64>> = vec![
+            vec![0],
+            vec![(rows - 1) as u64],
+            vec![0, 1, 2, 3],
+            // straddling the row-group boundary
+            vec![
+                (ROWS_PER_GROUP - 2) as u64,
+                (ROWS_PER_GROUP - 1) as u64,
+                ROWS_PER_GROUP as u64,
+                (ROWS_PER_GROUP + 1) as u64,
+            ],
+            // scattered across the whole table
+            (0..rows as u64).step_by(1013).collect(),
+            vec![7, 9000, (rows - 1) as u64],
+        ];
+        for want in cases {
+            let got = decode_rows(&spec, &blob, &want).unwrap();
+            let expected: TableData = full
+                .iter()
+                .map(|(n, c)| {
+                    let mut acc = ColumnData::from_le_bytes(c.numpy_code(), &[]).unwrap();
+                    for &r in &want {
+                        acc.extend(&c.slice(r as usize, r as usize + 1)).unwrap();
+                    }
+                    (n.clone(), acc)
+                })
+                .collect();
+            assert_eq!(got, expected, "decode_rows diverged for {want:?}");
+        }
+        // Empty selection is a well-defined empty table, not an error.
+        let empty = decode_rows(&spec, &blob, &[]).unwrap();
+        assert!(empty.iter().all(|(_, c)| c.is_empty()));
+    }
+
+    /// Unsorted, duplicated, or out-of-range indices are typed errors — `Selection::IncludeByIndex`
+    /// is only defined over sorted-unique indices, so accepting them would silently return the
+    /// wrong rows.
+    #[test]
+    fn decode_rows_rejects_malformed_selections() {
+        let (spec, data) = all_dtype_table(64);
+        let blob = encode(&spec, &data).unwrap();
+        for bad in [vec![3u64, 1], vec![2, 2], vec![0, 64]] {
+            let e = decode_rows(&spec, &blob, &bad).unwrap_err();
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("sorted and unique") || msg.contains("out of range"),
+                "expected a typed rejection for {bad:?}, got: {msg}"
+            );
+        }
     }
 
     /// Chunk statistics must describe the values that are PRESENT: a NULL is skipped, not folded


### PR DESCRIPTION
> **Stacked on #360 → #359** — retargeted to `dev` so CI runs (the workflow only triggers for PRs into `dev`/`release/**`/`main`). The commit list shows the two commits below it; they disappear as those merge. **Merge order: #359 → #360 → this.**

## The gap

`LogicalTableView::take` decoded every touched block **in full**, then indexed the result in memory. Taking 100 scattered rows from a 4M-row block paid for materialising all 4M.

The docstring said the Vortex random-take primitive *"is not exposed through `crate::table` today"*. It is — `ScanBuilder::with_row_indices` has been available all along. So the cost was avoidable, not inherent.

That matters because O(1) random-take is one of the two properties the table backend was chosen for (per the ADR: *smallest + O(1) random-take + filter-pushdown*). It was the headline claim going unimplemented.

## What this does

Adds `table::decode_rows(spec, blob, rows)`, which pushes a `Selection::IncludeByIndex` into the scan so only the segments covering the requested rows are read and decoded, and rewires `take` onto it.

## The contract, made explicit

`Selection::IncludeByIndex` is defined over **sorted, unique** indices and returns rows in *index* order — not in the order requested. Rather than assume callers know that:

- `decode_rows` **validates** sortedness/uniqueness/range and returns a typed error, instead of silently returning the wrong rows.
- `take` sorts and dedups per block, then maps back to caller order with a binary search.

So caller order is preserved exactly as before, including descending or repeated indices — and a row requested twice now costs nothing extra.

## Why the test is shaped the way it is

Pushing a selection down reads a **different set of segments** than a full scan, so the two paths could disagree — wrong rows, wrong order, or a chunk-boundary off-by-one — with nothing else failing. `decode_rows_matches_decode_then_slice` therefore asserts bit-exactness against decode-then-slice across:

| case | why |
|---|---|
| single row; first row; last row | boundary degenerate cases |
| contiguous run `[0,1,2,3]` | the trivial happy path |
| straddling a row-group boundary | the off-by-one that pushdown makes possible |
| scattered `step_by(1013)` over the whole table | many segments, sparse hits |
| empty selection | must be a well-defined empty table, not an error |

Plus `decode_rows_rejects_malformed_selections` for unsorted / duplicate / out-of-range.

**360 tests pass**; fmt + clippy `-D warnings` clean.

## Not in scope

Predicate pushdown (`ScanBuilder::with_filter`) — the other half of the ADR claim. `LogicalTableView` still does block-level min/max pruning only, with no row-level filter. Separate change.

Refs: #143
