### PR TITLE
AX onboarding quick wins: SIGPIPE fix + why-tessera comparison + quickstart (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ does not invent a codec; it **composes the proven engine per shape** under one F
 - **Identity & integrity** — blake3 hash-on-write, a Merkle-Mountain-Range `content_hash`, and a
   `manifest_hash` seal that transitively commits to every block digest + all metadata.
 
+**Why not just Parquet or HDF5?** They store bytes; Tessera adds the seal, provenance, versioning,
+signing and cloud/FAIR distribution *around* them — see the capability comparison in
+**[docs/book/src/why-tessera.md](docs/book/src/why-tessera.md)**.
+
 ## Install
 
 Tessera's one native dependency is **libhdf5** (used only to *read* vendor acquisitions at ingest). How
@@ -103,7 +107,17 @@ tessera verify  corpus/files/recon_int16.tsra
 # Navigate the structure like a zarr hierarchy
 tessera tree corpus/files/listmode_events.tsra      # root status · meta · blocks+columns · sources
 tessera ls   corpus/files/listmode_events.tsra events
-tessera read corpus/files/listmode_events.tsra events -c e0 --limit 5   # cross-block column → CSV
+
+# Read a table column → CSV: a preview, or the whole column, or a row range
+tessera read corpus/files/listmode_events.tsra events -c e0 --limit 5    # preview
+tessera read corpus/files/listmode_events.tsra events -c e0 --all > e0.csv
+tessera read corpus/files/listmode_events.tsra events -c e0 --rows 0:100 # a slice
+
+# Look at an array without decoding the whole volume
+tessera stats   corpus/files/recon_int16.tsra volume              # shape · dtype · codec · min/max/mean
+tessera slice   corpus/files/recon_int16.tsra volume --index "32,:,:"   # one plane → CSV
+tessera project corpus/files/recon_int16.tsra volume --axis z --mode max  # MIP → CSV
+# (Prefer NumPy/DataFrames? the `tessera` Python package returns np.ndarray / polars / pyarrow.)
 
 # Ingest a vendor acquisition (normalise at the door), or a declarative multi-product spec
 tessera ingest ge-hdf5 LIST.h5 out.tsra --name DP06-lm --timestamp 2024-01-01T00:00:00Z

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 
 - [Introduction](./intro.md)
+- [Why Tessera? (vs Parquet, HDF5, Zarr)](./why-tessera.md)
 - [Installing Tessera](./install.md)
 - [Command-line tool](./cli.md)

--- a/docs/book/src/why-tessera.md
+++ b/docs/book/src/why-tessera.md
@@ -1,0 +1,73 @@
+# Why Tessera? (vs Parquet, HDF5, Zarr)
+
+> **Short version.** Parquet, HDF5 and Zarr are *storage* formats — they hold bytes well. Tessera is a
+> *FAIR data-product* format: it makes **identity, integrity, provenance and versioning** first-class,
+> and **composes the best codec per data shape** (Zarr + [pcodec](https://github.com/mwlon/pcodec) for
+> arrays, [Vortex](https://github.com/spiraldb/vortex) for tables) underneath. If you'd otherwise reach
+> for "Parquet + a sidecar hash + a metadata JSON + a naming convention," Tessera is that, sealed into
+> one verifiable object.
+
+## The honest framing
+
+Tessera does **not** reinvent compression. Internally it *uses* Zarr, pcodec and Vortex — the same
+engines you'd pick anyway. What it adds is everything **around** the bytes that scientific and clinical
+data needs and that a bare storage format leaves to you:
+
+- a single **`manifest_hash` seal** (blake3 over the canonical manifest) that transitively commits to
+  every block digest and all metadata — tamper anywhere is detectable by one hash;
+- a **content-addressed identity** (`id`) and a Merkle-Mountain-Range **`content_hash`**, so the same
+  logical data is byte-reproducible **across machines and CPU architectures** (a gated property);
+- a **provenance graph** (`derived_from`, producer, generation recipe) carried *inside* the product;
+- **git-shaped versioning** (`init/import/commit/log/diff/publish/seal`) over a content-addressed store;
+- **signing + a trust store**, **OCI push/pull** distribution, **cloud range-reads** (fetch only the
+  bytes a query needs), and **FAIR / RO-Crate** export.
+
+## Capability comparison
+
+`native` = built in and sealed · `bolt-on` = possible but you assemble/maintain it yourself · `—` = no.
+
+| Capability | **Tessera** | Parquet | HDF5 | Zarr |
+| --- | --- | --- | --- | --- |
+| Dense N-D arrays | native (Zarr v3 + pcodec) | — | native | native |
+| Large event tables | native (Vortex) | native | via compound types | — |
+| **Best codec per shape in one file** | **native** | tables only | one-size-fits | arrays only |
+| Whole-object integrity **seal** | **native** (`manifest_hash`) | per-page CRC only | — | — |
+| Content-addressed **identity** | **native** | — | — | — |
+| **Cross-arch byte reproducibility** | **native** (gated) | not guaranteed | not guaranteed | codec-dependent |
+| **Provenance graph** in-product | **native** | bolt-on | bolt-on (attrs) | bolt-on (attrs) |
+| **Versioning / audit** (git-shaped) | **native** | — | — | — |
+| **Signing / trust** | **native** | — | — | — |
+| Cloud **range-read** (prune-before-fetch) | **native** | row-group/column | limited | native (chunks) |
+| **OCI** distribution | **native** | bolt-on | bolt-on | bolt-on |
+| Vendor **ingest normalisation** (DICOM, GE-HDF5, NIfTI) | **native** | — | — | — |
+| **FAIR / RO-Crate** export | **native** | — | — | — |
+| Self-describing, **versioned schema** | **native** (`ProductSchema`) | schema only | attrs | attrs |
+
+## "Why not just Parquet + a hash file?"
+
+You can get *some* of the top rows by hand: Parquet for tables, a `sha256` sidecar, a `metadata.json`,
+a folder convention for versions. The problem is that those pieces are **not bound together** — the hash
+doesn't cover the metadata, the provenance link is a filename, a re-export silently changes bytes, and
+nothing proves the JSON belongs to the data. Tessera's seal binds them into **one object you can verify
+offline, decades later**, with a single command:
+
+```bash
+tessera verify study.tsra     # re-checks the seal + every block digest
+```
+
+## The numbers we have (and the ones we're adding)
+
+- Arrays: Zarr + pcodec is **−21 % (CT) / −33 % (PET) vs zstd**, lossless, with sharded ROI reads.
+- Tables: Vortex float columns compress via pcodec and land competitive with — often smaller than —
+  Parquet+zstd on continuous scientific data (issue #380).
+
+A head-to-head `tessera bench compare` (same data → `.tsra` vs Parquet vs HDF5: size, column-projection
+and ROI-slice latency, cold-cache cloud read) is tracked as a follow-up so these claims ship as
+reproducible numbers, not assertions.
+
+## When a plain format is the right call
+
+Tessera earns its keep when data must be **shared, trusted, and outlive its tooling** — clinical/
+scientific archives, multi-site cohorts, anything with a chain of custody. If you just need a fast local
+scratch table for a single analysis and throw it away, reach for Parquet directly — that's exactly the
+engine Tessera would compose for you anyway.

--- a/tessera/Cargo.lock
+++ b/tessera/Cargo.lock
@@ -6115,6 +6115,7 @@ dependencies = [
  "dicom",
  "getrandom 0.2.17",
  "hdf5-metno",
+ "libc",
  "object_store 0.14.0",
  "serde",
  "serde_json",

--- a/tessera/crates/tessera-cli/Cargo.toml
+++ b/tessera/crates/tessera-cli/Cargo.toml
@@ -80,3 +80,8 @@ trycmd = "0.15"
 # elided; the dev-dep crates still build, but they're already cached from tessera-io's graph.
 object_store = { version = "0.14", default-features = false, features = ["aws"] }
 tokio = { version = "1", features = ["rt"] }
+
+# Reset the SIGPIPE disposition at startup (main.rs) so `tessera … | head` terminates quietly like a
+# standard Unix tool instead of erroring on the closed pipe. Unix-only; already in the dep tree.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -867,6 +867,16 @@ enum IngestSrc {
 }
 
 fn main() -> ExitCode {
+    // Restore the default SIGPIPE disposition so piping tessera's output into `head`, `less`, etc.
+    // terminates it quietly — like every standard Unix tool — instead of erroring. Rust's runtime
+    // sets SIGPIPE to SIG_IGN, which turns a reader closing the pipe into a `Broken pipe` write error
+    // on the streaming subcommands (`read`/`slice`/`project`) rather than a clean exit.
+    #[cfg(unix)]
+    // SAFETY: run once at startup before any thread is spawned; resetting a signal disposition to the
+    // OS default is sound.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
     // Surface library WARNs (e.g. the ingest engine's recommended-field nudge) on stderr. Quiet
     // (warn+ only), compact + timestamp-free so it reads as CLI output rather than a log.
     let _ = tracing_subscriber::fmt()


### PR DESCRIPTION
Quick wins from a 3-fresh-agent AX/onboarding audit (#390). The tool scored **4.5/5 on read/inspect UX**
but **2/5 on both "write your own data" and "advantage vs Parquet/HDF5"** — this PR takes the
docs/CLI-sized fixes; the feature-sized ones are filed (#386–#389).

## Changes
- **fix(cli): SIGPIPE** — `tessera slice/project/read … | head` printed `Broken pipe (os error 32)`
  and exited non-zero (Rust sets SIGPIPE=SIG_IGN → EPIPE). Reset to SIG_DFL at startup → clean exit,
  like a standard Unix tool. Verified.
- **docs/book/src/why-tessera.md** — the missing pitch: an honest framing (Tessera *composes*
  Zarr/pcodec/Vortex under a FAIR product model) + a native/bolt-on/no capability table vs
  Parquet/HDF5/Zarr + "why not just Parquet + a hash file?". Linked from the mdBook nav + README.
- **README quickstart** — surfaces the read/array commands the audit found hidden (`read --all`/`--rows`,
  `stats`/`slice`/`project`, Python pointer).

Gates green: typos, pymarkdown, clippy `-D warnings`, mdBook build.

## Follow-ups filed
#386 generic `ingest table/array` · #387 non-CSV array output · #388 `bench compare` vs Parquet/HDF5 ·
#389 ingest cookbook + product/schema reference + Python write example + fix `cli.md` stubs.