### PR TITLE
test(integrity): pin everyday tamper/trust cases + the L1/L2 verify ladder

### DIFF
--- a/tessera/crates/tessera-cli/tests/sign.rs
+++ b/tessera/crates/tessera-cli/tests/sign.rs
@@ -108,6 +108,89 @@ fn cli_sign_then_verify_sig_roundtrips_and_rejects_wrong_key() {
 }
 
 #[test]
+fn foreign_resign_leaves_integrity_intact_but_untrusted() {
+    // "Someone else re-signed it." A foreign key replaces the trusted signature on an UNMODIFIED
+    // product. Integrity (`verify`) still passes — signing only touches the seal-ignored aux subtree
+    // (ADR-0042) — yet `verify-sig` against the trust store now rejects it as untrusted. The dual
+    // "the bytes are fine, the signer isn't" property, asserted together (today's tests assert each
+    // half separately).
+    let dir = tempfile::tempdir().unwrap();
+    let tsra = dir.path().join("data.tsra");
+    sealed_tsra(&tsra);
+
+    // Repo-local trust store (`.tessera/trust/`, resolved relative to CWD) trusts key A as "lab".
+    let lab = SigningKey::from_bytes(&[17u8; 32]);
+    let lab_key = dir.path().join("lab.key");
+    std::fs::write(&lab_key, hex32(&lab.to_bytes())).unwrap();
+    let trust_dir = dir.path().join(".tessera/trust");
+    std::fs::create_dir_all(&trust_dir).unwrap();
+    std::fs::write(
+        trust_dir.join("lab.pub"),
+        verifying_key_hex(&lab.verifying_key()),
+    )
+    .unwrap();
+
+    // Every invocation runs in the tempdir with an isolated HOME/XDG so ONLY this trust store is
+    // consulted — the host's real ~/.config/tessera can neither add nor remove trust.
+    let mk = || {
+        let mut c = tessera();
+        c.current_dir(dir.path())
+            .env("HOME", dir.path())
+            .env("XDG_CONFIG_HOME", dir.path().join(".config"));
+        c
+    };
+
+    // Sign with the trusted lab key; verify-sig (no --pubkey ⇒ defaults to the trust store) → trusted.
+    assert!(mk()
+        .args(["sign"])
+        .arg(&tsra)
+        .arg("--key")
+        .arg(&lab_key)
+        .args(["--signer", "lab"])
+        .status()
+        .unwrap()
+        .success());
+    assert!(
+        mk().args(["verify-sig"])
+            .arg(&tsra)
+            .status()
+            .unwrap()
+            .success(),
+        "the lab signature is in the trust store → trusted"
+    );
+
+    // A FOREIGN key re-signs the unmodified product (single-signer semantics replace the lab sig).
+    let attacker = SigningKey::from_bytes(&[99u8; 32]);
+    let att_key = dir.path().join("attacker.key");
+    std::fs::write(&att_key, hex32(&attacker.to_bytes())).unwrap();
+    assert!(mk()
+        .args(["sign"])
+        .arg(&tsra)
+        .arg("--key")
+        .arg(&att_key)
+        .args(["--signer", "attacker"])
+        .status()
+        .unwrap()
+        .success());
+
+    // Integrity is intact — the payload + seal are byte-unchanged (the signature rides in aux).
+    assert!(
+        mk().args(["verify"]).arg(&tsra).status().unwrap().success(),
+        "the product bytes are unchanged, so integrity still verifies"
+    );
+    // But the signer is now untrusted — verify-sig against the trust store rejects it (non-zero).
+    assert!(
+        !mk()
+            .args(["verify-sig"])
+            .arg(&tsra)
+            .status()
+            .unwrap()
+            .success(),
+        "the foreign key is not in the trust store → untrusted"
+    );
+}
+
+#[test]
 fn cli_sign_sidecar_flag_writes_detached_and_verify_falls_back() {
     // `sign --sidecar` writes the legacy detached form; `verify-sig` falls back to it when no
     // embedded signature is present (ADR-0042). Same crypto, only the location differs.

--- a/tessera/crates/tessera-core/tests/integrity.rs
+++ b/tessera/crates/tessera-core/tests/integrity.rs
@@ -163,6 +163,59 @@ fn block_reorder_changes_content_hash() {
     );
 }
 
+// ---- metadata tamper / seal-vs-fingerprint -----------------------------------------------
+
+#[test]
+fn tamper_metadata_scalar_fails_verify() {
+    // The everyday "someone edited a field" attack. Seal a product carrying a metadata scalar,
+    // then flip it in the sealed manifest. id_inputs + blocks are untouched, so id and content_hash
+    // still recompute — verify() trips specifically on manifest_hash (metadata is under the seal).
+    let mut b = ProductBuilder::new("recon", "DP06", "d", "2023-12-08T00:00:00Z");
+    b.add_block(&ArrayBlock::new(
+        "volume",
+        ArraySpec::new(vec![8, 8, 8], "int16"),
+    ))
+    .unwrap();
+    b.with_field("patient_id", serde_json::json!("ANON9297"));
+    let mut m = b.seal().unwrap();
+    m.verify().expect("a freshly sealed product verifies");
+
+    m.metadata
+        .insert("patient_id".into(), serde_json::json!("EVIL"));
+    match m.verify() {
+        Err(tessera_core::Error::Integrity { what, .. }) => assert_eq!(what, "manifest_hash"),
+        other => panic!("expected a manifest_hash integrity error, got {other:?}"),
+    }
+}
+
+#[test]
+fn metadata_edit_moves_manifest_hash_not_content_hash() {
+    // Two products, identical blocks + id_inputs, one metadata field differs: the seal
+    // (manifest_hash) moves, the data fingerprint (content_hash) does NOT. Metadata is committed
+    // by the seal but is not part of the Merkle root over block digests — the two-hash separation.
+    fn sealed_with(modality: &str) -> Manifest {
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2023-12-08T00:00:00Z");
+        b.add_block(&ArrayBlock::new(
+            "volume",
+            ArraySpec::new(vec![8, 8, 8], "int16"),
+        ))
+        .unwrap();
+        b.with_field("modality", serde_json::json!(modality));
+        b.seal().unwrap()
+    }
+    let ct = sealed_with("CT");
+    let pt = sealed_with("PT");
+    assert_eq!(ct.id, pt.id, "id_inputs are unchanged");
+    assert_eq!(
+        ct.content_hash, pt.content_hash,
+        "a metadata edit must NOT move the data fingerprint (content_hash)"
+    );
+    assert_ne!(
+        ct.manifest_hash, pt.manifest_hash,
+        "a metadata edit MUST move the seal (manifest_hash)"
+    );
+}
+
 // ---- version handling --------------------------------------------------------------------
 
 #[test]

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -788,6 +788,103 @@ mod tests {
     }
 
     #[test]
+    fn tampered_table_block_payload_fails_on_read() {
+        // The Vortex-table twin of tampered_block_payload_fails_on_read (which uses an int16 array):
+        // flipping a single value's byte in an encoded table payload trips the block_payload digest
+        // on read, exactly as for an array/zarr block — the guarantee is kind-agnostic.
+        use tessera_core::block::table::{Column, TableBlock, TableSpec};
+        let spec = TableSpec {
+            columns: vec![Column {
+                name: "energy".into(),
+                dtype: "f4".into(),
+                ..Default::default()
+            }],
+            rows: 2_696_935,
+            row_index: Some("ms".into()),
+        };
+        // The valid payload is exactly what the block digest is computed over (the spec, in the
+        // spike — a real Vortex backend stores encoded column chunks with the same property).
+        let good = serde_json::to_vec(&spec).unwrap();
+        let events = TableBlock::new("events_3p", spec);
+
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2024-01-01T00:00:00Z");
+        b.add_block(&events).unwrap();
+        let sealed = b.seal().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        // Happy path: the correct payload reads back.
+        let good_path = dir.path().join("good.tsra");
+        pack(
+            &sealed,
+            &[BlockPayload::new("events_3p", good.clone())],
+            &good_path,
+        )
+        .unwrap();
+        assert_eq!(
+            Reader::open(&good_path)
+                .unwrap()
+                .read_block("events_3p")
+                .unwrap(),
+            good
+        );
+
+        // Flip ONE byte (a single value in the table) → block_payload integrity error on read.
+        let mut bad = good.clone();
+        bad[0] ^= 0xFF;
+        let bad_path = dir.path().join("bad.tsra");
+        pack(&sealed, &[BlockPayload::new("events_3p", bad)], &bad_path).unwrap();
+        match Reader::open(&bad_path).unwrap().read_block("events_3p") {
+            Err(Error::Integrity { what, .. }) => assert_eq!(what, "block_payload"),
+            other => panic!("expected block_payload integrity error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manifest_verify_is_l1_only_payload_flip_needs_read_path() {
+        // The verify escalation ladder, as an executable spec:
+        //   L1 = manifest.verify(): recomputes id / content_hash / manifest_hash from the RECORDED
+        //        block digests. It never reads block payloads, so a flipped payload left alongside
+        //        an untouched recorded digest still PASSES L1.
+        //   L2 = read_block: re-derives the digest from the ACTUAL stored bytes → catches the flip.
+        // (L3 = per-chunk sub-block Merkle, #214 / ADR-0028 §3, would localise WHICH chunk — n/a here.)
+        use tessera_core::block::table::{Column, TableBlock, TableSpec};
+        let spec = TableSpec {
+            columns: vec![Column {
+                name: "energy".into(),
+                dtype: "f4".into(),
+                ..Default::default()
+            }],
+            rows: 10,
+            row_index: Some("ms".into()),
+        };
+        let good = serde_json::to_vec(&spec).unwrap();
+        let events = TableBlock::new("events_3p", spec);
+
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2024-01-01T00:00:00Z");
+        b.add_block(&events).unwrap();
+        let sealed = b.seal().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flipped.tsra");
+        // Pack a FLIPPED payload but leave the manifest — and its recorded digest — untouched.
+        let mut flipped = good.clone();
+        flipped[0] ^= 0xFF;
+        pack(&sealed, &[BlockPayload::new("events_3p", flipped)], &path).unwrap();
+
+        let mut r = Reader::open(&path).unwrap();
+        // L1: the manifest itself still verifies — recorded digests, roots and seal are internally
+        // consistent because none of them were touched. L1 does not read payloads.
+        r.manifest()
+            .verify()
+            .expect("L1 (manifest self-consistency) passes: payload bytes are never read");
+        // L2: reading the block re-derives the digest from the stored bytes and catches the flip.
+        match r.read_block("events_3p") {
+            Err(Error::Integrity { what, .. }) => assert_eq!(what, "block_payload"),
+            other => panic!("expected a block_payload integrity error at L2, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn refuses_unsealed_manifest() {
         let m = Manifest::new("recon", "x", "d", "2024-01-01T00:00:00Z"); // not sealed
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #366.

Five regression tests for the everyday integrity/trust scenarios the suite didn't explicitly pin. **No production code change** — pure test additions; all guardrails gates pass.

## What's new

| # | Layer | Test | Pins |
|---|---|---|---|
| T1 | core | `tamper_metadata_scalar_fails_verify` | flip a metadata scalar in a sealed manifest → `verify()` trips on `manifest_hash` |
| T2 | core | `metadata_edit_moves_manifest_hash_not_content_hash` | the two-hash separation — metadata moves the seal, never the data fingerprint |
| T3 | io | `tampered_table_block_payload_fails_on_read` | the **Vortex-table twin** of the existing int16-array tamper test — a one-byte value flip trips `block_payload` on read (guarantee is block-kind-agnostic) |
| T4 | cli | `foreign_resign_leaves_integrity_intact_but_untrusted` | a foreign key re-signs an unmodified product → `verify` **passes** (aux is seal-ignored) yet `verify-sig` **rejects** as untrusted |
| T5 | io | `manifest_verify_is_l1_only_payload_flip_needs_read_path` | the **verify escalation ladder** as an executable spec (below) |

## The verify ladder (T5 makes it a guarantee)

- **L1** — `manifest.verify()`: recomputes `id`/`content_hash`/`manifest_hash` from the **recorded** block digests. Never reads payloads → a flipped payload with an untouched recorded digest **passes L1**.
- **L2** — `read_block` / `tessera verify`: re-derives each digest from the **actual bytes** → catches the flip (`block_payload`).
- **L3** — per-chunk sub-block Merkle (#214, ADR-0028 §3): localises *which* chunk. Out of scope.

## Notes

- Whole-block granularity is the current guarantee (L2). Per-value localisation is #214.
- The L2 probe is serial today — parallelising it is filed as #367 (with the adaptive-knee refinement).

Refs: #214, #367
