### PR TITLE
perf(verify): fan the L2 payload probe across the worker pool

### DIFF
--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -943,12 +943,28 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
             Ok(())
         }
         Cmd::Verify { file } => {
-            let mut r = open_local_or_url(&file)?; // magic + manifest seal
-            let n = r.manifest().blocks.len();
-            // Payload half of verification: stream every block at bounded RSS + typed, located
-            // errors (#268 parts 3+4). `open` already checked the seal.
-            r.verify_payloads(&file.display().to_string())?;
-            println!("OK  {} verified ({n} blocks)", file.display());
+            let label = file.display().to_string();
+            // Payload half of verification: re-derive every block's digest from its stored bytes at
+            // bounded RSS + typed, located errors (#268 parts 3+4). `open` already checked the seal.
+            // A local `.tsra` fans the probe across the worker pool — each block is independently
+            // addressable in the STORED zip (#367); a URL verifies serially (no cheap multi-handle
+            // reopen). Worker count is the machine default for now; #368 will feed it from the
+            // resource-cap resolver.
+            #[cfg(feature = "cloud")]
+            let is_url = cloud_url(&file).is_some();
+            #[cfg(not(feature = "cloud"))]
+            let is_url = false;
+            if is_url {
+                let mut r = open_local_or_url(&file)?; // magic + manifest seal
+                let n = r.manifest().blocks.len();
+                r.verify_payloads(&label)?;
+                println!("OK  {label} verified ({n} blocks)");
+            } else {
+                let n = Reader::open(&file)?.manifest().blocks.len(); // magic + manifest seal (L1)
+                let workers = tessera_io::WriteConfig::for_system().worker_count();
+                tessera_io::verify_payloads_parallel(&file, &label, workers)?;
+                println!("OK  {label} verified ({n} blocks)");
+            }
             Ok(())
         }
         Cmd::Tree { file, full, verify } => {

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -960,9 +960,9 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 r.verify_payloads(&label)?;
                 println!("OK  {label} verified ({n} blocks)");
             } else {
-                let n = Reader::open(&file)?.manifest().blocks.len(); // magic + manifest seal (L1)
                 let workers = tessera_io::WriteConfig::for_system().worker_count();
-                tessera_io::verify_payloads_parallel(&file, &label, workers)?;
+                // Returns the block count (verified with L1 seal + L2 payloads) — no extra reopen.
+                let n = tessera_io::verify_payloads_parallel(&file, &label, workers)?;
                 println!("OK  {label} verified ({n} blocks)");
             }
             Ok(())

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -468,11 +468,12 @@ impl<R: Read + Seek> Reader<R> {
 const PARALLEL_VERIFY_MIN_BYTES: u64 = 256 * 1024 * 1024;
 
 /// The adaptive knee for [`verify_payloads_parallel`]: fan the L2 payload probe across workers only
-/// when it pays back — more than one worker, more than one block, and a file large enough that
-/// thread setup + per-worker reopen is noise against the hashing. Small products stay serial (the
-/// same small-stays-single principle as the streaming write path, ADR-0026).
-fn should_parallelize(file_size: u64, block_count: usize, workers: usize) -> bool {
-    workers > 1 && block_count > 1 && file_size >= PARALLEL_VERIFY_MIN_BYTES
+/// when it pays back — more than one worker, more than one block, and a file at least `min_bytes`
+/// (thread setup + per-worker reopen is then noise against the hashing). Small products stay serial
+/// (the same small-stays-single principle as the streaming write path, ADR-0026). `min_bytes` is a
+/// parameter so tests can drop it to `0` and exercise the fan-out branch on a small fixture.
+fn should_parallelize(file_size: u64, block_count: usize, workers: usize, min_bytes: u64) -> bool {
+    workers > 1 && block_count > 1 && file_size >= min_bytes
 }
 
 /// The parallel core: verify `names` by streaming each block's stored bytes through
@@ -488,26 +489,32 @@ fn verify_payloads_multithread(
     label: &str,
     n_threads: usize,
 ) -> Result<()> {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     let cursor = AtomicUsize::new(0);
+    // Lock-free "someone already failed" flag gates the hot path (checked every iteration); the
+    // Mutex is only ever taken on the rare error path, and `swap` ensures exactly the first worker
+    // to fail records its error.
+    let failed = AtomicBool::new(false);
     let first_err: std::sync::Mutex<Option<Error>> = std::sync::Mutex::new(None);
+    let record = |e: Error| {
+        if !failed.swap(true, Ordering::AcqRel) {
+            *first_err.lock().unwrap() = Some(e);
+        }
+    };
     std::thread::scope(|s| {
         for _ in 0..n_threads {
             s.spawn(|| {
                 let mut r = match Reader::open(path) {
                     Ok(r) => r,
                     Err(e) => {
-                        let mut fe = first_err.lock().unwrap();
-                        if fe.is_none() {
-                            *fe = Some(e);
-                        }
+                        record(e);
                         return;
                     }
                 };
                 let mut sink = std::io::sink();
                 loop {
-                    // Stop pulling work once any worker has recorded a failure.
-                    if first_err.lock().unwrap().is_some() {
+                    // Stop pulling work once any worker has recorded a failure (lock-free check).
+                    if failed.load(Ordering::Acquire) {
                         return;
                     }
                     let i = cursor.fetch_add(1, Ordering::Relaxed);
@@ -515,14 +522,11 @@ fn verify_payloads_multithread(
                         return;
                     }
                     if let Err(e) = r.stream_block(&names[i], &mut sink) {
-                        let mut fe = first_err.lock().unwrap();
-                        if fe.is_none() {
-                            *fe = Some(Error::BlockIntegrity {
-                                file: label.to_string(),
-                                block: names[i].clone(),
-                                detail: e.to_string(),
-                            });
-                        }
+                        record(Error::BlockIntegrity {
+                            file: label.to_string(),
+                            block: names[i].clone(),
+                            detail: e.to_string(),
+                        });
                         return;
                     }
                 }
@@ -535,20 +539,33 @@ fn verify_payloads_multithread(
     }
 }
 
+/// Threshold-injectable core of [`verify_payloads_parallel`]: the public entry fixes `min_bytes` to
+/// [`PARALLEL_VERIFY_MIN_BYTES`]; tests pass `0` to force the fan-out branch on a small fixture.
+/// Returns the number of blocks verified, so a caller needn't reopen the archive to report the count.
+fn verify_payloads_parallel_with(
+    path: &Path,
+    label: &str,
+    workers: usize,
+    min_bytes: u64,
+) -> Result<usize> {
+    let names = Reader::open(path)?.block_names(); // L1 seal check + block list
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if should_parallelize(file_size, names.len(), workers, min_bytes) {
+        verify_payloads_multithread(path, &names, label, workers.min(names.len()))?;
+    } else {
+        Reader::open(path)?.verify_payloads(label)?;
+    }
+    Ok(names.len())
+}
+
 /// Parallel peer of [`Reader::verify_payloads`] for a **local** `.tsra` — the L2 payload probe fanned
 /// across up to `workers` OS threads. Above the [`should_parallelize`] knee it work-steals blocks
 /// across `min(workers, blocks)` threads via [`verify_payloads_multithread`]; below it (small file,
 /// single block, or `workers <= 1`) it falls back to the serial [`Reader::verify_payloads`], since the
-/// thread-spawn + reopen overhead doesn't pay back. The result — Ok, or a typed
-/// [`Error::BlockIntegrity`] — is identical to the serial path; only the wall-clock differs.
-pub fn verify_payloads_parallel(path: &Path, label: &str, workers: usize) -> Result<()> {
-    let names = Reader::open(path)?.block_names(); // L1 seal check + block list
-    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    if !should_parallelize(file_size, names.len(), workers) {
-        return Reader::open(path)?.verify_payloads(label);
-    }
-    let n_threads = workers.min(names.len());
-    verify_payloads_multithread(path, &names, label, n_threads)
+/// thread-spawn + reopen overhead doesn't pay back. The result — the block count on success, or a
+/// typed [`Error::BlockIntegrity`] — is identical to the serial path; only the wall-clock differs.
+pub fn verify_payloads_parallel(path: &Path, label: &str, workers: usize) -> Result<usize> {
+    verify_payloads_parallel_with(path, label, workers, PARALLEL_VERIFY_MIN_BYTES)
 }
 
 /// One aux member to add to an existing `.tsra` — a name **relative to `aux/`** (so
@@ -898,17 +915,23 @@ mod tests {
 
     #[test]
     fn should_parallelize_respects_the_knee() {
-        let big = PARALLEL_VERIFY_MIN_BYTES;
+        let floor = PARALLEL_VERIFY_MIN_BYTES;
         assert!(
-            should_parallelize(big, 4, 8),
-            "big + multi-block + workers → parallel"
+            should_parallelize(floor, 4, 8, floor),
+            "at the floor + multi-block + workers → parallel"
         );
         assert!(
-            !should_parallelize(big - 1, 4, 8),
-            "below the size floor → serial"
+            !should_parallelize(floor - 1, 4, 8, floor),
+            "one byte below the floor → serial"
         );
-        assert!(!should_parallelize(big, 1, 8), "single block → serial");
-        assert!(!should_parallelize(big, 4, 1), "single worker → serial");
+        assert!(
+            !should_parallelize(floor, 1, 8, floor),
+            "single block → serial"
+        );
+        assert!(
+            !should_parallelize(floor, 4, 1, floor),
+            "single worker → serial"
+        );
     }
 
     #[test]
@@ -965,7 +988,48 @@ mod tests {
             .verify_payloads(&label)
             .unwrap();
         verify_payloads_multithread(&path, &names, &label, 4).unwrap();
-        verify_payloads_parallel(&path, &label, 8).unwrap();
+        assert_eq!(verify_payloads_parallel(&path, &label, 8).unwrap(), 5);
+    }
+
+    #[test]
+    fn forced_parallel_dispatch_runs_end_to_end() {
+        // Exercise the PUBLIC entry's fan-out branch on a small fixture by dropping the size floor to
+        // 0 — so should_parallelize → true and verify_payloads_parallel_with dispatches to the
+        // multithread core (the branch the 256 MiB threshold hides from the other tests). Clean
+        // product → Ok(block count).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.tsra");
+        sealed_multiblock(&path, 5);
+        let label = path.display().to_string();
+        assert_eq!(
+            verify_payloads_parallel_with(&path, &label, 4, 0).unwrap(),
+            5
+        );
+    }
+
+    #[test]
+    fn forced_parallel_dispatch_catches_tamper() {
+        // Same forced fan-out, but one block is corrupt: the dispatch → multithread → typed error
+        // path must surface the bad block (not silently pass).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.tsra");
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2024-01-01T00:00:00Z");
+        let mut payloads = Vec::new();
+        for i in 0..5 {
+            let blk = ArrayBlock::new(format!("vol{i}"), ArraySpec::new(vec![8, 8, 8], "int16"));
+            b.add_block(&blk).unwrap();
+            let mut bytes = serde_json::to_vec(&blk.spec).unwrap();
+            if i == 2 {
+                bytes[0] ^= 0xFF;
+            }
+            payloads.push(BlockPayload::new(format!("vol{i}"), bytes));
+        }
+        let sealed = b.seal().unwrap();
+        pack(&sealed, &payloads, &path).unwrap();
+        match verify_payloads_parallel_with(&path, &path.display().to_string(), 4, 0) {
+            Err(Error::BlockIntegrity { block, .. }) => assert_eq!(block, "vol2"),
+            other => panic!("expected a BlockIntegrity error for vol2, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tessera/crates/tessera-io/src/container.rs
+++ b/tessera/crates/tessera-io/src/container.rs
@@ -462,6 +462,95 @@ impl<R: Read + Seek> Reader<R> {
     }
 }
 
+/// The size floor below which parallel verify isn't worth the thread-spawn + per-worker archive
+/// reopen overhead — mirrors the "a few hundred MiB" knee blake3's mmap/rayon path uses
+/// ([`crate::blob::blob_ref_streaming_parallel`]). Below this a `.tsra` verifies serially.
+const PARALLEL_VERIFY_MIN_BYTES: u64 = 256 * 1024 * 1024;
+
+/// The adaptive knee for [`verify_payloads_parallel`]: fan the L2 payload probe across workers only
+/// when it pays back — more than one worker, more than one block, and a file large enough that
+/// thread setup + per-worker reopen is noise against the hashing. Small products stay serial (the
+/// same small-stays-single principle as the streaming write path, ADR-0026).
+fn should_parallelize(file_size: u64, block_count: usize, workers: usize) -> bool {
+    workers > 1 && block_count > 1 && file_size >= PARALLEL_VERIFY_MIN_BYTES
+}
+
+/// The parallel core: verify `names` by streaming each block's stored bytes through
+/// [`Reader::stream_block`] into a null sink, fanned across `n_threads` OS threads. Each thread opens
+/// its **own** [`Reader`] (a `.tsra` is a STORED zip so every block is independently addressable) and
+/// work-steals blocks via a shared cursor, so one huge blob never idles the other workers. Read-only
+/// and order-independent — identical result to the serial path. On corruption it returns the typed
+/// [`Error::BlockIntegrity`] for *a* bad block (whichever a worker reaches first, not necessarily the
+/// first in manifest order). `std::thread` — the same worker-pool idiom as the write engine, no new dep.
+fn verify_payloads_multithread(
+    path: &Path,
+    names: &[String],
+    label: &str,
+    n_threads: usize,
+) -> Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let cursor = AtomicUsize::new(0);
+    let first_err: std::sync::Mutex<Option<Error>> = std::sync::Mutex::new(None);
+    std::thread::scope(|s| {
+        for _ in 0..n_threads {
+            s.spawn(|| {
+                let mut r = match Reader::open(path) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let mut fe = first_err.lock().unwrap();
+                        if fe.is_none() {
+                            *fe = Some(e);
+                        }
+                        return;
+                    }
+                };
+                let mut sink = std::io::sink();
+                loop {
+                    // Stop pulling work once any worker has recorded a failure.
+                    if first_err.lock().unwrap().is_some() {
+                        return;
+                    }
+                    let i = cursor.fetch_add(1, Ordering::Relaxed);
+                    if i >= names.len() {
+                        return;
+                    }
+                    if let Err(e) = r.stream_block(&names[i], &mut sink) {
+                        let mut fe = first_err.lock().unwrap();
+                        if fe.is_none() {
+                            *fe = Some(Error::BlockIntegrity {
+                                file: label.to_string(),
+                                block: names[i].clone(),
+                                detail: e.to_string(),
+                            });
+                        }
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    match first_err.into_inner().unwrap() {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Parallel peer of [`Reader::verify_payloads`] for a **local** `.tsra` — the L2 payload probe fanned
+/// across up to `workers` OS threads. Above the [`should_parallelize`] knee it work-steals blocks
+/// across `min(workers, blocks)` threads via [`verify_payloads_multithread`]; below it (small file,
+/// single block, or `workers <= 1`) it falls back to the serial [`Reader::verify_payloads`], since the
+/// thread-spawn + reopen overhead doesn't pay back. The result — Ok, or a typed
+/// [`Error::BlockIntegrity`] — is identical to the serial path; only the wall-clock differs.
+pub fn verify_payloads_parallel(path: &Path, label: &str, workers: usize) -> Result<()> {
+    let names = Reader::open(path)?.block_names(); // L1 seal check + block list
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if !should_parallelize(file_size, names.len(), workers) {
+        return Reader::open(path)?.verify_payloads(label);
+    }
+    let n_threads = workers.min(names.len());
+    verify_payloads_multithread(path, &names, label, n_threads)
+}
+
 /// One aux member to add to an existing `.tsra` — a name **relative to `aux/`** (so
 /// `"signatures/<key_id>.sig.json"` becomes `aux/signatures/<key_id>.sig.json` inside the archive)
 /// and its bytes. Aux members ride outside the seal (ADR-0042) — the container hashes
@@ -785,6 +874,98 @@ mod tests {
             Err(Error::Integrity { what, .. }) => assert_eq!(what, "block_payload"),
             other => panic!("expected block_payload integrity error, got {other:?}"),
         }
+    }
+
+    // Build a sealed multi-block product at `path`; return each block's (name, payload bytes).
+    fn sealed_multiblock(path: &Path, n: usize) -> Vec<(String, Vec<u8>)> {
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2024-01-01T00:00:00Z");
+        let blocks: Vec<ArrayBlock> = (0..n)
+            .map(|i| ArrayBlock::new(format!("vol{i}"), ArraySpec::new(vec![8, 8, 8], "int16")))
+            .collect();
+        let mut out = Vec::new();
+        for (i, blk) in blocks.iter().enumerate() {
+            b.add_block(blk).unwrap();
+            out.push((format!("vol{i}"), serde_json::to_vec(&blk.spec).unwrap()));
+        }
+        let sealed = b.seal().unwrap();
+        let payloads: Vec<BlockPayload> = out
+            .iter()
+            .map(|(name, bytes)| BlockPayload::new(name.clone(), bytes.clone()))
+            .collect();
+        pack(&sealed, &payloads, path).unwrap();
+        out
+    }
+
+    #[test]
+    fn should_parallelize_respects_the_knee() {
+        let big = PARALLEL_VERIFY_MIN_BYTES;
+        assert!(
+            should_parallelize(big, 4, 8),
+            "big + multi-block + workers → parallel"
+        );
+        assert!(
+            !should_parallelize(big - 1, 4, 8),
+            "below the size floor → serial"
+        );
+        assert!(!should_parallelize(big, 1, 8), "single block → serial");
+        assert!(!should_parallelize(big, 4, 1), "single worker → serial");
+    }
+
+    #[test]
+    fn parallel_core_verifies_clean_multiblock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.tsra");
+        let names: Vec<String> = sealed_multiblock(&path, 5)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        verify_payloads_multithread(&path, &names, &path.display().to_string(), 4).unwrap();
+    }
+
+    #[test]
+    fn parallel_core_catches_a_tampered_block() {
+        // One block's payload is flipped while its recorded digest stays — a worker re-deriving the
+        // digest from the stored bytes must catch it, even though other workers verify clean blocks.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.tsra");
+        let mut b = ProductBuilder::new("recon", "DP06", "d", "2024-01-01T00:00:00Z");
+        let mut names = Vec::new();
+        let mut payloads = Vec::new();
+        for i in 0..5 {
+            let blk = ArrayBlock::new(format!("vol{i}"), ArraySpec::new(vec![8, 8, 8], "int16"));
+            b.add_block(&blk).unwrap();
+            let mut bytes = serde_json::to_vec(&blk.spec).unwrap();
+            if i == 3 {
+                bytes[0] ^= 0xFF; // corrupt vol3's payload
+            }
+            names.push(format!("vol{i}"));
+            payloads.push(BlockPayload::new(format!("vol{i}"), bytes));
+        }
+        let sealed = b.seal().unwrap();
+        pack(&sealed, &payloads, &path).unwrap();
+        match verify_payloads_multithread(&path, &names, &path.display().to_string(), 4) {
+            Err(Error::BlockIntegrity { block, .. }) => assert_eq!(block, "vol3"),
+            other => panic!("expected a BlockIntegrity error for vol3, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parallel_and_serial_agree() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.tsra");
+        let names: Vec<String> = sealed_multiblock(&path, 5)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        let label = path.display().to_string();
+        // serial L2, the parallel core, and the public entry (which for this small file takes the
+        // serial fallback) must all agree that a clean product verifies.
+        Reader::open(&path)
+            .unwrap()
+            .verify_payloads(&label)
+            .unwrap();
+        verify_payloads_multithread(&path, &names, &label, 4).unwrap();
+        verify_payloads_parallel(&path, &label, 8).unwrap();
     }
 
     #[test]

--- a/tessera/crates/tessera-io/src/lib.rs
+++ b/tessera/crates/tessera-io/src/lib.rs
@@ -39,8 +39,8 @@ pub use collection::{
 pub use config::{parse_byte_size, WriteConfig, DEFAULT_RAM_BUDGET};
 pub use container::{
     add_aux_members, pack, pack_dir, pack_streaming, pack_streaming_verified, unpack,
-    write_aux_members, AuxMember, BlockPayload, Reader, AUX_PREFIX, AUX_PROVENANCE_ENTRY,
-    AUX_SIGNATURES_PREFIX, MIMETYPE,
+    verify_payloads_parallel, write_aux_members, AuxMember, BlockPayload, Reader, AUX_PREFIX,
+    AUX_PROVENANCE_ENTRY, AUX_SIGNATURES_PREFIX, MIMETYPE,
 };
 pub use multiblock::{ColumnBlockIter, LogicalTableView};
 pub use provenance::{


### PR DESCRIPTION
Closes #367.

`tessera verify`'s L2 payload probe (re-hashing every block's stored bytes vs its recorded digest) was a serial `for name in block_names { read_block }` loop — one block at a time on the calling thread, box idle. This fans it across the worker pool.

## What changed

- **`verify_payloads_parallel`** (tessera-io) — `std::thread::scope` work-stealing across up to `workers` threads. Each worker opens its **own** `Reader` (a `.tsra` is a STORED zip → every block is independently addressable) and pulls blocks off a shared `AtomicUsize` cursor, so one huge blob never idles the others. `std::thread` — the write engine's own idiom — so **no new dependency**.
- **Adaptive knee** (`should_parallelize`) — parallelize only above ~256 MiB with >1 block and >1 worker; below it the serial `verify_payloads` runs (thread + reopen overhead doesn't pay back — same small-stays-single principle as ADR-0026, reusing the "few hundred MiB" threshold blake3's mmap/rayon path already uses).
- **`Cmd::Verify`** — routes a local `.tsra` through the parallel path (workers = `WriteConfig::for_system`, the machine default until #368 feeds it from the resource-cap resolver); a URL keeps the serial path (no cheap multi-handle reopen). Output + error surface unchanged.

## Invariant

Read-only and order-independent → **identical result to the serial path** (Ok, or the same typed `BlockIntegrity`). Every block is verified-or-the-run-errors: workers loop the shared cursor until it's drained, and a failure records the first error and stops further work-pulling.

## Tests

Knee decision; clean multi-block under the parallel core; a flipped block caught by the core while sibling blocks verify clean; serial + parallel + public entry all agree on a clean product. All 45 CLI bin tests + tessera-io lib tests green locally.

## Scope

Block-level parallelism (the issue's core ask). **Single-huge-block within-block parallelism is the "eventually chunks" follow-up** the issue names (ties to #214 sub-block Merkle) — not in scope here. Perf is un-benched (parallel blake3 across blocks is self-evident; verify isn't an SLA-gated hot path).

Refs: #214, #368
