### PR TITLE
feat(nix): nix-native distribution channel — packages + reproducible py wheel (#376)

### DIFF
--- a/.github/workflows/release-nix.yml
+++ b/.github/workflows/release-nix.yml
@@ -1,0 +1,67 @@
+# Nix reproducibility channel — attaches the nix-built tessera-py wheel to a published GitHub Release,
+# alongside cargo-dist's prebuilt CLI binaries (release.yml). The CLI itself needs no upload here: nix
+# users install it straight from the flake (`nix run` / `nix profile install github:vig-os/tessera`).
+#
+# TRIGGER = `release: published`, NOT the tag push. cargo-dist's release.yml is what CREATES and
+# publishes the Release on a tag; firing on `published` means this runs AFTER that exists, so the upload
+# never races release creation. Each matrix leg builds the wheel for its own arch (the platform tag is
+# `linux_x86_64` / `linux_aarch64`) and attaches it with `--clobber` (idempotent on re-runs).
+#
+# NB: the nix-built wheel is a `linux_<arch>` wheel, not `manylinux` — fine to attach to a GitHub
+# Release for download, but a PyPI upload needs an `auditwheel repair` / manylinux build first (tracked
+# follow-up). Actions are SHA-pinned to match ci.yml.
+
+name: release-nix
+
+on:  # yamllint disable-line rule:truthy
+  release:
+    types: [published]
+  # Manual re-run against an existing release (e.g. after a transient runner failure).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build + attach the wheel to'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  wheel:
+    name: nix wheel (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64-linux
+            runner: ubuntu-latest
+          - arch: aarch64-linux
+            runner: ubuntu-24.04-arm
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
+
+      - name: Build the reproducible wheel
+        run: nix build .#wheel -L
+
+      - name: Attach the wheel to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          shopt -s nullglob
+          wheels=(result/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error::no wheel produced by 'nix build .#wheel'"
+            exit 1
+          fi
+          gh release upload "$TAG" "${wheels[@]}" --clobber

--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ cargo install --git https://github.com/vig-os/tessera --features static-hdf5 tes
 cd tessera && cargo build --release -p tessera-cli    # needs libhdf5 + pkg-config installed
 ```
 
-**4. Nix dev shell (contributors)** — pins the whole toolchain + native deps (hdf5/zstd/…):
+**4. Nix (run, or install onto PATH)** — the flake exposes `tessera` as a package; nix supplies the
+whole runtime closure (incl. libhdf5), so nothing is vendored and builds are reproducible:
+
+```bash
+nix run     github:vig-os/tessera -- inspect study.tsra   # run without installing
+nix profile install github:vig-os/tessera                 # put `tessera` on PATH
+```
+
+**5. Nix dev shell (contributors)** — pins the whole toolchain + native deps (hdf5/zstd/…):
 
 ```bash
 direnv allow          # or: nix develop
@@ -65,6 +73,20 @@ cd tessera && cargo test
 *Why bundled HDF5 is safe:* HDF5 is a read-only *input* format — Tessera re-encodes everything to
 Zarr+pcodec / Vortex on write, so the libhdf5 build is never in a sealed `.tsra`'s byte-path and can
 never affect a `content_hash`.
+
+### Python
+
+The `tessera` Python package (read / verify / write `.tsra`, returning NumPy arrays and
+polars/pyarrow tables) is a pure [pyo3](https://pyo3.rs) `abi3` extension — one wheel serves CPython
+≥ 3.9. Build the reproducible wheel with nix:
+
+```bash
+nix build github:vig-os/tessera#wheel      # → result/tessera-*-cp39-abi3-linux_<arch>.whl
+pip install result/*.whl                   # needs a libstdc++ on the loader path
+```
+
+(The nix-built wheel is a `linux_<arch>` wheel, not yet `manylinux` — auditwheel/manylinux repair for
+a PyPI upload is a tracked follow-up. It installs and imports today in any compatible-glibc env.)
 
 ## Quickstart
 

--- a/docs/book/src/install.md
+++ b/docs/book/src/install.md
@@ -13,6 +13,7 @@ below and why the bundled-HDF5 options are safe.
 | Prebuilt binary | nothing | end users |
 | `cargo install --features static-hdf5` | CMake + C compiler | source installs, any distro |
 | `cargo build` (default) | system libhdf5 + pkg-config | day-to-day development |
+| `nix run` / `nix profile install` | nix | nix users |
 | Nix dev shell | nix | contributors |
 
 ### 1. Prebuilt binary (recommended)
@@ -58,7 +59,19 @@ The default build (no `static-hdf5` feature) links a libhdf5 that is already ins
 cd tessera && cargo build --release -p tessera-cli
 ```
 
-### 4. Nix dev shell (contributors)
+### 4. Nix (run, or install onto PATH)
+
+The flake exposes `tessera` as a package, so nix users get a first-class install path without touching
+cargo-dist's binaries. Nix supplies the entire runtime closure (including libhdf5), so nothing is
+vendored and the build is reproducible by construction:
+
+```bash
+nix run     github:vig-os/tessera -- inspect study.tsra   # run without installing
+nix profile install github:vig-os/tessera                 # put `tessera` on PATH
+nix build   github:vig-os/tessera#wheel                   # the reproducible Python wheel (below)
+```
+
+### 5. Nix dev shell (contributors)
 
 The repository is Nix-managed; the dev shell pins the exact toolchain and every native dependency
 (hdf5, zstd, …):
@@ -67,6 +80,24 @@ The repository is Nix-managed; the dev shell pins the exact toolchain and every 
 direnv allow          # or: nix develop
 cd tessera && cargo test
 ```
+
+## Python
+
+The `tessera` Python package — read / verify / write `.tsra`, returning NumPy arrays and
+polars/pyarrow tables — is a pure [pyo3](https://pyo3.rs) `abi3` extension with **no** native
+dependencies of its own (it does not link libhdf5). One `abi3` wheel therefore serves CPython ≥ 3.9.
+Build the reproducible wheel with nix:
+
+```bash
+nix build github:vig-os/tessera#wheel      # → result/tessera-*-cp39-abi3-linux_<arch>.whl
+pip install result/*.whl                   # needs a libstdc++ on the loader path
+```
+
+The nix-built wheel carries the honest `linux_<arch>` platform tag — it is **not** yet a `manylinux`
+wheel, so it is not PyPI-uploadable as-is; running it through `auditwheel repair` (or building it in a
+`manylinux` image) is a tracked follow-up. It installs and imports today in any compatible-glibc
+environment — the `tessera-wheel-import` flake check proves it (pip-install + smoke test through the
+packaged wheel).
 
 ## Why bundling HDF5 can't affect your data
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,67 @@
           cargoExtraArgs = "-p tessera-cli --features cloud";
           doCheck = false;
         });
+
+        # The installable `tessera` CLI (the nix-native distribution channel — `nix run` /
+        # `nix profile install`, complementing cargo-dist's prebuilt binaries for non-nix users).
+        # Default features: libhdf5 comes from the nix closure (buildInputs), so — unlike the
+        # cargo-dist binaries — this does NOT need the `static-hdf5` vendored build; nix ships hdf5
+        # in the runtime closure. Reproducible by construction. `mainProgram` lets `nix run` resolve
+        # the binary name (`tessera`) without an explicit `#`-attr.
+        tessera-cli = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          pname = "tessera-cli";
+          cargoExtraArgs = "-p tessera-cli";
+          doCheck = false;
+          meta.mainProgram = "tessera";
+        });
+
+        # The reproducible tessera-py Python wheel (#210). tessera-py is a pure pyo3/abi3 extension
+        # with NO native deps (tessera-core + tessera-io only — no libhdf5), so the wheel is just the
+        # crane-built `_native.so` + the pure-Python `tessera/` wrapper, assembled and `wheel pack`ed.
+        # abi3-py39 → one wheel serves CPython ≥3.9 (tag `cp39-abi3`). The platform tag is the honest
+        # `linux_<arch>` — this is a nix build, not a manylinux one; auditwheel/manylinux repair for a
+        # PyPI upload is a deliberate follow-up (the wheel installs & imports in a compatible-glibc env
+        # today, which the `tessera-wheel-import` check proves).
+        tessera-wheel = let
+          pyVersion = "0.1.0a1"; # PEP 440 form of the workspace 0.1.0-alpha.1
+          arch = pkgs.stdenv.hostPlatform.parsed.cpu.name; # x86_64 / aarch64
+          wheelName = "tessera-${pyVersion}-cp39-abi3-linux_${arch}.whl";
+        in
+        pkgs.runCommand "tessera-wheel-${pyVersion}"
+          {
+            nativeBuildInputs = [ (pkgs.python312.withPackages (ps: [ ps.wheel ])) ];
+            passthru = { inherit wheelName; };
+          } ''
+          root=$PWD/wheel
+          mkdir -p "$root/tessera" "$root/tessera-${pyVersion}.dist-info"
+          cp -r ${./tessera/crates/tessera-py/python/tessera}/. "$root/tessera/"
+          cp ${tessera-py-lib}/lib/_native.so "$root/tessera/_native.so"
+
+          cat > "$root/tessera-${pyVersion}.dist-info/METADATA" <<EOF
+          Metadata-Version: 2.1
+          Name: tessera
+          Version: ${pyVersion}
+          Summary: FAIR data products — read / verify / write .tsra from Python (pyo3, abi3)
+          License: Apache-2.0
+          Requires-Python: >=3.9
+          Requires-Dist: numpy
+          Provides-Extra: tables
+          Requires-Dist: polars ; extra == 'tables'
+          Requires-Dist: pyarrow ; extra == 'tables'
+          EOF
+
+          cat > "$root/tessera-${pyVersion}.dist-info/WHEEL" <<EOF
+          Wheel-Version: 1.0
+          Generator: tessera-nix
+          Root-Is-Purelib: false
+          Tag: cp39-abi3-linux_${arch}
+          EOF
+
+          # `wheel pack` (re)generates the RECORD (sha256 + size per file) and zips deterministically.
+          mkdir -p "$out"
+          python -m wheel pack --dest-dir "$out" "$root"
+        '';
       in
       {
         # guardrails.mkDevShell brings the governance toolbelt (prek + gates + gitleaks +
@@ -150,6 +211,27 @@
             echo "[tessera] rust $(rustc --version 2>/dev/null | cut -d' ' -f2) · python ${pkgs.python312.version} · uv $(uv --version 2>/dev/null | cut -d' ' -f2)"
             echo "[tessera] cargo workspace lives in ./tessera  (cd tessera && cargo test)"
           '';
+        };
+
+        # ── Installable artifacts (the nix-native distribution channel). ──
+        #    `nix run github:vig-os/tessera`         → run the CLI without installing
+        #    `nix profile install github:vig-os/tessera` → install `tessera` onto PATH
+        #    `nix build .#wheel`                      → the reproducible tessera-py wheel
+        #    Complements cargo-dist's prebuilt binaries (which target non-nix users); here nix
+        #    supplies the whole runtime closure (incl. libhdf5), so these need no vendored static build.
+        packages = {
+          default = tessera-cli;
+          tessera = tessera-cli;
+          tessera-cloud = tessera-cli-cloud;
+          wheel = tessera-wheel;
+        };
+
+        apps = rec {
+          default = tessera;
+          tessera = flake-utils.lib.mkApp {
+            drv = tessera-cli;
+            name = "tessera";
+          };
         };
 
         # ── CI = a shim over `nix flake check`. The logic lives HERE so the exact same command
@@ -423,6 +505,25 @@
             cp -r ${./tessera/crates/tessera-py/python/tessera}/. tessera/
             cp ${tessera-py-lib}/lib/_native.so tessera/_native.so
             export PYTHONPATH=$PWD
+            python3 ${./tessera/crates/tessera-py/tests/smoke.py} ${./tessera/corpus/files}
+            touch $out
+          '';
+
+          # The RELEASE wheel (packages.wheel) must be pip-installable AND functional — not just the
+          # raw `_native.so` (that's tessera-py-import above). Installs the actual `.whl` into a target
+          # dir, then runs the same smoke test through it. Proves the assembled wheel's layout + RECORD
+          # + metadata are valid and importable. `LD_LIBRARY_PATH` supplies libstdc++ (the nix-built
+          # extension needs it — the same reason the wheel isn't manylinux-portable until auditwheel'd).
+          tessera-wheel-import = pkgs.runCommand "tessera-wheel-import"
+            {
+              nativeBuildInputs =
+                [ (pkgs.python312.withPackages (ps: [ ps.numpy ps.polars ps.pyarrow ps.pip ])) ];
+            } ''
+            export HOME=$TMPDIR
+            python3 -m pip install --no-index --no-deps --target=$TMPDIR/site \
+              ${tessera-wheel}/${tessera-wheel.wheelName}
+            export PYTHONPATH=$TMPDIR/site
+            export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib
             python3 ${./tessera/crates/tessera-py/tests/smoke.py} ${./tessera/corpus/files}
             touch $out
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,12 @@
           Version: ${pyVersion}
           Summary: FAIR data products — read / verify / write .tsra from Python (pyo3, abi3)
           License: Apache-2.0
+          Home-page: https://github.com/vig-os/tessera
+          Project-URL: Source, https://github.com/vig-os/tessera
+          Project-URL: Documentation, https://github.com/vig-os/tessera#readme
+          Classifier: License :: OSI Approved :: Apache Software License
+          Classifier: Programming Language :: Python :: 3
+          Classifier: Programming Language :: Rust
           Requires-Python: >=3.9
           Requires-Dist: numpy
           Provides-Extra: tables


### PR DESCRIPTION
Closes #376. The **nix-native distribution channel** — Task 2 of the alpha-distribution plan,
complementing the cargo-dist channel from #374. Scoped **lean** (per an explicit decision): the
highest-value, lowest-risk slice; full fenix + musl-static + xtask are deferred follow-ups.

## What & why

cargo-dist (#374) covers non-nix users with prebuilt static binaries. This adds the nix side: a
first-class `nix run` / `nix profile install` path and a reproducible Python wheel — no vendored HDF5
needed here, because nix supplies libhdf5 in the runtime closure.

## Changes (3 commits)

1. **`feat(nix)`** — flake outputs:
   - `packages.{default,tessera,tessera-cloud}` + `apps.{default,tessera}` → `nix run github:vig-os/tessera`
     and `nix profile install github:vig-os/tessera`. Default features (nix closure provides libhdf5).
   - `packages.wheel` — the tessera-py wheel. tessera-py is a **pure pyo3/abi3 extension with no native
     deps** (tessera-core + tessera-io only, no libhdf5), so the wheel is crane's `_native.so` + the
     pure-Python wrapper, `wheel pack`ed. `abi3-py39` → one `cp39-abi3` wheel for CPython ≥3.9.
   - `tessera-wheel-import` check — pip-installs the built wheel and runs the smoke test through it.
2. **`docs`** — README + mdBook install chapter: the nix install path + a Python/wheel section.
3. **`ci(release)`** — `release-nix.yml` builds + attaches the per-arch wheel on `release: published`
   (fires *after* cargo-dist creates the Release → no race; `--clobber` keeps re-runs idempotent).

## Validation

- `nix run .#tessera -- --version` → `tessera 0.1.0-alpha.1`.
- `nix build .#wheel` → `tessera-0.1.0a1-cp39-abi3-linux_x86_64.whl`; pip-install + import + smoke test
  pass (the `tessera-wheel-import` check).
- Full `nix flake check` green on x86_64-linux (aarch64 runs in CI; the wheel's arch tag adapts).
- typos / pymarkdown / yamllint green on the new files.

## Honest caveat / deferred

The nix wheel carries the `linux_<arch>` tag — it installs & imports in any compatible-glibc env, but
is **not** manylinux, so it is not PyPI-uploadable as-is (`auditwheel repair` / manylinux build is the
follow-up). Also deferred: fenix cross-toolchains + **musl fully-static** binary + an `xtask dist`
orchestrator (the CLI is already installable via `nix run`/`nix profile`, and cargo-dist ships portable
binaries).
