### PR TITLE
perf(table): grid-parallel numeric decode — uncap the column-count fan-out (#352)

### DIFF
--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -1193,7 +1193,10 @@ fn materialise_grid(
             // tasks below cover every one of the `total` rows and each writes its slice exactly once
             // before any read, so exposing `total` uninitialised slots here — instead of a full
             // zero-fill of the output, which would waste the very memory bandwidth this path is
-            // optimising — is sound. On a task error we return `Err` and never read the vector.
+            // optimising — is sound. Caller invariant on error: if any task returns `Err`, this
+            // function returns `Err` and the caller must discard `cols` without reading it (every
+            // current caller does — `decode_inner` drops it via `?`); the elements are `Copy`/no-`Drop`,
+            // so dropping a partially-written column never observes the uninitialised tail.
             unsafe {
                 v.set_len(total);
             }

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -1045,15 +1045,16 @@ fn extend_column(col: &mut ColumnData, prim: &PrimitiveArray) {
 /// spawns than it saves. Small tables stay exactly as serial as they were.
 const PARALLEL_MATERIALISE_MIN_VALUES: usize = 1 << 20;
 
-/// Decompress every column out of the already-scanned row-groups and copy it into the host
-/// accumulators — **column-parallel**.
+/// Decompress every column out of the already-scanned row-groups into the host accumulators, sizing
+/// the fan-out against the whole machine — this is where a full-materialise read spends its time
+/// (`examples/read_profile`: the field-decompress dominates; scan is ~2 %).
 ///
-/// This is where a full-materialise read spends its time (`examples/read_profile`: ~20 % Vortex
-/// decompress + ~78 % host copy, against ~2 % for the scan itself), and it parallelises perfectly:
-/// each column is touched by exactly one worker, and that worker walks the row-groups in order, so
-/// the output is **bit-identical** to a serial decode (asserted by
-/// `decode_is_bit_identical_across_thread_counts`). Measured 2.1× on a 10-core box for a
-/// 2 M-row × 21-column listmode table; the ceiling is memory bandwidth, not core count.
+/// Routes to one of two parallel strategies, both **bit-identical** to a serial decode:
+/// - **grid** ([`materialise_grid`]) for all-numeric tables — parallel over the (column × row-group)
+///   grid, so the fan-out is *not* capped at the column count. Measured on an 88-core box:
+///   a 4-column f64 table went 2.06× (804 → 1656 MB/s), reaching the same ~2 GB/s memory-bandwidth
+///   ceiling as a wide table instead of stalling at 4 workers.
+/// - **column** ([`materialise_with`]) as the fallback for Bool / Utf8 / Nullable shapes.
 ///
 /// The driver hands over already-scanned `chunks`, whose fields are still *encoded* views into the
 /// blob the caller already holds in memory — so this buys its parallelism without inflating the
@@ -1064,17 +1065,47 @@ fn materialise(s: &VortexSession, chunks: &[StructArray], cols: &mut [ColumnData
         return Ok(());
     }
     let values = chunks.iter().map(|c| c.len()).sum::<usize>() * ncols;
-    let threads = if values < PARALLEL_MATERIALISE_MIN_VALUES {
-        1
+    if values < PARALLEL_MATERIALISE_MIN_VALUES {
+        return materialise_with(s, chunks, cols, 1);
+    }
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    // GRID path (#352): for numeric columns, parallelise the decompress over the (column ×
+    // row-group) grid so the fan-out is NOT capped at the column count — a narrow (few-column)
+    // table can still use every core by splitting each column's row-groups across workers. Each
+    // (column, row-group) writes a DISJOINT offset slice of the pre-sized output, so there is no
+    // lock and no concat, and the result is bit-identical to a serial decode. Measured: a 4-column
+    // f64 table went from ~ncols-capped (stuck at 4 threads) to the memory-bandwidth ceiling.
+    //
+    // Bool / Utf8 / Nullable columns keep the column-parallel append path (`materialise_with`) — it
+    // handles the variable-width / bit-packed / dual-vector cases and is already parallel across
+    // columns; those shapes are rare in the wide-numeric listmode tables this grid targets.
+    if is_grid_eligible(cols) {
+        materialise_grid(s, chunks, cols, cores)
     } else {
-        // NB: sized against the whole machine. A caller that already decodes many blocks in
-        // parallel should decode each block on one thread rather than nest the fan-outs.
-        std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .min(ncols)
-    };
-    materialise_with(s, chunks, cols, threads)
+        materialise_with(s, chunks, cols, cores.min(ncols))
+    }
+}
+
+/// The grid decode path applies when every column is a plain fixed-width numeric vector (no
+/// Bool/Utf8/Nullable) — the only shapes for which a disjoint offset-write is trivially correct.
+fn is_grid_eligible(cols: &[ColumnData]) -> bool {
+    cols.iter().all(|c| {
+        matches!(
+            c,
+            ColumnData::I8(_)
+                | ColumnData::I16(_)
+                | ColumnData::I32(_)
+                | ColumnData::I64(_)
+                | ColumnData::U8(_)
+                | ColumnData::U16(_)
+                | ColumnData::U32(_)
+                | ColumnData::U64(_)
+                | ColumnData::F32(_)
+                | ColumnData::F64(_)
+        )
+    })
 }
 
 /// [`materialise`] with the worker count pinned — the seam the equivalence test drives to prove
@@ -1121,6 +1152,104 @@ fn materialise_with(
         for h in handles {
             h.join()
                 .map_err(|_| Error::Codec("table decode worker panicked".into()))??;
+        }
+        Ok(())
+    })
+}
+
+/// A boxed disjoint-slice write task for the grid path. Each captures one row-group's *encoded*
+/// field plus the exact output sub-slice it fills, so tasks never alias and need no lock.
+type GridTask<'a> = Box<dyn FnOnce(&mut ExecutionCtx) -> Result<()> + Send + 'a>;
+
+/// Decode numeric columns across the **(column × row-group) grid** (see [`materialise`]). Pre-sizes
+/// each output column to the full row count, then writes each row-group's decompressed values into
+/// its own disjoint offset slice — so the fan-out ceiling is `columns × row-groups`, not `columns`.
+/// Bit-identical to a serial decode: every slice is written exactly once from exactly one row-group.
+// `clippy::uninit_vec`: the `reserve` + `set_len` below deliberately exposes uninitialised slots to
+// skip a zero-fill; it is sound because the tasks cover and overwrite every slot before any read (see
+// the SAFETY note), and the element types are `Copy` with no `Drop`. clippy cannot see that invariant.
+#[allow(clippy::uninit_vec)]
+fn materialise_grid(
+    s: &VortexSession,
+    chunks: &[StructArray],
+    cols: &mut [ColumnData],
+    threads: usize,
+) -> Result<()> {
+    let total: usize = chunks.iter().map(|c| c.len()).sum();
+
+    // Build the disjoint write tasks. `split_at_mut` carves each column's output into per-row-group
+    // sub-slices (proving disjointness to the borrow checker); each task owns its slice + the
+    // still-encoded field it decompresses into it.
+    let mut tasks: Vec<GridTask> = Vec::with_capacity(cols.len() * chunks.len());
+    // One task per (column, row-group): pre-size the column, then carve it into per-row-group
+    // sub-slices with `split_at_mut` (disjoint → no lock) and hand each slice + its still-encoded
+    // field to a task that decompresses straight into place.
+    macro_rules! push_grid {
+        ($v:expr, $t:ty, $ci:expr) => {{
+            let v: &mut Vec<$t> = $v;
+            v.clear();
+            v.reserve(total);
+            // SAFETY: `$t` is a fixed-width numeric (`Copy`, no `Drop`). The disjoint per-row-group
+            // tasks below cover every one of the `total` rows and each writes its slice exactly once
+            // before any read, so exposing `total` uninitialised slots here — instead of a full
+            // zero-fill of the output, which would waste the very memory bandwidth this path is
+            // optimising — is sound. On a task error we return `Err` and never read the vector.
+            unsafe {
+                v.set_len(total);
+            }
+            let mut rest: &mut [$t] = v.as_mut_slice();
+            for chunk in chunks.iter() {
+                let (head, tail) = rest.split_at_mut(chunk.len());
+                rest = tail;
+                let field = chunk.unmasked_field($ci).clone();
+                tasks.push(Box::new(move |ctx: &mut ExecutionCtx| -> Result<()> {
+                    let p: PrimitiveArray = field.execute(ctx).map_err(ze)?;
+                    head.copy_from_slice(p.as_slice::<$t>());
+                    Ok(())
+                }));
+            }
+        }};
+    }
+    for (ci, col) in cols.iter_mut().enumerate() {
+        match col {
+            ColumnData::I8(v) => push_grid!(v, i8, ci),
+            ColumnData::I16(v) => push_grid!(v, i16, ci),
+            ColumnData::I32(v) => push_grid!(v, i32, ci),
+            ColumnData::I64(v) => push_grid!(v, i64, ci),
+            ColumnData::U8(v) => push_grid!(v, u8, ci),
+            ColumnData::U16(v) => push_grid!(v, u16, ci),
+            ColumnData::U32(v) => push_grid!(v, u32, ci),
+            ColumnData::U64(v) => push_grid!(v, u64, ci),
+            ColumnData::F32(v) => push_grid!(v, f32, ci),
+            ColumnData::F64(v) => push_grid!(v, f64, ci),
+            _ => unreachable!("materialise_grid is numeric-only (guarded by is_grid_eligible)"),
+        }
+    }
+
+    // Round-robin the tasks into one bucket per worker; each worker runs its bucket with its own
+    // ExecutionCtx. Tasks are near-uniform (one row-group each), so round-robin balances well.
+    let nb = threads.max(1).min(tasks.len().max(1));
+    let mut buckets: Vec<Vec<GridTask>> = (0..nb).map(|_| Vec::new()).collect();
+    for (k, t) in tasks.into_iter().enumerate() {
+        buckets[k % nb].push(t);
+    }
+    std::thread::scope(|sc| -> Result<()> {
+        let handles: Vec<_> = buckets
+            .into_iter()
+            .map(|bucket| {
+                let s = s.clone(); // Arc-backed
+                sc.spawn(move || -> Result<()> {
+                    let mut ctx = s.create_execution_ctx();
+                    for t in bucket {
+                        t(&mut ctx)?;
+                    }
+                    Ok(())
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join()
+                .map_err(|_| Error::Codec("table grid-decode worker panicked".into()))??;
         }
         Ok(())
     })
@@ -2218,6 +2347,52 @@ mod tests {
             panic!("expected F64 column back")
         };
         assert_eq!(g, &energy);
+    }
+
+    #[test]
+    fn grid_decode_numeric_matches_serial_across_row_groups() {
+        // The all-numeric GRID decode path (materialise_grid, via decode's auto routing) must be
+        // bit-identical to the serial column path. Size the table above PARALLEL_MATERIALISE_MIN_VALUES
+        // (rows × cols > 2^20) and across several row-groups so the grid actually fans out over the
+        // (column × row-group) grid, then cross-check the auto path (grid) against a pinned
+        // single-worker column decode.
+        let rows = ROWS_PER_GROUP * 7 + 321; // 8 row-groups incl. a partial tail; ×3 cols > 2^20
+        let mut lcg = 0x9E37_79B9_7F4A_7C15u64;
+        let mut next = || {
+            lcg = lcg
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            lcg
+        };
+        let a: Vec<f64> = (0..rows).map(|_| (next() >> 12) as f64 * 1e-9).collect();
+        let data: TableData = vec![
+            ("a".into(), ColumnData::F64(a)),
+            (
+                "b".into(),
+                ColumnData::I64((0..rows as i64).map(|k| k * 7 - 3).collect()),
+            ),
+            (
+                "c".into(),
+                ColumnData::U32(
+                    (0..rows as u32)
+                        .map(|k| k.wrapping_mul(2654435761))
+                        .collect(),
+                ),
+            ),
+        ];
+        let spec = TableSpec {
+            columns: vec![col("a", "f8"), col("b", "i8"), col("c", "u4")],
+            rows: rows as u64,
+            row_index: None,
+        };
+        let blob = encode(&spec, &data).unwrap();
+        let grid = decode(&spec, &blob).unwrap(); // auto → grid (all numeric, over threshold)
+        let serial = decode_with_workers(&spec, &blob, 1).unwrap(); // pinned single-worker column path
+        assert_eq!(grid, data, "grid decode diverged from the input");
+        assert_eq!(
+            grid, serial,
+            "grid decode diverged from serial column decode"
+        );
     }
 
     #[test]

--- a/tessera/crates/tessera-io/src/table.rs
+++ b/tessera/crates/tessera-io/src/table.rs
@@ -1082,10 +1082,23 @@ fn materialise(s: &VortexSession, chunks: &[StructArray], cols: &mut [ColumnData
     // handles the variable-width / bit-packed / dual-vector cases and is already parallel across
     // columns; those shapes are rare in the wide-numeric listmode tables this grid targets.
     if is_grid_eligible(cols) {
+        #[cfg(test)]
+        GRID_DECODES.with(|c| c.set(c.get() + 1));
         materialise_grid(s, chunks, cols, cores)
     } else {
         materialise_with(s, chunks, cols, cores.min(ncols))
     }
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only observability: per-thread count of how many times [`materialise`] routed to the
+    /// numeric grid path. Tests gate the *routing* (a large numeric table must take the grid; a small
+    /// or Bool/Utf8/Nullable one must not) without relying on timing — a non-flaky drift guard
+    /// against the grid being silently disabled or the eligibility/threshold logic regressing. It is
+    /// thread-local (not a global atomic) because the increment runs on the synchronous caller's
+    /// thread, so it stays correct even though cargo runs tests in parallel.
+    pub(crate) static GRID_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 /// The grid decode path applies when every column is a plain fixed-width numeric vector (no
@@ -2395,6 +2408,199 @@ mod tests {
         assert_eq!(
             grid, serial,
             "grid decode diverged from serial column decode"
+        );
+    }
+
+    #[test]
+    fn grid_decode_covers_every_numeric_dtype_and_edges() {
+        // Exercise EVERY `push_grid!` arm — all 10 numeric dtypes — through the grid, at two edge
+        // shapes: a partial-tail row-group and an exact multiple of ROWS_PER_GROUP. Values use
+        // truncating `as` / `wrapping_mul` so there is no debug-mode overflow. Grid (auto) must be
+        // bit-identical to the input and to the serial column path, and must actually take the grid.
+        for rows in [ROWS_PER_GROUP * 2 + 777, ROWS_PER_GROUP * 3] {
+            let data: TableData = vec![
+                (
+                    "i1".into(),
+                    ColumnData::I8((0..rows).map(|k| k as i8).collect()),
+                ),
+                (
+                    "i2".into(),
+                    ColumnData::I16((0..rows).map(|k| (k as i16).wrapping_mul(7)).collect()),
+                ),
+                (
+                    "i4".into(),
+                    ColumnData::I32((0..rows).map(|k| k as i32 - 5).collect()),
+                ),
+                (
+                    "i8".into(),
+                    ColumnData::I64((0..rows).map(|k| (k as i64).wrapping_mul(11)).collect()),
+                ),
+                (
+                    "u1".into(),
+                    ColumnData::U8((0..rows).map(|k| k as u8).collect()),
+                ),
+                (
+                    "u2".into(),
+                    ColumnData::U16((0..rows).map(|k| k as u16).collect()),
+                ),
+                (
+                    "u4".into(),
+                    ColumnData::U32(
+                        (0..rows)
+                            .map(|k| (k as u32).wrapping_mul(2654435761))
+                            .collect(),
+                    ),
+                ),
+                (
+                    "u8".into(),
+                    ColumnData::U64(
+                        (0..rows)
+                            .map(|k| (k as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
+                            .collect(),
+                    ),
+                ),
+                (
+                    "f4".into(),
+                    ColumnData::F32((0..rows).map(|k| k as f32 * 0.5).collect()),
+                ),
+                (
+                    "f8".into(),
+                    ColumnData::F64((0..rows).map(|k| k as f64 * 1e-6).collect()),
+                ),
+            ];
+            let spec = TableSpec {
+                columns: data.iter().map(|(n, c)| col(n, c.numpy_code())).collect(),
+                rows: rows as u64,
+                row_index: None,
+            };
+            let blob = encode(&spec, &data).unwrap();
+            GRID_DECODES.with(|c| c.set(0));
+            let grid = decode(&spec, &blob).unwrap();
+            assert!(
+                GRID_DECODES.with(|c| c.get()) >= 1,
+                "rows={rows}: decode did not take the grid path"
+            );
+            let serial = decode_with_workers(&spec, &blob, 1).unwrap();
+            assert_eq!(grid, data, "rows={rows}: grid decode != input");
+            assert_eq!(
+                grid, serial,
+                "rows={rows}: grid decode != serial column decode"
+            );
+        }
+    }
+
+    #[test]
+    fn grid_routing_is_gated_by_size_and_dtype() {
+        // Non-flaky drift guard on the ROUTING predicate (thread-local counter, no timing): a large
+        // all-numeric table must take the grid; a small one (below PARALLEL_MATERIALISE_MIN_VALUES)
+        // and a mixed-type one (a Bool present → not grid-eligible) must NOT.
+        let numeric = |rows: usize| -> (TableSpec, TableData) {
+            let data: TableData = vec![
+                (
+                    "a".into(),
+                    ColumnData::F64((0..rows).map(|k| k as f64).collect()),
+                ),
+                ("b".into(), ColumnData::I64((0..rows as i64).collect())),
+                ("c".into(), ColumnData::U32((0..rows as u32).collect())),
+            ];
+            let spec = TableSpec {
+                columns: data.iter().map(|(n, c)| col(n, c.numpy_code())).collect(),
+                rows: rows as u64,
+                row_index: None,
+            };
+            (spec, data)
+        };
+        let took_grid = |spec: &TableSpec, blob: &[u8]| -> usize {
+            GRID_DECODES.with(|c| c.set(0));
+            let _ = decode(spec, blob).unwrap();
+            GRID_DECODES.with(|c| c.get())
+        };
+
+        let big = ROWS_PER_GROUP * 6; // ×3 cols > 2^20 threshold
+        let (spec_b, data_b) = numeric(big);
+        let blob_b = encode(&spec_b, &data_b).unwrap();
+        assert!(
+            took_grid(&spec_b, &blob_b) >= 1,
+            "large numeric table must take the grid"
+        );
+
+        let (spec_s, data_s) = numeric(128);
+        let blob_s = encode(&spec_s, &data_s).unwrap();
+        assert_eq!(
+            took_grid(&spec_s, &blob_s),
+            0,
+            "small table must stay serial, not grid"
+        );
+
+        let mut data_m = data_b.clone();
+        data_m.push((
+            "flag".into(),
+            ColumnData::Bool((0..big).map(|k| k % 2 == 0).collect()),
+        ));
+        let spec_m = TableSpec {
+            columns: data_m.iter().map(|(n, c)| col(n, c.numpy_code())).collect(),
+            rows: big as u64,
+            row_index: None,
+        };
+        let blob_m = encode(&spec_m, &data_m).unwrap();
+        assert_eq!(
+            took_grid(&spec_m, &blob_m),
+            0,
+            "mixed-type (Bool) table must use the column fallback, not the grid"
+        );
+    }
+
+    #[test]
+    fn grid_decode_perf_ratchet_narrow_table() {
+        // Coarse performance drift floor (#352): the grid must actually parallelise a NARROW table —
+        // i.e. it must NOT collapse back to serial speed. Relative (machine-independent): the auto
+        // (grid) decode of a 2-column table must beat the 1-worker column-serial decode by a generous
+        // margin, best-of-N. Gated at >=8 cores on purpose: it runs on dev machines with headroom
+        // (a real perf guard) and is SKIPPED on the small, build-saturated CI runners where a timing
+        // assertion would be flaky. The non-flaky CI guard is the *routing* test
+        // (`grid_routing_is_gated_by_size_and_dtype`); absolute-throughput tracking belongs in a
+        // dedicated perf job, not a unit gate.
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        if cores < 8 {
+            return;
+        }
+        let rows = 4_000_000usize;
+        let data: TableData = vec![
+            (
+                "a".into(),
+                ColumnData::F64((0..rows).map(|k| k as f64 * 1e-6).collect()),
+            ),
+            ("b".into(), ColumnData::I64((0..rows as i64).collect())),
+        ];
+        let spec = TableSpec {
+            columns: data.iter().map(|(n, c)| col(n, c.numpy_code())).collect(),
+            rows: rows as u64,
+            row_index: None,
+        };
+        let blob = encode(&spec, &data).unwrap();
+        let best = |run: &dyn Fn()| -> f64 {
+            let mut m = f64::MAX;
+            for _ in 0..7 {
+                let t = std::time::Instant::now();
+                run();
+                m = m.min(t.elapsed().as_secs_f64());
+            }
+            m
+        };
+        let _ = decode(&spec, &blob).unwrap(); // warm
+        let grid = best(&|| {
+            decode(&spec, &blob).unwrap();
+        });
+        let serial = best(&|| {
+            decode_with_workers(&spec, &blob, 1).unwrap();
+        });
+        let speedup = serial / grid;
+        assert!(
+            speedup > 1.2,
+            "grid decode not parallelising a narrow table: {speedup:.2}× vs 1-worker serial \
+             (regression — grid path disabled, serialised, or the zero-fill returned?)"
         );
     }
 


### PR DESCRIPTION
Closes #352. The last parallelism gap in the read path: full-table `decode` fanned out across
**columns only**, so a narrow (few-column) table couldn't use more than `ncols` cores no matter how
many row-groups it had — the exact shape of the per-table listmode "singles" products (ADR-0051) and
the physics tables from #380.

## Spike first (per #352's ask)

Profiled on an 88-core box (`examples/read_profile` + a narrow-vs-wide sweep on identical 248 MiB
high-entropy data):
- The field **decompress dominates** a read (~95%; scan ~2%) — #352's (a), confirmed.
- A 4-column f64 table stalled at ~4 workers / **804 MB/s**, while the *same data* as 64 columns hit
  **1660 MB/s** — the **`ncols` cap**, not memory bandwidth, was the wall.

## Fix — decode the (column × row-group) grid

For all-numeric tables, `materialise_grid` parallelises over the **grid**: each (column, row-group)
decompresses into its own **disjoint offset slice** of the pre-sized output column (`split_at_mut`
carves the per-row-group slices → disjointness proven to the borrow checker; workers are
`std::thread::scope` with a per-worker `ExecutionCtx`). No lock, no concat. Fan-out is now
`columns × row-groups`, not `columns`.

Bit-identical to a serial decode **by construction** — every slot is written exactly once by one task
from one row-group, so bytes are independent of scheduling and of arch. The output vec is
`reserve`+`set_len` (not zero-filled), since every slot is written once — skipping that 320 MB memset
was worth ~1.7× on this bandwidth-bound path (justified `unsafe`, `Copy` numerics, all-slots-written).

Bool / Utf8 / Nullable columns keep the column-parallel append path (`materialise_with`) — variable
width / bit-packed / dual-vector shapes, rare in the wide-numeric tables this targets.

## Measured (high-entropy f64 — the *worst* case; compressible data gains more, being compute-bound)

| table | before | after | speedup |
|---|---|---|---|
| narrow (4 col) | 804 MB/s | **1656 MB/s** | **2.06×** |
| medium (16 col) | 1062 MB/s | 1958 MB/s | 1.84× |
| wide (64 col) | 1660 MB/s | 1977 MB/s | 1.19× |

All shapes now converge at the ~2 GB/s memory-bandwidth ceiling; biggest win is narrow tables.

## Tests / safety

- New `grid_decode_numeric_matches_serial_across_row_groups` (grid == serial == input, multi-row-group,
  over the parallel threshold). Existing `materialise_is_bit_identical_across_thread_counts` covers the
  Bool/Utf8/Nullable column fallback.
- Decode-only change → conformance goldens unchanged (green). fmt / clippy `-D warnings` / cargo-deny green.
- The aarch64 CI leg re-confirms cross-arch byte-determinism of the parallel decode.

## Scope note — the goal was "parallel + compression on zarr & VORTEX"

This closes the **Vortex table** decode gap. Verified the other three legs are already done:
Vortex **compression** (#380 Pco) and **write** (bounded-mem streaming + multi-block #224); the
**zarr/array** path already parallelises chunk encode/decode via zarrs (`concurrent_target` = available
parallelism, byte-deterministic per the conformance gate) with pcodec+`auto` compression. So with this
PR, `.tsra` read+write are parallel and compression-optimal across both backends.
