### PR TITLE
docs(main): point the default branch to dev until the first alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# README
+# Tessera
+
+A substrate-agnostic, Rust-native **FAIR data-product format** (`fd5` v2) — one immutable,
+content-addressed, self-describing product with a single identity / provenance / integrity /
+versioning spine.
+
+> ⚠️ **Active development is on the [`dev`](https://github.com/vig-os/tessera/tree/dev) branch.**
+> This `main` branch is **release-only** and has not yet received a release: the first alpha
+> (`0.1.0-alpha.1`) is staged but **deliberately held** while the on-disk format settles. Until it is
+> cut, the code, docs, CLI, and Nix flake all live on `dev` — `main` intentionally stays behind.
+>
+> To use or read Tessera today, see the **[`dev` README](https://github.com/vig-os/tessera/blob/dev/README.md)**
+> and, to consume it from another repo (git / Nix flake refs),
+> **[`dev` docs/CONSUMING.md](https://github.com/vig-os/tessera/blob/dev/docs/CONSUMING.md)**.


### PR DESCRIPTION
main's README was a bare `# README`. Anyone landing on the repo's **default branch** had no signal that all active work (code, docs, CLI, Nix flake) lives on `dev`, and that `main` is release-only with no release cut yet (`0.1.0-alpha.1` is held).

Adds a short landing README with a prominent banner → `dev` + `dev`'s `docs/CONSUMING.md`.

⚠️ **Note for the merger:** `main`'s branch protection requires a `nix flake check` status context, but `main`'s CI only produces `Dependency Review` + `CI Summary` (the real flake check lives on `dev`). So this PR's required check will never report on its own — it needs an **admin merge** (enforce_admins is off). Worth reconciling that protection rule vs. main's actual CI separately.