### PR TITLE
ADR-0057 Phase 0: `tessera info` + Gate B + drop static-hdf5 from the PR clippy matrix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,21 @@
             || (pkgs.lib.hasInfix "/tests/cmd/" path);
           name = "source";
         };
+        # Every feature declared anywhere in the workspace **except `static-hdf5`** (ADR-0057 §4), in
+        # cargo's `package/feature` form so one invocation from the virtual-manifest root covers all
+        # members. This is what the PR clippy gate builds instead of `--all-features`.
+        #   tessera-core   array-zarr, table-arrow   (= `full`)
+        #   tessera-io     cloud
+        #   tessera-cli    cloud (→ tessera-io/cloud), sql
+        #   tessera-ingest static-hdf5 only          → deliberately absent
+        #   tessera-py / tessera-wasm                → no features
+        workspaceFeatures = builtins.concatStringsSep "," [
+          "tessera-core/full"
+          "tessera-io/cloud"
+          "tessera-cli/cloud"
+          "tessera-cli/sql"
+        ];
+
         commonArgs = {
           inherit src;
           strictDeps = true;
@@ -56,10 +71,10 @@
           # runs bindgen (needs libclang) and links libstdc++. The tessera-ingest GE-HDF5 reader
           # links libhdf5 (found via pkg-config — `hdf5-metno-sys` reads PKG_CONFIG_PATH when
           # HDF5_DIR is unset). Provide all to every crane derivation (deps/clippy/test).
-          # `cmake` is needed by the `static-hdf5` feature (hdf5-metno-src builds libhdf5 from source via
-          # CMake); any check that enables all features — e.g. the `--all-features` clippy — compiles that
-          # vendored build, which doubles as CI coverage of the static/lib64 path on both arches. The
-          # default (pkg-config) builds don't invoke CMake, so it costs them nothing.
+          # `cmake` is kept for the `static-hdf5` feature (hdf5-metno-src builds libhdf5 from source via
+          # CMake). No *PR* check enables it any more (ADR-0057 §4 — see `workspace-clippy` below); it is
+          # exercised release-only, by the cargo-dist channel (`dist-workspace.toml`). The default
+          # (pkg-config) builds don't invoke CMake, so keeping it here costs them nothing.
           nativeBuildInputs = with pkgs; [ clang pkg-config cmake ];
           buildInputs = with pkgs; [ stdenv.cc.cc.lib hdf5 ];
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
@@ -244,9 +259,22 @@
         #    runs on a dev's machine and in CI — no "passes locally / fails in CI" drift. ──
         checks = {
           # Hermetic Rust gates over the tessera workspace.
+          #
+          # NOT `--all-features` (ADR-0057 §4): that pulls `static-hdf5`, which builds libhdf5 2.2.0
+          # from vendored source via CMake and dominated the ~90 min x86_64 check. `static-hdf5` only
+          # switches how libhdf5 *links* — there is not one `#[cfg(feature = "static-hdf5")]` in the
+          # tree — so dropping it from the PR matrix costs **zero** clippy coverage: nix supplies
+          # libhdf5 from the closure (`buildInputs`), and every line of hdf5 code still compiles here.
+          # It stays exercised release-only, by the cargo-dist channel (`dist-workspace.toml` sets
+          # `features = ["static-hdf5"]`).
+          #
+          # `workspaceFeatures` is therefore the explicit "every workspace feature EXCEPT static-hdf5"
+          # set. It must be kept exhaustive by hand — cargo has no `--all-features-except`. Adding a
+          # feature to any crate means adding it here.
           workspace-clippy = craneLib.cargoClippy (commonArgs // {
             inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets --all-features -- -D warnings";
+            cargoClippyExtraArgs =
+              "--all-targets --features ${workspaceFeatures} -- -D warnings";
           });
           workspace-test = craneLib.cargoNextest (commonArgs // {
             inherit cargoArtifacts;

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,8 @@
         # Cargo sources + the conformance corpus (tests/conformance.rs reads corpus/corpus.json) +
         # docs/examples (tessera-ingest::spec embeds the example ingest TOML via include_str! and a
         # test validates it) + the CLI docs-as-tests (`tests/cmd/*.trycmd` walkthroughs + their `.in/`
-        # fixtures) — cleanCargoSource would otherwise strip these non-Rust files, so the trycmd
+        # fixtures) + Gate B's committed feature snapshots (`tests/feature-snapshots/*.txt`, ADR-0057
+        # §5) — cleanCargoSource would otherwise strip these non-Rust files, so the trycmd
         # docs-as-tests would silently run ZERO cases in the hermetic gate.
         src = pkgs.lib.cleanSourceWith {
           src = ./tessera;
@@ -44,7 +45,8 @@
             || (pkgs.lib.hasInfix "/corpus/" path)
             || (pkgs.lib.hasInfix "/docs/examples/" path)
             || (pkgs.lib.hasInfix "/docs/dictionaries/" path)
-            || (pkgs.lib.hasInfix "/tests/cmd/" path);
+            || (pkgs.lib.hasInfix "/tests/cmd/" path)
+            || (pkgs.lib.hasInfix "/tests/feature-snapshots/" path);
           name = "source";
         };
         # Every feature declared anywhere in the workspace **except `static-hdf5`** (ADR-0057 §4), in
@@ -270,7 +272,8 @@
           #
           # `workspaceFeatures` is therefore the explicit "every workspace feature EXCEPT static-hdf5"
           # set. It must be kept exhaustive by hand — cargo has no `--all-features-except`. Adding a
-          # feature to any crate means adding it here.
+          # feature to any crate means adding it here (the `feature-snapshots` check below will also
+          # notice, since a new feature moves the resolved graph).
           workspace-clippy = craneLib.cargoClippy (commonArgs // {
             inherit cargoArtifacts;
             cargoClippyExtraArgs =
@@ -288,6 +291,44 @@
             cargoTestExtraArgs = "--doc";
           });
           workspace-fmt = craneLib.cargoFmt { inherit src; };
+
+          # **Gate B — the feature-snapshot determinism gate** (ADR-0057 §5). Regenerates the resolved
+          # feature graph of every crate on the seal path and diffs it against the committed baseline
+          # in `tessera/tests/feature-snapshots/` — the hermetic equivalent of the ADR's
+          # `git diff --exit-code` (there is no `.git` inside the nix sandbox).
+          #
+          # Gate A (Phase 1) catches a golden that moved; Gate B catches the *risk* on the PR that
+          # introduced it. It is what would have flagged `sql` turning on `arrow-array/chrono-tz`
+          # — ADR-0056 hazard H1 (tzdb: compiled-in vs. host `/usr/share/zoneinfo`) arriving through
+          # a feature rather than a host — on the PR that added `sql`, instead of on the release that
+          # shipped an ingest path through it. Feature unification is monotonic, so the same class of
+          # hazard would silently re-register ALP in the Vortex float compressor (#380/#384).
+          #
+          # A failure is NOT automatically a bug: it is a deliberate corpus event. Regenerate with
+          # `scripts/feature-snapshots.sh tessera/tests/feature-snapshots` and either show no golden
+          # moved (stating why in the PR) or carry the corpus regeneration alongside.
+          #
+          # `cargo tree` reads the lockfile + the vendored manifests; it compiles nothing, so this
+          # check is nearly free (`cargoArtifacts = null` — there is no target dir to inherit).
+          feature-snapshots = craneLib.mkCargoDerivation (commonArgs // {
+            cargoArtifacts = null;
+            doInstallCargoArtifacts = false;
+            pnameSuffix = "-feature-snapshots";
+            buildPhaseCargoCommand = ''
+              TESSERA_WORKSPACE="$PWD" bash ${./scripts/feature-snapshots.sh} "$TMPDIR/snapshots"
+              # `--exclude='*.md'` skips the directory's README (the reviewer-facing explainer);
+              # every `<crate>.txt` is still compared, and a snapshot that vanished still shows up
+              # as an "Only in …" line.
+              if ! diff -ru --exclude='*.md' tests/feature-snapshots "$TMPDIR/snapshots"; then
+                echo "" >&2
+                echo "Gate B (ADR-0057 §5): the resolved feature graph of a seal-path crate CHANGED." >&2
+                echo "This is a deliberate corpus event — see the diff above, then regenerate with:" >&2
+                echo "    scripts/feature-snapshots.sh tessera/tests/feature-snapshots" >&2
+                echo "and justify it in the PR (no golden moved, or the corpus regen rides along)." >&2
+                exit 1
+              fi
+            '';
+          });
 
           # `tessera-core` must stay **wasm32-compatible** (#210): the pure-Rust spine — manifest /
           # identity / hash / inclusion+consistency proofs / referencing / ed25519 *verify* — has zero

--- a/scripts/feature-snapshots.sh
+++ b/scripts/feature-snapshots.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Gate B — the feature-snapshot determinism gate (ADR-0057 §5).
+#
+# Gate A (Phase 1) tells you the day the goldens moved. Gate B tells you the day the *risk* was
+# introduced, on the PR that introduced it: it snapshots the resolved feature set of every crate on
+# the **seal path** and fails when one changes.
+#
+# Why this matters concretely (ADR-0057 §5, "the hazard the probe actually found"): the optional,
+# ingest-unrelated `sql` feature already turns on `arrow-array/chrono-tz` — ADR-0056 hazard H1
+# (tzdb as a compiled-in vs. filesystem dependency), rated *high × fatal*, arriving through a
+# feature instead of through a host. The same class of hazard is worse on the Vortex side: the
+# workspace pins `vortex-btrblocks = { features = ["pco"] }` to *exclude* ALP, which was not
+# byte-deterministic (#380/#384). Feature unification is monotonic — it can only add — so any
+# future dependency that transitively enables `vortex-btrblocks/alp` silently re-encodes every
+# float column in every table.
+#
+# A changed snapshot is NOT automatically wrong. It is a **deliberate corpus event**: the PR must
+# either show that no golden moved (and update the snapshot with a stated reason) or carry the
+# corpus regeneration alongside.
+#
+# Usage:
+#   scripts/feature-snapshots.sh <OUT_DIR>
+#
+# Regenerate the committed baseline (run from the repo root, inside `nix develop`):
+#   scripts/feature-snapshots.sh tessera/tests/feature-snapshots
+#
+# The `feature-snapshots` flake check runs this into a temp dir and `diff`s it against the
+# committed baseline — the hermetic equivalent of `git diff --exit-code`.
+set -euo pipefail
+
+out_dir="${1:-}"
+if [ -z "${out_dir}" ]; then
+  echo "usage: $0 <OUT_DIR>" >&2
+  exit 2
+fi
+
+# The seal path: everything that can move sealed bytes. Hand-maintained — ADR-0057 names deriving
+# this from the dependency graph as an open gap. Adding a codec crate to the write path without
+# adding it here leaves a blind spot.
+#
+#   blake3                            content_hash / manifest_hash
+#   zarrs pco zstd                    the array block backend + its codecs
+#   vortex-btrblocks vortex-file      the table block backend (compressor + writer)
+#   vortex-array vortex-buffer        the table block in-memory representation
+#   arrow-array arrow-buffer arrow-schema
+#                                     the shared arrow tree the ADR-0056 table lane canonicalises
+#                                     through (and where `sql` flips `chrono-tz` today)
+#
+# NB: ADR-0057 §5 spells the pcodec entry `pcodec` — that is the *project* name; the crate on
+# crates.io (and in `Cargo.lock`) is `pco`, so that is what `cargo tree -i` can be given. Same
+# codec, and it is the one the workspace pins `vortex-btrblocks/pco` to reach.
+CRATES=(
+  blake3
+  zarrs
+  pco
+  zstd
+  vortex-btrblocks
+  vortex-file
+  vortex-array
+  vortex-buffer
+  arrow-array
+  arrow-buffer
+  arrow-schema
+)
+
+# Determinism of the invocation itself:
+#   LC_ALL=C           `sort` collation must not depend on the developer's locale.
+#   --charset ascii    the tree glyphs must not depend on a UTF-8 terminal.
+#   --locked           resolve against the committed Cargo.lock, never re-resolve.
+#   --offline          no network: the hermetic nix check has none, and a registry fetch could
+#                      silently change what is being snapshotted.
+#   --all-features     ADR-0057 §5 — snapshot the *widest* graph, including `static-hdf5` (which
+#                      the PR clippy gate no longer builds) and `sql`, so a drift anywhere in the
+#                      feature space is visible even though no single build enables all of it.
+#   -e features        feature edges, not just package edges — the whole point of Gate B.
+#   -i <crate>         invert: who pulls this crate in, and with which features.
+#   --target all       cargo tree otherwise resolves cfg() against the HOST triple, which would make
+#                      the snapshot host-dependent — and CI runs `nix flake check` on x86_64-linux
+#                      AND aarch64-linux, so a target-gated dependency appearing on one and not the
+#                      other would fail the gate on one arch for no determinism reason. All 11
+#                      snapshots are byte-identical under host / aarch64 / all today; this keeps
+#                      them that way by construction rather than by luck.
+export LC_ALL=C
+
+# The cargo workspace root. Normally `<repo>/tessera`, derived from this script's own location so a
+# developer can run it from anywhere. The `feature-snapshots` flake check sets `TESSERA_WORKSPACE`
+# instead, because there the script lives in the nix store while the sources are unpacked in $PWD.
+workspace_dir="${TESSERA_WORKSPACE:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../tessera" && pwd)}"
+
+mkdir -p "${out_dir}"
+out_dir="$(cd -- "${out_dir}" && pwd)"
+
+# Two normalisations, so the snapshot records the *dependency graph* and nothing else. Both are
+# lossless for Gate B's purpose — neither can hide a feature change:
+#
+#  1. `cargo tree` prints path-dependencies as `tessera-io v… (/abs/path/to/crates/tessera-io)`.
+#     That absolute path differs between a developer's checkout, a git worktree, and the nix
+#     sandbox's `/build/source`, which would make the gate fail for everyone but its author.
+#
+#  2. Workspace members share one `version.workspace` (`0.1.0-alpha.1` today), which release-plz
+#     bumps on every release. A software version bump cannot change an encoding — it is not a
+#     corpus event — so pinning it to `vWORKSPACE` keeps release PRs out of Gate B's face. The
+#     versions that *can* move bytes are the third-party ones, and those stay verbatim.
+normalise() {
+  sed -E \
+    -e 's# \(/[^)]*\)##g' \
+    -e 's#(tessera-(core|io|cli|ingest|py|wasm)) v[0-9][^ ]*#\1 vWORKSPACE#g'
+}
+
+cd "${workspace_dir}"
+for c in "${CRATES[@]}"; do
+  cargo tree --quiet --locked --offline --all-features --charset ascii --target all \
+    -e features -i "${c}" \
+    | normalise \
+    | sort > "${out_dir}/${c}.txt"
+done
+
+echo "wrote ${#CRATES[@]} feature snapshots to ${out_dir}"

--- a/tessera/crates/tessera-cli/src/info.rs
+++ b/tessera/crates/tessera-cli/src/info.rs
@@ -1,0 +1,227 @@
+//! `tessera info` — what *this* build is (ADR-0057 §7).
+//!
+//! Feature selection may decide whether a format is **readable**; it may never change the **bytes**
+//! produced for a readable one (ADR-0057 §7's guarantee, enforced by §5's gates). That makes the
+//! feature set of a binary a support question rather than a correctness one — but only if someone
+//! who did not build the binary can *see* it. Before this, `--version` printed a bare version and
+//! every "why did this fail?" cost a round-trip.
+//!
+//! Three lines, one question each:
+//!
+//! ```text
+//! tessera 0.1.0-alpha.1  (format tessera_version 0.0.0)
+//! backends:   blob · dicom 0.9.7 · dicom-series 0.9.7 · hdf-compound 1.14.6 · nifti · raw
+//! disabled:   (none)
+//! build:      static-hdf5=no · cloud=no · sql=no
+//! ```
+//!
+//! `--json` emits the same facts in a shape meant to be embedded in `aux/provenance.json`.
+//!
+//! **The flavor is deliberately NOT sealed.** ADR-0056 §6.2 seals `ingest_decoder` — the decoder
+//! name + version, the thing that actually determined the bytes. A compile-time bundle label did
+//! not, and sealing it would invite the false inference "same flavor ⇒ same bytes". ADR-0042's line
+//! holds: sealed = what changed the bytes; `aux/` = who was in the room.
+
+use std::io::Write;
+
+use serde::Serialize;
+use tessera_core::{Error, Result};
+use tessera_ingest::backends::{backend_version, backends_disabled, BACKENDS_ENABLED};
+
+/// A **build mode** — how this binary was assembled, as opposed to what it can decode.
+///
+/// ADR-0057 §4/§5 keeps these separate on purpose: `static-hdf5` is not a capability (it only
+/// switches how libhdf5 links) and is deliberately excluded from the `full` capability set, while
+/// `cloud` and `sql` add surfaces rather than decoders. All three are `cfg!`, so they cost nothing
+/// at runtime and cannot disagree with the binary they were compiled into.
+const BUILD_FLAGS: &[(&str, bool)] = &[
+    ("static-hdf5", cfg!(feature = "static-hdf5")),
+    ("cloud", cfg!(feature = "cloud")),
+    ("sql", cfg!(feature = "sql")),
+];
+
+/// One compiled-in backend and, when there is one to report, its decoder version.
+#[derive(Debug, Serialize)]
+struct BackendInfo {
+    name: &'static str,
+    /// Omitted for the in-tree parsers, which have no third-party decoder to name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+}
+
+/// The machine-readable form of `tessera info`, shaped for `aux/provenance.json`.
+#[derive(Debug, Serialize)]
+struct Info {
+    /// The software version (ADR-0052 §1) — `CARGO_PKG_VERSION`, not the format version.
+    tessera_version: &'static str,
+    /// The format/spec version this build *writes* into a manifest's `tessera_version` field.
+    format_version: &'static str,
+    backends: Vec<BackendInfo>,
+    /// Known backend names whose handler is not in this build. Empty until Phase 1's feature graph.
+    backends_disabled: Vec<&'static str>,
+    /// Build modes, by the same names their Cargo features carry.
+    build: std::collections::BTreeMap<&'static str, bool>,
+}
+
+fn collect() -> Info {
+    Info {
+        tessera_version: env!("CARGO_PKG_VERSION"),
+        format_version: tessera_core::manifest::TESSERA_VERSION,
+        backends: BACKENDS_ENABLED
+            .iter()
+            .map(|&name| BackendInfo {
+                name,
+                version: backend_version(name),
+            })
+            .collect(),
+        backends_disabled: backends_disabled(),
+        build: BUILD_FLAGS.iter().copied().collect(),
+    }
+}
+
+/// Render `name version` / `name` for the human `backends:` line.
+fn render(b: &BackendInfo) -> String {
+    match &b.version {
+        Some(v) => format!("{} {v}", b.name),
+        None => b.name.to_string(),
+    }
+}
+
+/// `tessera info [--json]` — the version, the resolved backend set, and the build-mode flags.
+pub fn info(json: bool, out: &mut dyn Write) -> Result<()> {
+    let i = collect();
+
+    if json {
+        let text = serde_json::to_string_pretty(&i)
+            .map_err(|e| Error::Invalid(format!("info: serialize: {e}")))?;
+        return writeln!(out, "{text}").map_err(Error::from);
+    }
+
+    writeln!(
+        out,
+        "tessera {}  (format tessera_version {})",
+        i.tessera_version, i.format_version
+    )
+    .map_err(Error::from)?;
+    let backends: Vec<String> = i.backends.iter().map(render).collect();
+    writeln!(out, "backends:   {}", backends.join(" · ")).map_err(Error::from)?;
+    let disabled = if i.backends_disabled.is_empty() {
+        "(none)".to_string()
+    } else {
+        i.backends_disabled.join(" · ")
+    };
+    writeln!(out, "disabled:   {disabled}").map_err(Error::from)?;
+    // Declaration order here, not the map's sorted order: ADR-0057 §7 reads build mode first
+    // (`static-hdf5=yes · cloud=yes · sql=no`). The JSON form keeps the map, whose sorted keys are
+    // what the repo's JCS canonicalisation wants anyway.
+    let flags: Vec<String> = BUILD_FLAGS
+        .iter()
+        .map(|(name, on)| format!("{name}={}", if *on { "yes" } else { "no" }))
+        .collect();
+    writeln!(out, "build:      {}", flags.join(" · ")).map_err(Error::from)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tessera_ingest::backends::BACKENDS_ALL;
+
+    fn human() -> String {
+        let mut buf = Vec::new();
+        info(false, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn human_form_reports_version_backends_and_build_modes() {
+        let out = human();
+        let mut lines = out.lines();
+
+        let first = lines.next().unwrap();
+        assert!(
+            first.starts_with(&format!("tessera {} ", env!("CARGO_PKG_VERSION"))),
+            "first line must lead with the software version: {first}"
+        );
+        assert!(
+            first.contains(tessera_core::manifest::TESSERA_VERSION),
+            "first line must name the format version too: {first}"
+        );
+
+        let backends = lines.next().unwrap();
+        assert!(backends.starts_with("backends:   "));
+        for name in BACKENDS_ENABLED {
+            assert!(
+                backends.contains(name),
+                "compiled-in backend '{name}' missing from: {backends}"
+            );
+        }
+
+        assert_eq!(
+            lines.next().unwrap(),
+            "disabled:   (none)",
+            "no decoder feature gate exists yet, so nothing is disabled (Phase 1 changes this)"
+        );
+
+        let build = lines.next().unwrap();
+        for (flag, _) in BUILD_FLAGS {
+            assert!(
+                build.contains(&format!("{flag}=")),
+                "build mode '{flag}' missing from: {build}"
+            );
+        }
+        assert!(lines.next().is_none(), "info is exactly four lines");
+    }
+
+    /// The build-mode line must describe *this* binary, not a hard-coded guess. The test binary is
+    /// compiled with the same features as the crate under test, so `cfg!` is the ground truth to
+    /// compare against.
+    #[test]
+    fn build_modes_track_the_compiled_features() {
+        let out = human();
+        let expect = |flag: &str, on: bool| {
+            let want = format!("{flag}={}", if on { "yes" } else { "no" });
+            assert!(out.contains(&want), "expected '{want}' in: {out}");
+        };
+        expect("static-hdf5", cfg!(feature = "static-hdf5"));
+        expect("cloud", cfg!(feature = "cloud"));
+        expect("sql", cfg!(feature = "sql"));
+    }
+
+    #[test]
+    fn json_form_is_parseable_and_carries_the_same_facts() {
+        let mut buf = Vec::new();
+        info(true, &mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+
+        assert_eq!(v["tessera_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(v["format_version"], tessera_core::manifest::TESSERA_VERSION);
+        assert_eq!(
+            v["backends"].as_array().unwrap().len(),
+            BACKENDS_ENABLED.len()
+        );
+        assert!(v["backends_disabled"].as_array().unwrap().is_empty());
+        assert_eq!(v["build"]["cloud"], cfg!(feature = "cloud"));
+
+        // hdf-compound reports the libhdf5 actually linked; the in-tree parsers report no decoder.
+        let by_name = |n: &str| {
+            v["backends"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|b| b["name"] == n)
+                .unwrap()
+                .clone()
+        };
+        assert!(by_name("hdf-compound")["version"].is_string());
+        assert!(by_name("raw").get("version").is_none());
+    }
+
+    /// ADR-0057 §6: the *name* set is build-invariant. Today no decoder feature exists, so the
+    /// compiled-in set is the whole set — and `info` says so rather than implying a lean build.
+    #[test]
+    fn every_known_backend_is_compiled_in_today() {
+        assert_eq!(BACKENDS_ENABLED, BACKENDS_ALL);
+        assert!(human().contains("disabled:   (none)"));
+    }
+}

--- a/tessera/crates/tessera-cli/src/main.rs
+++ b/tessera/crates/tessera-cli/src/main.rs
@@ -6,6 +6,7 @@
 
 mod bench;
 mod collection;
+mod info;
 mod nav;
 mod resource;
 #[cfg(feature = "sql")]
@@ -147,6 +148,7 @@ Signing & trust:
   verify-sig  Verify a sealed .tsra against its signature (embedded first, sidecar fallback)
 
 Diagnostics:
+  info        What this build is (version, backends, build modes) — --json for machines
   bench       Bench the write engine on this host (throughput + peak RSS)
 
 Run `tsra help <command>` for details, flags, and what to pass.
@@ -616,6 +618,17 @@ enum Cmd {
     Collection {
         #[command(subcommand)]
         action: CollectionAction,
+    },
+    /// What this build is: version, compiled-in backends, build modes (ADR-0057 §7).
+    ///
+    /// Feature selection decides which formats are **readable**; it never changes the **bytes**
+    /// produced for a readable one. This is how someone who did not build the binary can see which
+    /// side of that line a failure is on. `--json` emits the same facts in a shape suitable for
+    /// embedding in `aux/provenance.json`.
+    Info {
+        /// Emit JSON instead of the human summary.
+        #[arg(long)]
+        json: bool,
     },
     /// Bench the write engine on this host (throughput + peak RSS).
     ///
@@ -1451,6 +1464,7 @@ fn run(cmd: Cmd) -> tessera_core::Result<()> {
                 CollectionAction::Verify { file } => collection::verify(&file, &mut out),
             }
         }
+        Cmd::Info { json } => info::info(json, &mut std::io::stdout().lock()),
         Cmd::Bench { action } => match action {
             BenchAction::Write {
                 schema,

--- a/tessera/crates/tessera-cli/tests/cmd/help.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/help.trycmd
@@ -51,6 +51,7 @@ Signing & trust:
   verify-sig  Verify a sealed .tsra against its signature (embedded first, sidecar fallback)
 
 Diagnostics:
+  info        What this build is (version, backends, build modes) — --json for machines
   bench       Bench the write engine on this host (throughput + peak RSS)
 
 Run `tsra help <command>` for details, flags, and what to pass.

--- a/tessera/crates/tessera-cli/tests/cmd/info.trycmd
+++ b/tessera/crates/tessera-cli/tests/cmd/info.trycmd
@@ -1,0 +1,58 @@
+`tessera info` — what this build is (ADR-0057 §7). The shape is pinned here; the *semantics*
+(build modes tracking `cfg!`, JSON keys, the disabled set) are pinned by the unit tests in
+`src/info.rs`. Versions are wildcarded because a dependency bump must not break a docs walkthrough.
+
+```
+$ tessera info
+tessera [..]
+backends:   blob · dicom [..] · dicom-series [..] · hdf-compound [..] · nifti · raw
+disabled:   (none)
+build:      static-hdf5=[..] · cloud=[..] · sql=[..]
+
+```
+
+Nothing is disabled today: no decoder feature gate exists yet, so every known backend is compiled
+in. Phase 1's feature graph (ADR-0057 §5) is what starts moving names onto the `disabled:` line —
+and the missing-backend error will point here.
+
+`--json` emits the same facts in a shape meant for `aux/provenance.json`. The binary flavor is
+deliberately NOT sealed: ADR-0056 §6.2 seals `ingest_decoder`, which is what actually determined the
+bytes. ADR-0042's line holds — sealed = what changed the bytes; `aux/` = who was in the room.
+
+```
+$ tessera info --json
+{
+  "tessera_version": "[..]",
+  "format_version": "[..]",
+  "backends": [
+    {
+      "name": "blob"
+    },
+    {
+      "name": "dicom",
+      "version": "[..]"
+    },
+    {
+      "name": "dicom-series",
+      "version": "[..]"
+    },
+    {
+      "name": "hdf-compound",
+      "version": "[..]"
+    },
+    {
+      "name": "nifti"
+    },
+    {
+      "name": "raw"
+    }
+  ],
+  "backends_disabled": [],
+  "build": {
+    "cloud": [..],
+    "sql": [..],
+    "static-hdf5": [..]
+  }
+}
+
+```

--- a/tessera/crates/tessera-ingest/build.rs
+++ b/tessera/crates/tessera-ingest/build.rs
@@ -1,4 +1,24 @@
-//! Build script — only does one thing, and only under the `static-hdf5` feature.
+//! Build script — two unrelated jobs, both purely about the *build*, neither in the sealed
+//! byte-path: (1) capture the resolved decoder-crate pins for `tessera info`, and (2) the
+//! `static-hdf5` lib64 link-search fallback.
+//!
+//! ## 1. Decoder pins for `tessera info` (ADR-0057 §7)
+//!
+//! Cargo gives a crate its *own* version as `CARGO_PKG_VERSION` but exposes nothing about its
+//! dependencies' resolved versions, so the pins are read out of the workspace `Cargo.lock` — the
+//! same file `--locked` builds resolve against — and re-emitted as `rustc-env` vars that
+//! `option_env!` picks up in `backends::backend_version`. This is the read side of the fact
+//! ADR-0056 §6.2 seals as `ingest_decoder`.
+//!
+//! Failure is silent **by design**: built as a crates.io dependency there is no workspace lockfile,
+//! `option_env!` yields `None`, and `tessera info` prints the backend name without a version. A
+//! missing diagnostic must never fail a build.
+//!
+//! Decoders whose version is better answered at runtime are deliberately not here: `hdf-compound`
+//! reports the libhdf5 actually linked, which differs between a system libhdf5 and the `static-hdf5`
+//! vendored build — a compile-time pin could not tell them apart.
+//!
+//! ## 2. The `static-hdf5` lib64 fallback
 //!
 //! When we link a *vendored* libhdf5 (feature `static-hdf5` → `hdf5-metno-sys/static`, which builds
 //! HDF5 from source via `hdf5-metno-src`), `hdf5-metno-sys`'s build script emits its link-search path
@@ -19,9 +39,18 @@
 //! read-only input (Tessera encodes to Vortex/pcodec), never in the sealed byte-path, so nothing here
 //! can move a content_hash.
 
+use std::path::{Path, PathBuf};
+
+/// `(Cargo.lock package name, env var `backends::backend_version` reads via `option_env!`)`.
+///
+/// Phase 1's `parquet` / `arrow` decoders are one line each.
+const DECODERS: &[(&str, &str)] = &[("dicom", "TESSERA_DEP_DICOM")];
+
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rerun-if-env-changed=DEP_HDF5_ROOT");
+
+    emit_decoder_pins();
 
     // Only relevant for the vendored-static build; a no-op for the default pkg-config path (where
     // hdf5-metno-sys does not emit `root`, so DEP_HDF5_ROOT is unset).
@@ -32,4 +61,59 @@ fn main() {
         // Additive fallback next to hdf5-metno-sys's own `{root}/lib`; covers the lib64 install layout.
         println!("cargo::rustc-link-search=native={root}/lib64");
     }
+}
+
+/// Re-emit each [`DECODERS`] pin from the workspace lockfile as a `rustc-env` var. Silent no-op when
+/// there is no lockfile to read (see the module docs).
+fn emit_decoder_pins() {
+    let Some(lock_path) = find_lockfile() else {
+        return;
+    };
+    println!("cargo::rerun-if-changed={}", lock_path.display());
+    let Ok(lock) = std::fs::read_to_string(&lock_path) else {
+        return;
+    };
+    for (package, var) in DECODERS {
+        if let Some(version) = lock_version(&lock, package) {
+            println!("cargo::rustc-env={var}={version}");
+        }
+    }
+}
+
+/// Walk up from this crate's manifest to the nearest `Cargo.lock` (the workspace root).
+fn find_lockfile() -> Option<PathBuf> {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
+    let mut dir: Option<&Path> = Some(Path::new(&manifest_dir));
+    while let Some(d) = dir {
+        let candidate = d.join("Cargo.lock");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// The `version` of one `[[package]]` entry in a `Cargo.lock`.
+///
+/// Hand-scanned rather than parsed with `toml`, to keep this build script dependency-free: adding a
+/// `[build-dependencies]` entry would move the resolved feature graph, which is a Gate B event
+/// (ADR-0057 §5) — a disproportionate price for reading one string. The lockfile's shape is fixed by
+/// cargo (`[[package]]`, then `name = "…"`, then `version = "…"`, one key per line, in that order)
+/// and contains no nested tables, so a scanner cannot mis-parse it.
+fn lock_version(lock: &str, package: &str) -> Option<String> {
+    let mut in_wanted_package = false;
+    for line in lock.lines() {
+        let line = line.trim();
+        if line == "[[package]]" {
+            in_wanted_package = false;
+        } else if let Some(name) = line.strip_prefix("name = ") {
+            in_wanted_package = name.trim_matches('"') == package;
+        } else if in_wanted_package {
+            if let Some(version) = line.strip_prefix("version = ") {
+                return Some(version.trim_matches('"').to_owned());
+            }
+        }
+    }
+    None
 }

--- a/tessera/crates/tessera-ingest/src/backends.rs
+++ b/tessera/crates/tessera-ingest/src/backends.rs
@@ -1,0 +1,219 @@
+//! The backend name set — one string set for every surface that names a decoder (ADR-0057 §6/§7).
+//!
+//! ADR-0057 §6 keeps [`crate::spec::FormatOptions`] a **closed and total** enum: every variant
+//! parses on every build, so a TOML spec's meaning — and therefore the `spec_hash` that ADR-0035
+//! writes into each member's `ingested_via_spec` provenance edge — never depends on which binary
+//! read it. What a feature gate may switch off is the *handler*, not the *name*.
+//!
+//! Two constants fall out of that, and they are what `tessera info` prints:
+//!
+//! - [`BACKENDS_ALL`] — every backend name, on every build. Build-invariant.
+//! - [`BACKENDS_ENABLED`] — the subset whose handler is compiled into *this* build.
+//!
+//! Today no decoder feature exists yet (`dicom` and `hdf5-metno` are unconditional dependencies of
+//! this crate), so `BACKENDS_ENABLED == BACKENDS_ALL`. ADR-0057 §5's feature graph lands in Phase 1
+//! and turns the entries of `BACKENDS_ENABLED` into `#[cfg(feature = "…")]`-gated elements — the
+//! list is written in that shape already, so the change is one attribute per line and `BACKENDS_ALL`
+//! is not touched at all.
+
+/// Every backend name `FormatOptions` can carry — the `format = "<name>"` tag in an ingest spec, and
+/// (per ADR-0056 §4) the `--from <name>` string the CLI will take. **Build-invariant**: this list is
+/// identical in every build, including builds that cannot run half of it.
+///
+/// Sorted, so `tessera info` and every error message that enumerates it are stable.
+///
+/// Kept in sync with `FormatOptions` by [`backend_name`], whose `match` the compiler forces to be
+/// total, and by `tests::backends_all_matches_the_serde_variant_list`, which reads the variant list
+/// out of serde's own "unknown variant" error rather than a hand-written copy.
+pub const BACKENDS_ALL: &[&str] = &[
+    "blob",
+    "dicom",
+    "dicom-series",
+    "hdf-compound",
+    "nifti",
+    "raw",
+];
+
+/// The backends whose handler is compiled into **this** build.
+///
+/// Phase 1 (ADR-0057 §5) gates the heavy native-dep decoders; the shape of that change is one
+/// `#[cfg(feature = "…")]` attribute per element here, e.g.
+///
+/// ```ignore
+/// pub const BACKENDS_ENABLED: &[&str] = &[
+///     "blob",
+///     #[cfg(feature = "dicom")]
+///     "dicom",
+///     …
+/// ];
+/// ```
+///
+/// so nothing downstream — `tessera info`, the missing-backend error, `aux/provenance.json` — has to
+/// change when it happens.
+pub const BACKENDS_ENABLED: &[&str] = &[
+    // in-tree: ADR-0038 opaque preservation tier. Never gated off in practice.
+    "blob",
+    // `dep:dicom` + `dep:dicom-transfer-syntax-registry` (Phase 1: feature `dicom`)
+    "dicom",
+    "dicom-series",
+    // `dep:hdf5-metno` + `dep:hdf5-metno-sys` — needs a native libhdf5 (Phase 1: feature `hdf5`)
+    "hdf-compound",
+    // in-tree parsers, no third-party decoder
+    "nifti",
+    "raw",
+];
+
+/// Backend names that exist but whose handler is not in this build — `BACKENDS_ALL \ BACKENDS_ENABLED`.
+///
+/// This is the "known but disabled" line of ADR-0057 §7's missing-backend error, and the `disabled:`
+/// line of `tessera info`. Empty today.
+pub fn backends_disabled() -> Vec<&'static str> {
+    BACKENDS_ALL
+        .iter()
+        .copied()
+        .filter(|n| !BACKENDS_ENABLED.contains(n))
+        .collect()
+}
+
+/// The version of the **decoder** behind a backend, when there is a meaningful one to report.
+///
+/// ADR-0056 §6.2 seals `ingest_decoder` (decoder name + version) because `content_hash` is, honestly,
+/// a function of it. This is the read side of the same fact — what a support round-trip needs when
+/// someone asks "why did my hash change?".
+///
+/// Three sources, in decreasing order of how much they tell you:
+///
+/// - `hdf-compound` reports the **libhdf5 actually linked**, queried at runtime. That is the number
+///   that differs between a nix build (system libhdf5 from the closure) and a released binary
+///   (`static-hdf5`, vendored HDF5 built from source) — a compile-time pin could not tell them apart.
+/// - `dicom` / `dicom-series` report the `dicom` crate pin captured from `Cargo.lock` by `build.rs`.
+///   Absent (→ `None`) when the crate is built without the workspace lockfile, e.g. as a
+///   crates.io dependency.
+/// - the in-tree parsers (`nifti`, `raw`, `blob`) have no third-party decoder to name. Their version
+///   *is* the tessera version already on the first line.
+pub fn backend_version(name: &str) -> Option<String> {
+    match name {
+        "dicom" | "dicom-series" => option_env!("TESSERA_DEP_DICOM").map(str::to_owned),
+        "hdf-compound" => {
+            let (major, minor, patch) = hdf5_metno::library_version();
+            Some(format!("{major}.{minor}.{patch}"))
+        }
+        _ => None,
+    }
+}
+
+/// The backend name of a parsed spec entry.
+///
+/// The `match` is exhaustive, so adding a variant to [`crate::spec::FormatOptions`] without giving it
+/// a name here is a **compile error**, not a silently unnamed backend.
+pub fn backend_name(opts: &crate::spec::FormatOptions) -> &'static str {
+    use crate::spec::FormatOptions as F;
+    match opts {
+        F::Blob { .. } => "blob",
+        F::Dicom { .. } => "dicom",
+        F::DicomSeries { .. } => "dicom-series",
+        F::HdfCompound { .. } => "hdf-compound",
+        F::Nifti { .. } => "nifti",
+        F::Raw { .. } => "raw",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backends_all_is_sorted_and_unique() {
+        let mut sorted = BACKENDS_ALL.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted, BACKENDS_ALL,
+            "BACKENDS_ALL must stay sorted + duplicate-free — it is printed verbatim"
+        );
+    }
+
+    #[test]
+    fn enabled_is_a_subset_of_all() {
+        for name in BACKENDS_ENABLED {
+            assert!(
+                BACKENDS_ALL.contains(name),
+                "BACKENDS_ENABLED names '{name}', which is not a known backend"
+            );
+        }
+        // Today every backend is unconditional. When Phase 1's feature gates land this stops being
+        // an equality and `backends_disabled()` starts returning names — which is the point.
+        assert_eq!(BACKENDS_ENABLED, BACKENDS_ALL);
+        assert!(backends_disabled().is_empty());
+    }
+
+    /// The anti-drift guard: serde derives the variant list from `FormatOptions` itself, and reports
+    /// it verbatim when an unknown `format = "…"` tag is deserialised. Comparing against *that* —
+    /// rather than a second hand-written list — means a new variant fails this test until it is
+    /// registered in `BACKENDS_ALL`.
+    #[test]
+    fn backends_all_matches_the_serde_variant_list() {
+        let err = toml::from_str::<crate::spec::FormatOptions>("format = \"__no_such_backend__\"")
+            .expect_err("an unknown format tag must not parse")
+            .to_string();
+        let (_, list) = err
+            .split_once("expected one of ")
+            .unwrap_or_else(|| panic!("serde error text changed shape: {err}"));
+        let mut variants: Vec<String> = list
+            .split('`')
+            .skip(1)
+            .step_by(2)
+            .map(str::to_owned)
+            // `Blob` carries `#[serde(alias = "junk")]` — the cathartic alias is an input spelling,
+            // not a backend. `tessera info` lists backends, so it stays out.
+            .filter(|v| v != "junk")
+            .collect();
+        variants.sort();
+        variants.dedup();
+        assert_eq!(
+            variants, BACKENDS_ALL,
+            "FormatOptions and BACKENDS_ALL have drifted — add the new variant to BACKENDS_ALL \
+             (and to BACKENDS_ENABLED if its handler is compiled in unconditionally)"
+        );
+    }
+
+    /// `backend_name` is total by construction (the compiler checks the match); this pins the actual
+    /// strings, so a rename shows up here rather than in a user's broken `--from` invocation.
+    #[test]
+    fn backend_name_agrees_with_the_serde_tag() {
+        use crate::spec::FormatOptions as F;
+        let samples = [
+            F::Blob {
+                input: "x".into(),
+                media_type: None,
+            },
+            F::Dicom {
+                input: "x".into(),
+                deidentify: false,
+            },
+            F::Nifti { input: "x".into() },
+        ];
+        for s in &samples {
+            let tag = serde_json::to_value(s).unwrap()["format"]
+                .as_str()
+                .unwrap()
+                .to_owned();
+            assert_eq!(tag, backend_name(s));
+            assert!(BACKENDS_ALL.contains(&tag.as_str()));
+        }
+    }
+
+    #[test]
+    fn linked_libhdf5_version_is_reportable() {
+        let v = backend_version("hdf-compound").expect("libhdf5 is linked, so it has a version");
+        assert!(
+            v.split('.').count() == 3 && v.starts_with(|c: char| c.is_ascii_digit()),
+            "expected a major.minor.patch libhdf5 version, got '{v}'"
+        );
+        assert_eq!(
+            backend_version("raw"),
+            None,
+            "in-tree parsers have no decoder"
+        );
+    }
+}

--- a/tessera/crates/tessera-ingest/src/lib.rs
+++ b/tessera/crates/tessera-ingest/src/lib.rs
@@ -6,6 +6,7 @@
 //! it preserves the native sample dtype and carries the provenance + units as metadata rather than
 //! rewriting pixels.
 
+pub mod backends;
 pub mod blob;
 pub mod dicom;
 pub mod engine;

--- a/tessera/tests/feature-snapshots/README.md
+++ b/tessera/tests/feature-snapshots/README.md
@@ -1,0 +1,61 @@
+# Feature snapshots — Gate B (ADR-0057 §5)
+
+These files are **not** test fixtures. They are the committed baseline of the resolved Cargo feature
+graph for every crate on the **seal path** — the crates whose behaviour can move sealed bytes.
+
+Each `<crate>.txt` is the output of:
+
+```bash
+cargo tree --locked --offline --all-features --charset ascii -e features -i <crate> | sort
+```
+
+normalised (absolute paths stripped, workspace-member versions pinned to `vWORKSPACE`) so the file
+depends on the dependency graph and nothing else. See `scripts/feature-snapshots.sh` — it is the
+single source of truth for the crate list and the invocation.
+
+## What this gate is for
+
+The guarantee ADR-0057 §7 states, and that Gate B protects:
+
+> For any input `F` and any tessera version `V`, `tessera ingest F` produces the same `content_hash`
+> under every distributed build of `V`. Feature selection may change which formats are **readable**;
+> it must never change the **bytes** produced for a readable one.
+
+Cargo feature unification is **monotonic** — enabling a feature anywhere in the graph can only add
+features, never remove them. So an optional feature on an apparently unrelated crate can silently
+change what the encoder does:
+
+- the optional `sql` feature already turns on `arrow-array/chrono-tz` — ADR-0056 hazard **H1**
+  (tzdb as a compiled-in dependency vs. the host's `/usr/share/zoneinfo`), rated *high × fatal*,
+  arriving through a **feature** rather than through a host. It is captured in `arrow-array.txt` as
+  today's baseline, deliberately, so the drift is recorded rather than discovered later;
+- the workspace pins `vortex-btrblocks = { features = ["pco"] }` specifically to **exclude** ALP,
+  which was not byte-deterministic (#380/#384). Any future dependency that transitively enables
+  `vortex-btrblocks/alp` re-registers ALP in the compressor dictionary and re-encodes **every float
+  column in every table** — ingested or not.
+
+Gate A (the behavioural gate, Phase 1) tells you the day the goldens moved. Gate B tells you the day
+the *risk* was introduced, on the PR that introduced it.
+
+## When the gate fails
+
+A changed snapshot is **not automatically wrong**. It is a *deliberate corpus event*, and the PR
+must account for it. Regenerate from the repo root inside `nix develop`:
+
+```bash
+scripts/feature-snapshots.sh tessera/tests/feature-snapshots
+```
+
+Then either:
+
+- show that no golden moved (the conformance corpus is unchanged) and state in the PR **why** the
+  feature graph moved and why it is safe; or
+- carry the corpus regeneration in the same PR.
+
+Reviewing the diff is the job. Treat it exactly like a change to `corpus/corpus.json`.
+
+## Known gap
+
+The crate list in `scripts/feature-snapshots.sh` is hand-maintained. Adding a codec crate to the
+seal path without adding it there leaves a blind spot; ADR-0057 records deriving the list from the
+dependency graph as an open gap.

--- a/tessera/tests/feature-snapshots/arrow-array.txt
+++ b/tessera/tests/feature-snapshots/arrow-array.txt
@@ -1,0 +1,462 @@
+    `-- vortex-array v0.75.0 (*)
+`-- arrow-array feature "ffi"
+arrow-array v58.3.0
+|       `-- datafusion-sql v54.0.0 (*)
+|       |               `-- datafusion v54.0.0 (*)
+|       |           `-- datafusion-functions-table feature "default"
+|       |       `-- datafusion feature "sql" (*)
+|       |       `-- datafusion-common feature "sql" (*)
+|       |       `-- datafusion-functions-table v54.0.0
+|       |       |       `-- datafusion v54.0.0 (*)
+|       |       |   `-- datafusion-catalog-listing feature "default"
+|       |       |-- datafusion v54.0.0 (*)
+|       |       |-- datafusion-catalog-listing v54.0.0
+|       |   `-- datafusion feature "sqlparser"
+|       |   `-- datafusion-catalog feature "default"
+|       |   `-- datafusion-common feature "sqlparser"
+|       |   `-- datafusion-session v54.0.0 (*)
+|       |   |           `-- tessera-cli feature "static-hdf5" (command-line)
+|       |   |           |-- tessera-cli feature "cloud" (command-line)
+|       |   |           |-- tessera-cli feature "default" (command-line)
+|       |   |           |-- tessera-cli feature "sql" (command-line)
+|       |   |       `-- datafusion-expr feature "sql" (*)
+|       |   |       `-- datafusion-pruning v54.0.0 (*)
+|       |   |       `-- tessera-cli vWORKSPACE
+|       |   |       |       `-- datafusion-physical-plan v54.0.0 (*)
+|       |   |       |       |-- datafusion-expr v54.0.0 (*)
+|       |   |       |       |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |   |       |       |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |       |       |-- datafusion-physical-expr v54.0.0 (*)
+|       |   |       |   `-- datafusion-functions-aggregate-common feature "default"
+|       |   |       |   `-- datafusion-pruning v54.0.0 (*)
+|       |   |       |   |       `-- datafusion-physical-plan v54.0.0 (*)
+|       |   |       |   |       |-- datafusion-expr v54.0.0 (*)
+|       |   |       |   |       |-- datafusion-functions-window v54.0.0 (*)
+|       |   |       |   |   `-- datafusion-functions-window-common feature "default"
+|       |   |       |   |-- datafusion v54.0.0 (*)
+|       |   |       |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |       |   |-- datafusion-datasource v54.0.0 (*)
+|       |   |       |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |       |   |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |       |   |-- datafusion-datasource-json v54.0.0 (*)
+|       |   |       |   |-- datafusion-execution v54.0.0 (*)
+|       |   |       |   |-- datafusion-expr v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions-window v54.0.0 (*)
+|       |   |       |   |-- datafusion-functions-window-common v54.0.0
+|       |   |       |   |-- datafusion-physical-expr v54.0.0 (*)
+|       |   |       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|       |   |       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |       |   |-- datafusion-physical-plan v54.0.0 (*)
+|       |   |       |-- datafusion v54.0.0 (*)
+|       |   |       |-- datafusion-expr v54.0.0 (*)
+|       |   |       |-- datafusion-functions v54.0.0 (*)
+|       |   |       |-- datafusion-functions-aggregate-common v54.0.0
+|       |   |       |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |       |-- datafusion-optimizer v54.0.0 (*)
+|       |   |       |-- datafusion-physical-expr v54.0.0 (*)
+|       |   |       |-- datafusion-physical-expr-common v54.0.0
+|       |   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |   `-- datafusion feature "recursive_protection" (*)
+|       |   |   `-- datafusion feature "sql"
+|       |   |   `-- datafusion feature "sql" (*)
+|       |   |   `-- datafusion-datasource-json v54.0.0 (*)
+|       |   |   `-- datafusion-expr feature "sqlparser"
+|       |   |   `-- datafusion-expr-common feature "default"
+|       |   |   `-- datafusion-pruning v54.0.0 (*)
+|       |   |   `-- datafusion-session v54.0.0 (*)
+|       |   |   `-- datafusion-session v54.0.0 (*)
+|       |   |   `-- datafusion-sql v54.0.0 (*)
+|       |   |   `-- tessera-cli vWORKSPACE (*)
+|       |   |   |                   `-- datafusion feature "recursive_protection" (*)
+|       |   |   |               `-- datafusion-physical-optimizer feature "recursive_protection"
+|       |   |   |               |   `-- datafusion v54.0.0 (*)
+|       |   |   |               |-- datafusion-physical-optimizer feature "default"
+|       |   |   |           `-- datafusion-physical-optimizer v54.0.0
+|       |   |   |       `-- datafusion feature "recursive_protection" (*)
+|       |   |   |       `-- datafusion feature "recursive_protection" (*)
+|       |   |   |       `-- datafusion v54.0.0 (*)
+|       |   |   |       `-- datafusion-functions feature "string_expressions" (*)
+|       |   |   |       `-- datafusion-functions-nested v54.0.0 (*)
+|       |   |   |       `-- datafusion-pruning feature "default"
+|       |   |   |       |-- datafusion v54.0.0 (*)
+|       |   |   |   `-- datafusion feature "recursive_protection" (*)
+|       |   |   |   `-- datafusion v54.0.0 (*)
+|       |   |   |   `-- datafusion-functions feature "uuid"
+|       |   |   |   `-- datafusion-functions-aggregate feature "default"
+|       |   |   |   `-- datafusion-functions-nested feature "sql" (*)
+|       |   |   |   `-- datafusion-functions-window feature "default"
+|       |   |   |   `-- datafusion-optimizer feature "recursive_protection"
+|       |   |   |   `-- datafusion-physical-expr feature "recursive_protection"
+|       |   |   |   `-- datafusion-pruning v54.0.0
+|       |   |   |   `-- datafusion-pruning v54.0.0 (*)
+|       |   |   |   `-- datafusion-sql v54.0.0 (*)
+|       |   |   |   |                           `-- datafusion-datasource-json v54.0.0 (*)
+|       |   |   |   |                           |-- datafusion v54.0.0 (*)
+|       |   |   |   |                           |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |   |                           |-- datafusion-datasource v54.0.0 (*)
+|       |   |   |   |                           |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |   |   |                           |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |   |   |                       `-- datafusion-session feature "default"
+|       |   |   |   |                   `-- datafusion-session v54.0.0
+|       |   |   |   |                   |-- datafusion v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-datasource v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-datasource-json v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-functions-table v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |   |   |                   |-- datafusion-pruning v54.0.0 (*)
+|       |   |   |   |               `-- datafusion-physical-plan feature "default"
+|       |   |   |   |           `-- datafusion-physical-plan v54.0.0
+|       |   |   |   |           |               `-- datafusion-sql feature "default" (*)
+|       |   |   |   |           |           `-- datafusion-sql feature "unparser"
+|       |   |   |   |           |           |   `-- datafusion feature "recursive_protection" (*)
+|       |   |   |   |           |           |   `-- datafusion v54.0.0 (*)
+|       |   |   |   |           |           |   `-- datafusion-sql feature "default" (*)
+|       |   |   |   |           |           |-- datafusion-sql feature "default"
+|       |   |   |   |           |           |-- datafusion-sql feature "recursive_protection"
+|       |   |   |   |           |           |-- datafusion-sql feature "unicode_expressions"
+|       |   |   |   |           |       `-- datafusion-sql v54.0.0
+|       |   |   |   |           |   `-- datafusion-datasource v54.0.0 (*)
+|       |   |   |   |           |   `-- datafusion-functions-nested feature "sql"
+|       |   |   |   |           |   |-- datafusion v54.0.0 (*)
+|       |   |   |   |           |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |   |           |-- datafusion v54.0.0 (*)
+|       |   |   |   |           |-- datafusion-functions-nested v54.0.0
+|       |   |   |   |           |-- datafusion-physical-expr-adapter v54.0.0
+|       |   |   |   |       `-- datafusion-functions feature "default"
+|       |   |   |   |       `-- datafusion-functions feature "default" (*)
+|       |   |   |   |       `-- datafusion-functions feature "default" (*)
+|       |   |   |   |   `-- datafusion v54.0.0 (*)
+|       |   |   |   |   `-- datafusion v54.0.0 (*)
+|       |   |   |   |   `-- datafusion v54.0.0 (*)
+|       |   |   |   |   `-- datafusion-functions feature "datetime_expressions"
+|       |   |   |   |   `-- datafusion-functions feature "default" (*)
+|       |   |   |   |   `-- datafusion-functions feature "default" (*)
+|       |   |   |   |   `-- datafusion-functions feature "default" (*)
+|       |   |   |   |   `-- datafusion-functions feature "encoding_expressions"
+|       |   |   |   |   `-- datafusion-functions feature "encoding_expressions" (*)
+|       |   |   |   |   `-- datafusion-functions feature "regex_expressions"
+|       |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+|       |   |   |   |-- datafusion v54.0.0 (*)
+|       |   |   |   |-- datafusion v54.0.0 (*)
+|       |   |   |   |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |   |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |   |-- datafusion-datasource v54.0.0 (*)
+|       |   |   |   |-- datafusion-datasource-arrow v54.0.0
+|       |   |   |   |-- datafusion-datasource-csv v54.0.0
+|       |   |   |   |-- datafusion-datasource-json v54.0.0
+|       |   |   |   |-- datafusion-functions feature "base64"
+|       |   |   |   |-- datafusion-functions feature "chrono-tz"
+|       |   |   |   |-- datafusion-functions feature "datetime_expressions" (*)
+|       |   |   |   |-- datafusion-functions feature "default" (*)
+|       |   |   |   |-- datafusion-functions feature "encoding_expressions" (*)
+|       |   |   |   |-- datafusion-functions feature "hex"
+|       |   |   |   |-- datafusion-functions feature "math_expressions"
+|       |   |   |   |-- datafusion-functions feature "regex"
+|       |   |   |   |-- datafusion-functions feature "regex_expressions" (*)
+|       |   |   |   |-- datafusion-functions feature "string_expressions"
+|       |   |   |   |-- datafusion-functions feature "unicode_expressions"
+|       |   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |   |   |   |-- datafusion-functions-table v54.0.0 (*)
+|       |   |   |   |-- datafusion-functions-window v54.0.0 (*)
+|       |   |   |   |-- datafusion-optimizer v54.0.0 (*)
+|       |   |   |   |-- datafusion-physical-expr feature "default"
+|       |   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|       |   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |   |-- datafusion v54.0.0 (*)
+|       |   |   |-- datafusion v54.0.0 (*)
+|       |   |   |-- datafusion v54.0.0 (*)
+|       |   |   |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |-- datafusion-catalog v54.0.0 (*)
+|       |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|       |   |   |-- datafusion-datasource v54.0.0
+|       |   |   |-- datafusion-datasource v54.0.0 (*)
+|       |   |   |-- datafusion-datasource v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-json v54.0.0 (*)
+|       |   |   |-- datafusion-datasource-json v54.0.0 (*)
+|       |   |   |-- datafusion-execution v54.0.0 (*)
+|       |   |   |-- datafusion-expr feature "recursive_protection"
+|       |   |   |-- datafusion-expr feature "sql"
+|       |   |   |-- datafusion-functions v54.0.0
+|       |   |   |-- datafusion-functions v54.0.0 (*)
+|       |   |   |-- datafusion-functions-aggregate v54.0.0
+|       |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |   |-- datafusion-functions-table v54.0.0 (*)
+|       |   |   |-- datafusion-functions-window v54.0.0
+|       |   |   |-- datafusion-optimizer v54.0.0
+|       |   |   |-- datafusion-optimizer v54.0.0 (*)
+|       |   |   |-- datafusion-physical-expr v54.0.0
+|       |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|       |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |   |-- datafusion-physical-plan v54.0.0 (*)
+|       |   |   |-- datafusion-physical-plan v54.0.0 (*)
+|       |   |-- datafusion feature "datafusion-sql"
+|       |   |-- datafusion feature "recursive_protection"
+|       |   |-- datafusion feature "sql" (*)
+|       |   |-- datafusion-catalog v54.0.0 (*)
+|       |   |-- datafusion-common feature "default"
+|       |   |-- datafusion-common feature "object_store"
+|       |   |-- datafusion-common feature "recursive_protection"
+|       |   |-- datafusion-common feature "sql"
+|       |   |-- datafusion-execution v54.0.0
+|       |   |-- datafusion-expr v54.0.0
+|       |   |-- datafusion-expr-common v54.0.0
+|       |   |-- datafusion-functions v54.0.0 (*)
+|       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|       |   |-- datafusion-functions-nested v54.0.0 (*)
+|       |   |-- datafusion-functions-table v54.0.0 (*)
+|       |   |-- datafusion-functions-window v54.0.0 (*)
+|       |   |-- datafusion-functions-window-common v54.0.0 (*)
+|       |   |-- datafusion-physical-expr v54.0.0 (*)
+|       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|       |   |-- datafusion-physical-expr-common v54.0.0 (*)
+|       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |   |-- datafusion-physical-plan v54.0.0 (*)
+|       |-- datafusion v54.0.0
+|       |-- datafusion-catalog v54.0.0
+|       |-- datafusion-catalog-listing v54.0.0 (*)
+|       |-- datafusion-common v54.0.0
+|       |-- datafusion-datasource v54.0.0 (*)
+|       |-- datafusion-datasource-arrow v54.0.0 (*)
+|       |-- datafusion-datasource-csv v54.0.0 (*)
+|       |-- datafusion-datasource-json v54.0.0 (*)
+|       |-- datafusion-execution v54.0.0 (*)
+|       |-- datafusion-expr v54.0.0 (*)
+|       |-- datafusion-expr-common v54.0.0 (*)
+|       |-- datafusion-functions v54.0.0 (*)
+|       |-- datafusion-functions-aggregate v54.0.0 (*)
+|       |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|       |-- datafusion-functions-nested v54.0.0 (*)
+|       |-- datafusion-functions-table v54.0.0 (*)
+|       |-- datafusion-functions-window v54.0.0 (*)
+|       |-- datafusion-optimizer v54.0.0 (*)
+|       |-- datafusion-physical-expr v54.0.0 (*)
+|       |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|       |-- datafusion-physical-expr-common v54.0.0 (*)
+|       |-- datafusion-physical-optimizer v54.0.0 (*)
+|       |-- datafusion-physical-plan v54.0.0 (*)
+|       |-- datafusion-pruning v54.0.0 (*)
+|   `-- arrow feature "chrono-tz"
+|   `-- vortex-layout v0.75.0 (*)
+|   |               `-- tessera-io vWORKSPACE (*)
+|   |               `-- vortex-file v0.75.0 (*)
+|   |               |-- vortex-btrblocks v0.75.0 (*)
+|   |           `-- vortex-array feature "default"
+|   |           `-- vortex-zigzag v0.75.0
+|   |           |       `-- tessera-io vWORKSPACE (*)
+|   |           |   `-- vortex-btrblocks v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-file v0.75.0 (*)
+|   |           |   `-- vortex-io feature "default"
+|   |           |   `-- vortex-layout v0.75.0 (*)
+|   |           |   `-- vortex-layout v0.75.0 (*)
+|   |           |   `-- vortex-layout v0.75.0 (*)
+|   |           |   `-- vortex-layout v0.75.0 (*)
+|   |           |   |           `-- tessera-io vWORKSPACE (*)
+|   |           |   |       `-- tessera-io vWORKSPACE (*)
+|   |           |   |       `-- vortex-file v0.75.0 (*)
+|   |           |   |       `-- vortex-layout feature "default"
+|   |           |   |   `-- vortex-btrblocks feature "pco"
+|   |           |   |   `-- vortex-layout v0.75.0
+|   |           |   |   |                   `-- tessera-py feature "default" (command-line)
+|   |           |   |   |               `-- tessera-py vWORKSPACE
+|   |           |   |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+|   |           |   |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|   |           |   |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+|   |           |   |   |               |   |-- tessera-ingest feature "default" (command-line)
+|   |           |   |   |               |-- tessera-cli vWORKSPACE (*)
+|   |           |   |   |               |-- tessera-ingest vWORKSPACE
+|   |           |   |   |           `-- tessera-io feature "default" (command-line)
+|   |           |   |   |           |   `-- tessera-cli feature "cloud" (command-line)
+|   |           |   |   |           |-- tessera-io feature "cloud" (command-line)
+|   |           |   |   |       `-- tessera-io vWORKSPACE
+|   |           |   |   |   `-- tessera-io vWORKSPACE (*)
+|   |           |   |   |   `-- vortex-file feature "default"
+|   |           |   |   |-- vortex-btrblocks feature "default"
+|   |           |   |   |-- vortex-file v0.75.0
+|   |           |   |-- vortex-alp v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-btrblocks v0.75.0 (*)
+|   |           |   |-- vortex-file v0.75.0 (*)
+|   |           |   |-- vortex-file v0.75.0 (*)
+|   |           |   |-- vortex-file v0.75.0 (*)
+|   |           |   |-- vortex-file v0.75.0 (*)
+|   |           |-- vortex-alp v0.75.0
+|   |           |-- vortex-btrblocks v0.75.0 (*)
+|   |           |-- vortex-bytebool v0.75.0
+|   |           |-- vortex-compressor v0.75.0
+|   |           |-- vortex-datetime-parts v0.75.0
+|   |           |-- vortex-decimal-byte-parts v0.75.0
+|   |           |-- vortex-fastlanes v0.75.0
+|   |           |-- vortex-file v0.75.0 (*)
+|   |           |-- vortex-fsst v0.75.0
+|   |           |-- vortex-io v0.75.0
+|   |           |-- vortex-layout v0.75.0 (*)
+|   |           |-- vortex-pco v0.75.0
+|   |           |-- vortex-runend v0.75.0
+|   |           |-- vortex-scan v0.75.0
+|   |           |-- vortex-sequence v0.75.0
+|   |           |-- vortex-sparse v0.75.0
+|   |       `-- arrow v58.3.0 (*)
+|   |       `-- datafusion-physical-plan v54.0.0 (*)
+|   |       `-- datafusion-sql v54.0.0 (*)
+|   |       `-- vortex-array v0.75.0
+|   |       `-- vortex-array v0.75.0 (*)
+|   |       `-- vortex-array v0.75.0 (*)
+|   |       |       `-- vortex-array v0.75.0 (*)
+|   |       |       |-- arrow v58.3.0 (*)
+|   |       |   `-- arrow-string feature "default"
+|   |       |-- arrow v58.3.0 (*)
+|   |       |-- arrow v58.3.0 (*)
+|   |       |-- arrow v58.3.0 (*)
+|   |       |-- arrow-cast v58.3.0 (*)
+|   |       |-- arrow-cast v58.3.0 (*)
+|   |       |-- arrow-ipc v58.3.0 (*)
+|   |       |-- arrow-json v58.3.0 (*)
+|   |       |-- arrow-json v58.3.0 (*)
+|   |       |-- arrow-ord v58.3.0 (*)
+|   |       |-- arrow-string v58.3.0
+|   |       |-- datafusion v54.0.0 (*)
+|   |       |-- datafusion-catalog v54.0.0 (*)
+|   |       |-- datafusion-catalog-listing v54.0.0 (*)
+|   |       |-- datafusion-common v54.0.0 (*)
+|   |       |-- datafusion-common v54.0.0 (*)
+|   |       |-- datafusion-datasource v54.0.0 (*)
+|   |       |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |       |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |       |-- datafusion-datasource-csv v54.0.0 (*)
+|   |       |-- datafusion-datasource-json v54.0.0 (*)
+|   |       |-- datafusion-execution v54.0.0 (*)
+|   |       |-- datafusion-expr v54.0.0 (*)
+|   |       |-- datafusion-expr-common v54.0.0 (*)
+|   |       |-- datafusion-functions v54.0.0 (*)
+|   |       |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |       |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |       |-- datafusion-functions-nested v54.0.0 (*)
+|   |       |-- datafusion-functions-table v54.0.0 (*)
+|   |       |-- datafusion-functions-window v54.0.0 (*)
+|   |       |-- datafusion-optimizer v54.0.0 (*)
+|   |       |-- datafusion-physical-expr v54.0.0 (*)
+|   |       |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |       |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |       |-- datafusion-physical-plan v54.0.0 (*)
+|   |       |-- datafusion-pruning v54.0.0 (*)
+|   |   `-- arrow feature "prettyprint"
+|   |   `-- arrow-arith feature "default"
+|   |   `-- arrow-cast feature "prettyprint" (*)
+|   |   `-- arrow-ipc feature "zstd"
+|   |   `-- arrow-ord feature "default"
+|   |   `-- arrow-row feature "default"
+|   |   `-- arrow-select feature "default"
+|   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |           `-- datafusion-sql v54.0.0 (*)
+|   |   |           |-- datafusion v54.0.0 (*)
+|   |   |           |-- datafusion-catalog v54.0.0 (*)
+|   |   |           |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |           |-- datafusion-common v54.0.0 (*)
+|   |   |           |-- datafusion-datasource v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |           |-- datafusion-execution v54.0.0 (*)
+|   |   |           |-- datafusion-expr v54.0.0 (*)
+|   |   |           |-- datafusion-expr-common v54.0.0 (*)
+|   |   |           |-- datafusion-functions v54.0.0 (*)
+|   |   |           |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |           |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |   |           |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |           |-- datafusion-functions-table v54.0.0 (*)
+|   |   |           |-- datafusion-functions-window v54.0.0 (*)
+|   |   |           |-- datafusion-optimizer v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |   |           |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |           |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |           |-- datafusion-pruning v54.0.0 (*)
+|   |   |       `-- arrow feature "default"
+|   |   |       `-- arrow feature "default" (*)
+|   |   |       `-- arrow feature "default" (*)
+|   |   |       `-- arrow feature "prettyprint" (*)
+|   |   |       `-- tessera-cli vWORKSPACE (*)
+|   |   |   `-- arrow feature "csv"
+|   |   |   `-- arrow feature "ipc"
+|   |   |   `-- arrow feature "json"
+|   |   |   `-- arrow v58.3.0 (*)
+|   |   |   `-- arrow-cast feature "prettyprint"
+|   |   |   `-- arrow-ipc feature "lz4" (*)
+|   |   |   `-- datafusion-expr v54.0.0 (*)
+|   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   `-- vortex-array v0.75.0 (*)
+|   |   |   |       `-- arrow v58.3.0 (*)
+|   |   |   |       `-- arrow v58.3.0 (*)
+|   |   |   |   `-- arrow-csv feature "default"
+|   |   |   |   `-- arrow-json feature "default"
+|   |   |   |-- arrow v58.3.0 (*)
+|   |   |   |-- arrow-csv v58.3.0
+|   |   |   |-- arrow-json v58.3.0
+|   |   |   |-- datafusion-common v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |-- arrow feature "arrow-csv"
+|   |   |-- arrow feature "arrow-ipc"
+|   |   |-- arrow feature "arrow-json"
+|   |   |-- arrow feature "canonical_extension_types"
+|   |   |-- arrow feature "chrono-tz" (*)
+|   |   |-- arrow feature "csv" (*)
+|   |   |-- arrow feature "default" (*)
+|   |   |-- arrow feature "ipc" (*)
+|   |   |-- arrow feature "json" (*)
+|   |   |-- arrow-cast feature "comfy-table"
+|   |   |-- arrow-cast feature "default"
+|   |   |-- arrow-ipc feature "default"
+|   |   |-- arrow-ipc feature "lz4"
+|   |   |-- arrow-ipc feature "lz4_flex"
+|   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |-- arrow v58.3.0
+|   |-- arrow-arith v58.3.0
+|   |-- arrow-cast v58.3.0
+|   |-- arrow-csv v58.3.0 (*)
+|   |-- arrow-ipc v58.3.0
+|   |-- arrow-json v58.3.0 (*)
+|   |-- arrow-ord v58.3.0
+|   |-- arrow-row v58.3.0
+|   |-- arrow-select v58.3.0
+|   |-- arrow-string v58.3.0 (*)
+|   |-- vortex-array v0.75.0 (*)
+|-- arrow-array feature "chrono-tz"
+|-- arrow-array feature "default"

--- a/tessera/tests/feature-snapshots/arrow-buffer.txt
+++ b/tessera/tests/feature-snapshots/arrow-buffer.txt
@@ -1,0 +1,544 @@
+            `-- tessera-io vWORKSPACE (*)
+        `-- vortex-buffer feature "default"
+        `-- vortex-zigzag v0.75.0 (*)
+        |       `-- vortex-zigzag v0.75.0 (*)
+        |       |-- vortex-alp v0.75.0 (*)
+        |       |-- vortex-array v0.75.0 (*)
+        |       |-- vortex-bytebool v0.75.0 (*)
+        |       |-- vortex-compressor v0.75.0 (*)
+        |       |-- vortex-datetime-parts v0.75.0 (*)
+        |       |-- vortex-decimal-byte-parts v0.75.0 (*)
+        |       |-- vortex-fastlanes v0.75.0 (*)
+        |       |-- vortex-file v0.75.0 (*)
+        |       |-- vortex-fsst v0.75.0 (*)
+        |       |-- vortex-layout v0.75.0 (*)
+        |       |-- vortex-pco v0.75.0 (*)
+        |       |-- vortex-runend v0.75.0 (*)
+        |       |-- vortex-scan v0.75.0 (*)
+        |       |-- vortex-sequence v0.75.0 (*)
+        |       |-- vortex-sparse v0.75.0 (*)
+        |   `-- vortex-flatbuffers feature "layout" (*)
+        |   `-- vortex-mask v0.75.0
+        |   |       `-- vortex-layout v0.75.0 (*)
+        |   |   `-- vortex-array v0.75.0 (*)
+        |   |   `-- vortex-array v0.75.0 (*)
+        |   |   `-- vortex-flatbuffers feature "array" (*)
+        |   |   `-- vortex-flatbuffers feature "layout"
+        |   |   |       `-- vortex-file v0.75.0 (*)
+        |   |   |   `-- vortex-flatbuffers feature "file"
+        |   |   |-- vortex-flatbuffers feature "ipc"
+        |   |-- vortex-array v0.75.0 (*)
+        |   |-- vortex-flatbuffers feature "array"
+        |   |-- vortex-flatbuffers feature "dtype"
+        |   |-- vortex-flatbuffers feature "file" (*)
+        |   |-- vortex-flatbuffers feature "ipc" (*)
+        |-- vortex-alp v0.75.0 (*)
+        |-- vortex-btrblocks v0.75.0 (*)
+        |-- vortex-buffer feature "arrow"
+        |-- vortex-bytebool v0.75.0 (*)
+        |-- vortex-compressor v0.75.0 (*)
+        |-- vortex-datetime-parts v0.75.0 (*)
+        |-- vortex-decimal-byte-parts v0.75.0 (*)
+        |-- vortex-fastlanes v0.75.0 (*)
+        |-- vortex-file v0.75.0 (*)
+        |-- vortex-flatbuffers v0.75.0
+        |-- vortex-fsst v0.75.0 (*)
+        |-- vortex-io v0.75.0 (*)
+        |-- vortex-layout v0.75.0 (*)
+        |-- vortex-pco v0.75.0 (*)
+        |-- vortex-runend v0.75.0 (*)
+        |-- vortex-scan v0.75.0 (*)
+        |-- vortex-sequence v0.75.0 (*)
+        |-- vortex-sparse v0.75.0 (*)
+    `-- vortex-buffer v0.75.0
+    |               `-- tessera-io vWORKSPACE (*)
+    |               `-- vortex-file v0.75.0 (*)
+    |               |-- vortex-btrblocks v0.75.0 (*)
+    |           `-- vortex-array feature "default"
+    |           `-- vortex-zigzag v0.75.0
+    |           |       `-- tessera-io vWORKSPACE (*)
+    |           |   `-- vortex-btrblocks v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-file v0.75.0 (*)
+    |           |   `-- vortex-io feature "default"
+    |           |   `-- vortex-layout v0.75.0 (*)
+    |           |   `-- vortex-layout v0.75.0 (*)
+    |           |   `-- vortex-layout v0.75.0 (*)
+    |           |   `-- vortex-layout v0.75.0 (*)
+    |           |   |           `-- tessera-io vWORKSPACE (*)
+    |           |   |       `-- tessera-io vWORKSPACE (*)
+    |           |   |       `-- vortex-file v0.75.0 (*)
+    |           |   |       `-- vortex-layout feature "default"
+    |           |   |   `-- vortex-btrblocks feature "pco"
+    |           |   |   `-- vortex-layout v0.75.0
+    |           |   |   |                   `-- tessera-py feature "default" (command-line)
+    |           |   |   |               `-- tessera-py vWORKSPACE
+    |           |   |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+    |           |   |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+    |           |   |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+    |           |   |   |               |   |-- tessera-ingest feature "default" (command-line)
+    |           |   |   |               |-- tessera-cli vWORKSPACE (*)
+    |           |   |   |               |-- tessera-ingest vWORKSPACE
+    |           |   |   |           `-- tessera-io feature "default" (command-line)
+    |           |   |   |           |   `-- tessera-cli feature "cloud" (command-line)
+    |           |   |   |           |-- tessera-io feature "cloud" (command-line)
+    |           |   |   |       `-- tessera-io vWORKSPACE
+    |           |   |   |   `-- tessera-io vWORKSPACE (*)
+    |           |   |   |   `-- vortex-file feature "default"
+    |           |   |   |-- vortex-btrblocks feature "default"
+    |           |   |   |-- vortex-file v0.75.0
+    |           |   |-- vortex-alp v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-btrblocks v0.75.0 (*)
+    |           |   |-- vortex-file v0.75.0 (*)
+    |           |   |-- vortex-file v0.75.0 (*)
+    |           |   |-- vortex-file v0.75.0 (*)
+    |           |   |-- vortex-file v0.75.0 (*)
+    |           |-- vortex-alp v0.75.0
+    |           |-- vortex-btrblocks v0.75.0 (*)
+    |           |-- vortex-bytebool v0.75.0
+    |           |-- vortex-compressor v0.75.0
+    |           |-- vortex-datetime-parts v0.75.0
+    |           |-- vortex-decimal-byte-parts v0.75.0
+    |           |-- vortex-fastlanes v0.75.0
+    |           |-- vortex-file v0.75.0 (*)
+    |           |-- vortex-fsst v0.75.0
+    |           |-- vortex-io v0.75.0
+    |           |-- vortex-layout v0.75.0 (*)
+    |           |-- vortex-pco v0.75.0
+    |           |-- vortex-runend v0.75.0
+    |           |-- vortex-scan v0.75.0
+    |           |-- vortex-sequence v0.75.0
+    |           |-- vortex-sparse v0.75.0
+    |       `-- arrow-array feature "ffi" (*)
+    |       `-- datafusion-sql v54.0.0 (*)
+    |       `-- vortex-array v0.75.0
+    |       `-- vortex-array v0.75.0 (*)
+    |       |-- arrow v58.3.0 (*)
+    |       |-- datafusion v54.0.0 (*)
+    |       |-- datafusion-catalog v54.0.0 (*)
+    |       |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |-- datafusion-common v54.0.0 (*)
+    |       |-- datafusion-datasource v54.0.0 (*)
+    |       |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |-- datafusion-datasource-json v54.0.0 (*)
+    |       |-- datafusion-execution v54.0.0 (*)
+    |       |-- datafusion-expr v54.0.0 (*)
+    |       |-- datafusion-expr-common v54.0.0 (*)
+    |       |-- datafusion-functions v54.0.0 (*)
+    |       |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |       |-- datafusion-functions-nested v54.0.0 (*)
+    |       |-- datafusion-functions-table v54.0.0 (*)
+    |       |-- datafusion-functions-window v54.0.0 (*)
+    |       |-- datafusion-optimizer v54.0.0 (*)
+    |       |-- datafusion-physical-expr v54.0.0 (*)
+    |       |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |-- datafusion-physical-expr-common v54.0.0 (*)
+    |       |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |-- datafusion-physical-plan v54.0.0 (*)
+    |       |-- datafusion-pruning v54.0.0 (*)
+    |   `-- arrow feature "prettyprint"
+    |   `-- arrow-arith feature "default"
+    |   `-- arrow-array feature "ffi"
+    |   `-- arrow-data feature "ffi"
+    |   `-- datafusion-physical-plan v54.0.0 (*)
+    |   |           `-- datafusion-sql v54.0.0 (*)
+    |   |           |       `-- datafusion-common feature "sql" (*)
+    |   |           |   `-- datafusion-common feature "sqlparser"
+    |   |           |   `-- datafusion-session v54.0.0 (*)
+    |   |           |   |       `-- datafusion-expr feature "sql" (*)
+    |   |           |   |       `-- datafusion-pruning v54.0.0 (*)
+    |   |           |   |       |       `-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |   |       |       |-- datafusion-expr v54.0.0 (*)
+    |   |           |   |       |       |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |   |       |       |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |   |       |       |-- datafusion-physical-expr v54.0.0 (*)
+    |   |           |   |       |   `-- datafusion-functions-aggregate-common feature "default"
+    |   |           |   |       |   `-- datafusion-pruning v54.0.0 (*)
+    |   |           |   |       |   |       `-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |   |       |   |       |-- datafusion-expr v54.0.0 (*)
+    |   |           |   |       |   |       |-- datafusion-functions-window v54.0.0 (*)
+    |   |           |   |       |   |   `-- datafusion-functions-window-common feature "default"
+    |   |           |   |       |   |-- datafusion v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-datasource v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-datasource-json v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-execution v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-expr v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions-window v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-functions-window-common v54.0.0
+    |   |           |   |       |   |-- datafusion-physical-expr v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |   |       |   |-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |   |       |-- datafusion v54.0.0 (*)
+    |   |           |   |       |-- datafusion-expr v54.0.0 (*)
+    |   |           |   |       |-- datafusion-functions v54.0.0 (*)
+    |   |           |   |       |-- datafusion-functions-aggregate-common v54.0.0
+    |   |           |   |       |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |   |       |-- datafusion-optimizer v54.0.0 (*)
+    |   |           |   |       |-- datafusion-physical-expr v54.0.0 (*)
+    |   |           |   |       |-- datafusion-physical-expr-common v54.0.0
+    |   |           |   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |   |   `-- datafusion feature "recursive_protection" (*)
+    |   |           |   |   `-- datafusion feature "sql" (*)
+    |   |           |   |   `-- datafusion-datasource-json v54.0.0 (*)
+    |   |           |   |   `-- datafusion-expr feature "sqlparser"
+    |   |           |   |   `-- datafusion-expr-common feature "default"
+    |   |           |   |   `-- datafusion-pruning v54.0.0 (*)
+    |   |           |   |   `-- datafusion-session v54.0.0 (*)
+    |   |           |   |   `-- datafusion-sql v54.0.0 (*)
+    |   |           |   |   |       `-- datafusion feature "recursive_protection" (*)
+    |   |           |   |   |       `-- datafusion feature "recursive_protection" (*)
+    |   |           |   |   |       `-- datafusion v54.0.0 (*)
+    |   |           |   |   |   `-- datafusion feature "recursive_protection" (*)
+    |   |           |   |   |   `-- datafusion v54.0.0 (*)
+    |   |           |   |   |   `-- datafusion-functions-nested feature "sql" (*)
+    |   |           |   |   |   `-- datafusion-functions-window feature "default"
+    |   |           |   |   |   `-- datafusion-optimizer feature "recursive_protection"
+    |   |           |   |   |   `-- datafusion-physical-expr feature "recursive_protection"
+    |   |           |   |   |   `-- datafusion-pruning v54.0.0 (*)
+    |   |           |   |   |   `-- datafusion-sql v54.0.0 (*)
+    |   |           |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-catalog v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-datasource v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-functions-table v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-functions-window v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-optimizer v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-physical-expr feature "default"
+    |   |           |   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |           |   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |   |   |-- datafusion v54.0.0 (*)
+    |   |           |   |   |-- datafusion v54.0.0 (*)
+    |   |           |   |   |-- datafusion-catalog v54.0.0 (*)
+    |   |           |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |           |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |   |           |   |   |-- datafusion-datasource-json v54.0.0 (*)
+    |   |           |   |   |-- datafusion-execution v54.0.0 (*)
+    |   |           |   |   |-- datafusion-expr feature "recursive_protection"
+    |   |           |   |   |-- datafusion-expr feature "sql"
+    |   |           |   |   |-- datafusion-functions v54.0.0 (*)
+    |   |           |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |   |   |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |   |   |-- datafusion-functions-table v54.0.0 (*)
+    |   |           |   |   |-- datafusion-functions-window v54.0.0
+    |   |           |   |   |-- datafusion-optimizer v54.0.0
+    |   |           |   |   |-- datafusion-optimizer v54.0.0 (*)
+    |   |           |   |   |-- datafusion-physical-expr v54.0.0
+    |   |           |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |           |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |   |   |-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |   |-- datafusion-catalog v54.0.0 (*)
+    |   |           |   |-- datafusion-common feature "default"
+    |   |           |   |-- datafusion-common feature "object_store"
+    |   |           |   |-- datafusion-common feature "recursive_protection"
+    |   |           |   |-- datafusion-common feature "sql"
+    |   |           |   |-- datafusion-execution v54.0.0 (*)
+    |   |           |   |-- datafusion-expr v54.0.0
+    |   |           |   |-- datafusion-expr-common v54.0.0
+    |   |           |   |-- datafusion-functions v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-table v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-window v54.0.0 (*)
+    |   |           |   |-- datafusion-functions-window-common v54.0.0 (*)
+    |   |           |   |-- datafusion-physical-expr v54.0.0 (*)
+    |   |           |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |           |   |-- datafusion-physical-expr-common v54.0.0 (*)
+    |   |           |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |   |-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |-- datafusion v54.0.0 (*)
+    |   |           |-- datafusion-catalog v54.0.0 (*)
+    |   |           |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |           |-- datafusion-common v54.0.0
+    |   |           |-- datafusion-datasource v54.0.0 (*)
+    |   |           |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |           |-- datafusion-datasource-csv v54.0.0 (*)
+    |   |           |-- datafusion-datasource-json v54.0.0 (*)
+    |   |           |-- datafusion-execution v54.0.0 (*)
+    |   |           |-- datafusion-expr v54.0.0 (*)
+    |   |           |-- datafusion-expr-common v54.0.0 (*)
+    |   |           |-- datafusion-functions v54.0.0 (*)
+    |   |           |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |           |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |   |           |-- datafusion-functions-nested v54.0.0 (*)
+    |   |           |-- datafusion-functions-table v54.0.0 (*)
+    |   |           |-- datafusion-functions-window v54.0.0 (*)
+    |   |           |-- datafusion-optimizer v54.0.0 (*)
+    |   |           |-- datafusion-physical-expr v54.0.0 (*)
+    |   |           |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |           |-- datafusion-physical-expr-common v54.0.0 (*)
+    |   |           |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |           |-- datafusion-physical-plan v54.0.0 (*)
+    |   |           |-- datafusion-pruning v54.0.0 (*)
+    |   |       `-- arrow feature "default"
+    |   |       `-- arrow feature "default" (*)
+    |   |       `-- arrow feature "default" (*)
+    |   |       `-- tessera-cli vWORKSPACE (*)
+    |   |   `-- arrow feature "chrono-tz" (*)
+    |   |   `-- arrow feature "csv"
+    |   |   `-- arrow feature "ipc"
+    |   |   `-- arrow feature "json"
+    |   |   `-- datafusion-expr v54.0.0 (*)
+    |   |   `-- datafusion-sql v54.0.0 (*)
+    |   |   `-- vortex-array v0.75.0 (*)
+    |   |   `-- vortex-layout v0.75.0 (*)
+    |   |   |       `-- arrow v58.3.0 (*)
+    |   |   |       `-- datafusion-physical-plan v54.0.0 (*)
+    |   |   |       `-- vortex-array v0.75.0 (*)
+    |   |   |       `-- vortex-array v0.75.0 (*)
+    |   |   |       |       `-- vortex-array v0.75.0 (*)
+    |   |   |       |       |-- arrow v58.3.0 (*)
+    |   |   |       |   `-- arrow-string feature "default"
+    |   |   |       |-- arrow v58.3.0 (*)
+    |   |   |       |-- arrow v58.3.0 (*)
+    |   |   |       |-- arrow-cast v58.3.0 (*)
+    |   |   |       |-- arrow-cast v58.3.0 (*)
+    |   |   |       |-- arrow-ipc v58.3.0 (*)
+    |   |   |       |-- arrow-json v58.3.0 (*)
+    |   |   |       |-- arrow-json v58.3.0 (*)
+    |   |   |       |-- arrow-ord v58.3.0 (*)
+    |   |   |       |-- arrow-string v58.3.0
+    |   |   |       |-- datafusion-common v54.0.0 (*)
+    |   |   |       |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |   |   `-- arrow-cast feature "prettyprint" (*)
+    |   |   |   `-- arrow-ipc feature "zstd"
+    |   |   |   `-- arrow-ord feature "default"
+    |   |   |   `-- arrow-row feature "default"
+    |   |   |   `-- arrow-select feature "default"
+    |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+    |   |   |   |       `-- arrow feature "prettyprint" (*)
+    |   |   |   |   `-- arrow v58.3.0 (*)
+    |   |   |   |   `-- arrow-cast feature "prettyprint"
+    |   |   |   |   `-- arrow-ipc feature "lz4" (*)
+    |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+    |   |   |   |   `-- vortex-array v0.75.0 (*)
+    |   |   |   |   |       `-- arrow v58.3.0 (*)
+    |   |   |   |   |       `-- arrow v58.3.0 (*)
+    |   |   |   |   |   `-- arrow-csv feature "default"
+    |   |   |   |   |   `-- arrow-json feature "default"
+    |   |   |   |   |-- arrow v58.3.0 (*)
+    |   |   |   |   |-- arrow-csv v58.3.0
+    |   |   |   |   |-- arrow-json v58.3.0
+    |   |   |   |   |-- datafusion-common v54.0.0 (*)
+    |   |   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |   |   |-- arrow-cast feature "comfy-table"
+    |   |   |   |-- arrow-cast feature "default"
+    |   |   |   |-- arrow-ipc feature "default"
+    |   |   |   |-- arrow-ipc feature "lz4"
+    |   |   |   |-- arrow-ipc feature "lz4_flex"
+    |   |   |   |-- datafusion-functions-nested v54.0.0 (*)
+    |   |   |-- arrow v58.3.0 (*)
+    |   |   |-- arrow v58.3.0 (*)
+    |   |   |-- arrow-arith v58.3.0 (*)
+    |   |   |-- arrow-arith v58.3.0 (*)
+    |   |   |-- arrow-array v58.3.0 (*)
+    |   |   |-- arrow-cast v58.3.0
+    |   |   |-- arrow-cast v58.3.0 (*)
+    |   |   |-- arrow-csv v58.3.0 (*)
+    |   |   |-- arrow-ipc v58.3.0
+    |   |   |-- arrow-ipc v58.3.0 (*)
+    |   |   |-- arrow-json v58.3.0 (*)
+    |   |   |-- arrow-ord v58.3.0
+    |   |   |-- arrow-ord v58.3.0 (*)
+    |   |   |-- arrow-row v58.3.0
+    |   |   |-- arrow-row v58.3.0 (*)
+    |   |   |-- arrow-select v58.3.0
+    |   |   |-- arrow-select v58.3.0 (*)
+    |   |   |-- arrow-string v58.3.0 (*)
+    |   |   |-- arrow-string v58.3.0 (*)
+    |   |   |-- datafusion v54.0.0 (*)
+    |   |   |-- datafusion-catalog v54.0.0 (*)
+    |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |   |   |-- datafusion-common v54.0.0 (*)
+    |   |   |-- datafusion-datasource v54.0.0 (*)
+    |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |   |   |-- datafusion-datasource-json v54.0.0 (*)
+    |   |   |-- datafusion-execution v54.0.0 (*)
+    |   |   |-- datafusion-expr v54.0.0 (*)
+    |   |   |-- datafusion-expr-common v54.0.0 (*)
+    |   |   |-- datafusion-functions v54.0.0 (*)
+    |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |   |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |   |   |-- datafusion-functions-nested v54.0.0 (*)
+    |   |   |-- datafusion-functions-table v54.0.0 (*)
+    |   |   |-- datafusion-functions-window v54.0.0 (*)
+    |   |   |-- datafusion-optimizer v54.0.0 (*)
+    |   |   |-- datafusion-physical-expr v54.0.0 (*)
+    |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |   |   |-- datafusion-physical-expr-common v54.0.0 (*)
+    |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |   |   |-- datafusion-physical-plan v54.0.0 (*)
+    |   |   |-- datafusion-pruning v54.0.0 (*)
+    |   |   |-- vortex-array v0.75.0 (*)
+    |   |-- arrow feature "arrow-csv"
+    |   |-- arrow feature "arrow-ipc"
+    |   |-- arrow feature "arrow-json"
+    |   |-- arrow feature "canonical_extension_types"
+    |   |-- arrow feature "chrono-tz"
+    |   |-- arrow feature "csv" (*)
+    |   |-- arrow feature "default" (*)
+    |   |-- arrow feature "ipc" (*)
+    |   |-- arrow feature "json" (*)
+    |   |-- arrow-array feature "chrono-tz"
+    |   |-- arrow-array feature "default"
+    |   |-- arrow-data feature "default"
+    |-- arrow v58.3.0
+    |-- arrow-arith v58.3.0
+    |-- arrow-array v58.3.0
+    |-- arrow-cast v58.3.0 (*)
+    |-- arrow-data v58.3.0
+    |-- arrow-ipc v58.3.0 (*)
+    |-- arrow-json v58.3.0 (*)
+    |-- arrow-ord v58.3.0 (*)
+    |-- arrow-row v58.3.0 (*)
+    |-- arrow-select v58.3.0 (*)
+    |-- arrow-string v58.3.0 (*)
+    |-- vortex-array v0.75.0 (*)
+`-- arrow-buffer feature "default"
+`-- datafusion-functions v54.0.0 (*)
+arrow-buffer v58.3.0
+|   `-- datafusion-session v54.0.0 (*)
+|   |                   `-- datafusion feature "recursive_protection" (*)
+|   |               `-- datafusion v54.0.0 (*)
+|   |               `-- datafusion-physical-optimizer feature "recursive_protection"
+|   |               |   `-- datafusion v54.0.0 (*)
+|   |               |-- datafusion-physical-optimizer feature "default"
+|   |           `-- datafusion-functions-table feature "default"
+|   |           `-- datafusion-physical-optimizer v54.0.0
+|   |       `-- datafusion feature "sql" (*)
+|   |       `-- datafusion-functions feature "string_expressions" (*)
+|   |       `-- datafusion-functions-nested v54.0.0 (*)
+|   |       `-- datafusion-functions-table v54.0.0
+|   |       `-- datafusion-pruning feature "default"
+|   |       |       `-- datafusion v54.0.0 (*)
+|   |       |   `-- datafusion-catalog-listing feature "default"
+|   |       |-- datafusion v54.0.0 (*)
+|   |       |-- datafusion v54.0.0 (*)
+|   |       |-- datafusion-catalog-listing v54.0.0
+|   |   `-- datafusion feature "sqlparser"
+|   |   `-- datafusion-catalog feature "default"
+|   |   `-- datafusion-functions feature "uuid"
+|   |   `-- datafusion-functions-aggregate feature "default"
+|   |   `-- datafusion-pruning v54.0.0
+|   |   |                           `-- datafusion-datasource-json v54.0.0 (*)
+|   |   |                           |-- datafusion v54.0.0 (*)
+|   |   |                           |-- datafusion-catalog v54.0.0 (*)
+|   |   |                           |-- datafusion-datasource v54.0.0 (*)
+|   |   |                           |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |                           |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |                       `-- datafusion-session feature "default"
+|   |   |                   `-- datafusion-session v54.0.0
+|   |   |                   |-- datafusion v54.0.0 (*)
+|   |   |                   |-- datafusion-catalog v54.0.0 (*)
+|   |   |                   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |                   |-- datafusion-datasource v54.0.0 (*)
+|   |   |                   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |                   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |                   |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |                   |-- datafusion-functions-table v54.0.0 (*)
+|   |   |                   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |                   |-- datafusion-pruning v54.0.0 (*)
+|   |   |               `-- datafusion-physical-plan feature "default"
+|   |   |           `-- datafusion-physical-plan v54.0.0
+|   |   |           `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |           |               `-- datafusion-sql feature "default" (*)
+|   |   |           |           `-- datafusion-sql feature "unparser"
+|   |   |           |           |   `-- datafusion feature "recursive_protection" (*)
+|   |   |           |           |   `-- datafusion v54.0.0 (*)
+|   |   |           |           |   `-- datafusion-sql feature "default" (*)
+|   |   |           |           |-- datafusion-sql feature "default"
+|   |   |           |           |-- datafusion-sql feature "recursive_protection"
+|   |   |           |           |-- datafusion-sql feature "unicode_expressions"
+|   |   |           |       `-- datafusion-sql v54.0.0
+|   |   |           |   `-- datafusion-datasource v54.0.0 (*)
+|   |   |           |   `-- datafusion-functions-nested feature "sql"
+|   |   |           |   |-- datafusion v54.0.0 (*)
+|   |   |           |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |           |-- datafusion v54.0.0 (*)
+|   |   |           |-- datafusion-functions-nested v54.0.0
+|   |   |           |-- datafusion-physical-expr-adapter v54.0.0
+|   |   |           |-- tessera-cli feature "cloud" (command-line)
+|   |   |           |-- tessera-cli feature "default" (command-line)
+|   |   |           |-- tessera-cli feature "sql" (command-line)
+|   |   |       `-- datafusion-functions feature "default"
+|   |   |       `-- datafusion-functions feature "default" (*)
+|   |   |       `-- datafusion-functions feature "default" (*)
+|   |   |       `-- tessera-cli vWORKSPACE
+|   |   |   `-- datafusion feature "sql"
+|   |   |   `-- datafusion v54.0.0 (*)
+|   |   |   `-- datafusion v54.0.0 (*)
+|   |   |   `-- datafusion v54.0.0 (*)
+|   |   |   `-- datafusion-functions feature "datetime_expressions"
+|   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   `-- datafusion-functions feature "encoding_expressions"
+|   |   |   `-- datafusion-functions feature "encoding_expressions" (*)
+|   |   |   `-- datafusion-functions feature "regex_expressions"
+|   |   |   `-- tessera-cli vWORKSPACE (*)
+|   |   |-- datafusion feature "datafusion-sql"
+|   |   |-- datafusion feature "recursive_protection"
+|   |   |-- datafusion feature "sql" (*)
+|   |   |-- datafusion v54.0.0 (*)
+|   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |-- datafusion-datasource-arrow v54.0.0
+|   |   |-- datafusion-datasource-csv v54.0.0
+|   |   |-- datafusion-datasource-json v54.0.0
+|   |   |-- datafusion-functions feature "base64"
+|   |   |-- datafusion-functions feature "chrono-tz"
+|   |   |-- datafusion-functions feature "datetime_expressions" (*)
+|   |   |-- datafusion-functions feature "default" (*)
+|   |   |-- datafusion-functions feature "encoding_expressions" (*)
+|   |   |-- datafusion-functions feature "hex"
+|   |   |-- datafusion-functions feature "math_expressions"
+|   |   |-- datafusion-functions feature "regex"
+|   |   |-- datafusion-functions feature "regex_expressions" (*)
+|   |   |-- datafusion-functions feature "string_expressions"
+|   |   |-- datafusion-functions feature "unicode_expressions"
+|   |-- datafusion v54.0.0
+|   |-- datafusion-catalog v54.0.0
+|   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |-- datafusion-datasource v54.0.0
+|   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |-- datafusion-datasource-json v54.0.0 (*)
+|   |-- datafusion-functions v54.0.0
+|   |-- datafusion-functions-aggregate v54.0.0
+|   |-- datafusion-functions-nested v54.0.0 (*)
+|   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |-- datafusion-physical-plan v54.0.0 (*)
+|-- datafusion-execution v54.0.0

--- a/tessera/tests/feature-snapshots/arrow-schema.txt
+++ b/tessera/tests/feature-snapshots/arrow-schema.txt
@@ -1,0 +1,608 @@
+                `-- datafusion-datasource-json v54.0.0 (*)
+                |-- datafusion v54.0.0 (*)
+                |-- datafusion-catalog v54.0.0 (*)
+                |-- datafusion-datasource v54.0.0 (*)
+                |-- datafusion-datasource-arrow v54.0.0 (*)
+                |-- datafusion-datasource-csv v54.0.0 (*)
+            `-- datafusion-session feature "default"
+        `-- datafusion-session v54.0.0
+        |                   `-- datafusion feature "recursive_protection" (*)
+        |               `-- datafusion v54.0.0 (*)
+        |               `-- datafusion-physical-optimizer feature "recursive_protection"
+        |               |   `-- datafusion v54.0.0 (*)
+        |               |-- datafusion-physical-optimizer feature "default"
+        |           `-- datafusion-functions-table feature "default"
+        |           `-- datafusion-physical-optimizer v54.0.0
+        |       `-- datafusion feature "sql" (*)
+        |       `-- datafusion-functions-table v54.0.0
+        |       `-- datafusion-pruning feature "default"
+        |       |       `-- datafusion v54.0.0 (*)
+        |       |   `-- datafusion-catalog-listing feature "default"
+        |       |-- datafusion v54.0.0 (*)
+        |       |-- datafusion-catalog-listing v54.0.0
+        |   `-- datafusion feature "sqlparser"
+        |   `-- datafusion-catalog feature "default"
+        |   `-- datafusion-pruning v54.0.0
+        |   |           `-- tessera-cli feature "static-hdf5" (command-line)
+        |   |           |-- tessera-cli feature "cloud" (command-line)
+        |   |           |-- tessera-cli feature "default" (command-line)
+        |   |           |-- tessera-cli feature "sql" (command-line)
+        |   |       `-- tessera-cli vWORKSPACE
+        |   |   `-- datafusion feature "sql"
+        |   |   `-- datafusion v54.0.0 (*)
+        |   |   `-- datafusion v54.0.0 (*)
+        |   |   `-- datafusion v54.0.0 (*)
+        |   |   `-- tessera-cli vWORKSPACE (*)
+        |   |-- datafusion feature "datafusion-sql"
+        |   |-- datafusion feature "recursive_protection"
+        |   |-- datafusion feature "sql" (*)
+        |   |-- datafusion v54.0.0 (*)
+        |   |-- datafusion-catalog v54.0.0 (*)
+        |   |-- datafusion-catalog-listing v54.0.0 (*)
+        |   |-- datafusion-datasource-arrow v54.0.0
+        |   |-- datafusion-datasource-csv v54.0.0
+        |   |-- datafusion-datasource-json v54.0.0
+        |-- datafusion v54.0.0
+        |-- datafusion-catalog v54.0.0
+        |-- datafusion-catalog-listing v54.0.0 (*)
+        |-- datafusion-datasource v54.0.0
+        |-- datafusion-datasource-arrow v54.0.0 (*)
+        |-- datafusion-datasource-csv v54.0.0 (*)
+        |-- datafusion-datasource-json v54.0.0 (*)
+        |-- datafusion-functions-table v54.0.0 (*)
+        |-- datafusion-physical-optimizer v54.0.0 (*)
+        |-- datafusion-pruning v54.0.0 (*)
+    `-- datafusion-physical-plan feature "default"
+`-- arrow-schema feature "ffi" (*)
+`-- datafusion-physical-plan v54.0.0
+arrow-schema v58.3.0
+|           `-- arrow-array feature "ffi" (*)
+|       `-- arrow-data feature "ffi"
+|       `-- datafusion-expr v54.0.0 (*)
+|       |           `-- tessera-io vWORKSPACE (*)
+|       |           `-- vortex-file v0.75.0 (*)
+|       |           |-- vortex-btrblocks v0.75.0 (*)
+|       |       `-- vortex-array feature "default"
+|       |       `-- vortex-zigzag v0.75.0
+|       |       |       `-- tessera-io vWORKSPACE (*)
+|       |       |   `-- vortex-btrblocks v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-file v0.75.0 (*)
+|       |       |   `-- vortex-io feature "default"
+|       |       |   `-- vortex-layout v0.75.0 (*)
+|       |       |   `-- vortex-layout v0.75.0 (*)
+|       |       |   `-- vortex-layout v0.75.0 (*)
+|       |       |   `-- vortex-layout v0.75.0 (*)
+|       |       |   |           `-- tessera-io vWORKSPACE (*)
+|       |       |   |       `-- tessera-io vWORKSPACE (*)
+|       |       |   |       `-- vortex-file v0.75.0 (*)
+|       |       |   |       `-- vortex-layout feature "default"
+|       |       |   |   `-- vortex-btrblocks feature "pco"
+|       |       |   |   `-- vortex-layout v0.75.0
+|       |       |   |   |                   `-- tessera-py feature "default" (command-line)
+|       |       |   |   |               `-- tessera-py vWORKSPACE
+|       |       |   |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+|       |       |   |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|       |       |   |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+|       |       |   |   |               |   |-- tessera-ingest feature "default" (command-line)
+|       |       |   |   |               |-- tessera-cli vWORKSPACE (*)
+|       |       |   |   |               |-- tessera-ingest vWORKSPACE
+|       |       |   |   |           `-- tessera-io feature "default" (command-line)
+|       |       |   |   |           |   `-- tessera-cli feature "cloud" (command-line)
+|       |       |   |   |           |-- tessera-io feature "cloud" (command-line)
+|       |       |   |   |       `-- tessera-io vWORKSPACE
+|       |       |   |   |   `-- tessera-io vWORKSPACE (*)
+|       |       |   |   |   `-- vortex-file feature "default"
+|       |       |   |   |-- vortex-btrblocks feature "default"
+|       |       |   |   |-- vortex-file v0.75.0
+|       |       |   |-- vortex-alp v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-btrblocks v0.75.0 (*)
+|       |       |   |-- vortex-file v0.75.0 (*)
+|       |       |   |-- vortex-file v0.75.0 (*)
+|       |       |   |-- vortex-file v0.75.0 (*)
+|       |       |   |-- vortex-file v0.75.0 (*)
+|       |       |-- vortex-alp v0.75.0
+|       |       |-- vortex-btrblocks v0.75.0 (*)
+|       |       |-- vortex-bytebool v0.75.0
+|       |       |-- vortex-compressor v0.75.0
+|       |       |-- vortex-datetime-parts v0.75.0
+|       |       |-- vortex-decimal-byte-parts v0.75.0
+|       |       |-- vortex-fastlanes v0.75.0
+|       |       |-- vortex-file v0.75.0 (*)
+|       |       |-- vortex-fsst v0.75.0
+|       |       |-- vortex-io v0.75.0
+|       |       |-- vortex-layout v0.75.0 (*)
+|       |       |-- vortex-pco v0.75.0
+|       |       |-- vortex-runend v0.75.0
+|       |       |-- vortex-scan v0.75.0
+|       |       |-- vortex-sequence v0.75.0
+|       |       |-- vortex-sparse v0.75.0
+|       |   `-- vortex-array v0.75.0
+|       |-- arrow-array feature "ffi"
+|   `-- arrow feature "canonical_extension_types"
+|   `-- arrow-schema feature "ffi"
+|   `-- vortex-array v0.75.0 (*)
+|   `-- vortex-layout v0.75.0 (*)
+|   |       `-- datafusion-common feature "sql" (*)
+|   |       `-- datafusion-sql v54.0.0 (*)
+|   |       `-- vortex-array v0.75.0 (*)
+|   |       `-- vortex-array v0.75.0 (*)
+|   |       |-- arrow v58.3.0 (*)
+|   |       |-- datafusion v54.0.0 (*)
+|   |       |-- datafusion-catalog v54.0.0 (*)
+|   |       |-- datafusion-catalog-listing v54.0.0 (*)
+|   |       |-- datafusion-common v54.0.0 (*)
+|   |       |-- datafusion-datasource v54.0.0 (*)
+|   |       |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |       |-- datafusion-datasource-csv v54.0.0 (*)
+|   |       |-- datafusion-datasource-json v54.0.0 (*)
+|   |       |-- datafusion-execution v54.0.0 (*)
+|   |       |-- datafusion-expr v54.0.0 (*)
+|   |       |-- datafusion-expr-common v54.0.0 (*)
+|   |       |-- datafusion-functions v54.0.0 (*)
+|   |       |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |       |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |       |-- datafusion-functions-nested v54.0.0 (*)
+|   |       |-- datafusion-functions-table v54.0.0 (*)
+|   |       |-- datafusion-functions-window v54.0.0 (*)
+|   |       |-- datafusion-optimizer v54.0.0 (*)
+|   |       |-- datafusion-physical-expr v54.0.0 (*)
+|   |       |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |       |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |       |-- datafusion-physical-plan v54.0.0 (*)
+|   |       |-- datafusion-pruning v54.0.0 (*)
+|   |   `-- arrow feature "prettyprint"
+|   |   `-- arrow-arith feature "default"
+|   |   `-- arrow-array feature "ffi" (*)
+|   |   `-- arrow-data feature "ffi" (*)
+|   |   `-- datafusion-common feature "sqlparser"
+|   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   `-- datafusion-session v54.0.0 (*)
+|   |   `-- vortex-error feature "flatbuffers"
+|   |   `-- vortex-zigzag v0.75.0 (*)
+|   |   |           `-- datafusion-sql v54.0.0 (*)
+|   |   |           |-- datafusion v54.0.0 (*)
+|   |   |           |-- datafusion-catalog v54.0.0 (*)
+|   |   |           |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |           |-- datafusion-common v54.0.0 (*)
+|   |   |           |-- datafusion-datasource v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |           |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |           |-- datafusion-execution v54.0.0 (*)
+|   |   |           |-- datafusion-expr v54.0.0 (*)
+|   |   |           |-- datafusion-expr-common v54.0.0 (*)
+|   |   |           |-- datafusion-functions v54.0.0 (*)
+|   |   |           |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |           |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |   |           |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |           |-- datafusion-functions-table v54.0.0 (*)
+|   |   |           |-- datafusion-functions-window v54.0.0 (*)
+|   |   |           |-- datafusion-optimizer v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |           |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |   |           |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |           |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |           |-- datafusion-pruning v54.0.0 (*)
+|   |   |       `-- arrow feature "default"
+|   |   |       `-- arrow feature "default" (*)
+|   |   |       `-- arrow feature "default" (*)
+|   |   |       `-- datafusion-expr feature "sql" (*)
+|   |   |       `-- datafusion-pruning v54.0.0 (*)
+|   |   |       `-- tessera-cli vWORKSPACE (*)
+|   |   |       `-- tessera-io vWORKSPACE (*)
+|   |   |       `-- tessera-io vWORKSPACE (*)
+|   |   |       `-- vortex-array v0.75.0 (*)
+|   |   |       |       `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |       |       |-- datafusion-expr v54.0.0 (*)
+|   |   |       |       |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |       |       |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |       |       |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |       |   `-- datafusion-functions-aggregate-common feature "default"
+|   |   |       |   `-- datafusion-pruning v54.0.0 (*)
+|   |   |       |   |       `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |       |   |       |-- datafusion-expr v54.0.0 (*)
+|   |   |       |   |       |-- datafusion-functions-window v54.0.0 (*)
+|   |   |       |   |   `-- datafusion-functions-window-common feature "default"
+|   |   |       |   |-- datafusion v54.0.0 (*)
+|   |   |       |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |       |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |       |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |       |   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |       |   |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |       |   |-- datafusion-execution v54.0.0 (*)
+|   |   |       |   |-- datafusion-expr v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions-window v54.0.0 (*)
+|   |   |       |   |-- datafusion-functions-window-common v54.0.0
+|   |   |       |   |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |       |   |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |       |-- datafusion v54.0.0 (*)
+|   |   |       |-- datafusion-expr v54.0.0 (*)
+|   |   |       |-- datafusion-functions v54.0.0 (*)
+|   |   |       |-- datafusion-functions-aggregate-common v54.0.0
+|   |   |       |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |       |-- datafusion-optimizer v54.0.0 (*)
+|   |   |       |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |       |-- datafusion-physical-expr-common v54.0.0
+|   |   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |   `-- arrow feature "chrono-tz" (*)
+|   |   |   `-- arrow feature "csv"
+|   |   |   `-- arrow feature "ipc"
+|   |   |   `-- arrow feature "json"
+|   |   |   `-- datafusion feature "recursive_protection" (*)
+|   |   |   `-- datafusion feature "sql" (*)
+|   |   |   `-- datafusion-datasource-json v54.0.0 (*)
+|   |   |   `-- datafusion-expr feature "sqlparser"
+|   |   |   `-- datafusion-expr-common feature "default"
+|   |   |   `-- datafusion-pruning v54.0.0 (*)
+|   |   |   `-- datafusion-session v54.0.0 (*)
+|   |   |   `-- datafusion-session v54.0.0 (*)
+|   |   |   `-- datafusion-sql v54.0.0 (*)
+|   |   |   `-- datafusion-sql v54.0.0 (*)
+|   |   |   `-- vortex-array v0.75.0 (*)
+|   |   |   `-- vortex-buffer feature "default"
+|   |   |   `-- vortex-io v0.75.0 (*)
+|   |   |   `-- vortex-layout v0.75.0 (*)
+|   |   |   `-- vortex-session feature "default"
+|   |   |   `-- vortex-utils feature "dyn-traits"
+|   |   |   `-- vortex-zigzag v0.75.0 (*)
+|   |   |   `-- vortex-zigzag v0.75.0 (*)
+|   |   |   |       `-- arrow v58.3.0 (*)
+|   |   |   |       `-- datafusion feature "recursive_protection" (*)
+|   |   |   |       `-- datafusion feature "recursive_protection" (*)
+|   |   |   |       `-- datafusion v54.0.0 (*)
+|   |   |   |       `-- datafusion-functions feature "string_expressions" (*)
+|   |   |   |       `-- datafusion-functions-nested v54.0.0 (*)
+|   |   |   |       `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |       `-- vortex-array v0.75.0 (*)
+|   |   |   |       `-- vortex-array v0.75.0 (*)
+|   |   |   |       `-- vortex-zigzag v0.75.0 (*)
+|   |   |   |       |       `-- vortex-array v0.75.0 (*)
+|   |   |   |       |       |-- arrow v58.3.0 (*)
+|   |   |   |       |   `-- arrow-string feature "default"
+|   |   |   |       |-- arrow v58.3.0 (*)
+|   |   |   |       |-- arrow v58.3.0 (*)
+|   |   |   |       |-- arrow-cast v58.3.0 (*)
+|   |   |   |       |-- arrow-cast v58.3.0 (*)
+|   |   |   |       |-- arrow-ipc v58.3.0 (*)
+|   |   |   |       |-- arrow-json v58.3.0 (*)
+|   |   |   |       |-- arrow-json v58.3.0 (*)
+|   |   |   |       |-- arrow-ord v58.3.0 (*)
+|   |   |   |       |-- arrow-string v58.3.0
+|   |   |   |       |-- datafusion v54.0.0 (*)
+|   |   |   |       |-- datafusion-common v54.0.0 (*)
+|   |   |   |       |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |       |-- vortex-alp v0.75.0 (*)
+|   |   |   |       |-- vortex-array v0.75.0 (*)
+|   |   |   |       |-- vortex-bytebool v0.75.0 (*)
+|   |   |   |       |-- vortex-compressor v0.75.0 (*)
+|   |   |   |       |-- vortex-datetime-parts v0.75.0 (*)
+|   |   |   |       |-- vortex-decimal-byte-parts v0.75.0 (*)
+|   |   |   |       |-- vortex-fastlanes v0.75.0 (*)
+|   |   |   |       |-- vortex-file v0.75.0 (*)
+|   |   |   |       |-- vortex-fsst v0.75.0 (*)
+|   |   |   |       |-- vortex-layout v0.75.0 (*)
+|   |   |   |       |-- vortex-pco v0.75.0 (*)
+|   |   |   |       |-- vortex-runend v0.75.0 (*)
+|   |   |   |       |-- vortex-scan v0.75.0 (*)
+|   |   |   |       |-- vortex-sequence v0.75.0 (*)
+|   |   |   |       |-- vortex-sparse v0.75.0 (*)
+|   |   |   |   `-- arrow-cast feature "prettyprint" (*)
+|   |   |   |   `-- arrow-ipc feature "zstd"
+|   |   |   |   `-- arrow-ord feature "default"
+|   |   |   |   `-- arrow-row feature "default"
+|   |   |   |   `-- arrow-select feature "default"
+|   |   |   |   `-- datafusion feature "recursive_protection" (*)
+|   |   |   |   `-- datafusion v54.0.0 (*)
+|   |   |   |   `-- datafusion-functions feature "uuid"
+|   |   |   |   `-- datafusion-functions-aggregate feature "default"
+|   |   |   |   `-- datafusion-functions-nested feature "sql" (*)
+|   |   |   |   `-- datafusion-functions-window feature "default"
+|   |   |   |   `-- datafusion-optimizer feature "recursive_protection"
+|   |   |   |   `-- datafusion-physical-expr feature "recursive_protection"
+|   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |   `-- datafusion-pruning v54.0.0 (*)
+|   |   |   |   `-- datafusion-sql v54.0.0 (*)
+|   |   |   |   `-- vortex-flatbuffers feature "layout" (*)
+|   |   |   |   `-- vortex-mask v0.75.0
+|   |   |   |   `-- vortex-session v0.75.0 (*)
+|   |   |   |   |           `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |   |           |               `-- datafusion-sql feature "default" (*)
+|   |   |   |   |           |           `-- datafusion-sql feature "unparser"
+|   |   |   |   |           |           |   `-- datafusion feature "recursive_protection" (*)
+|   |   |   |   |           |           |   `-- datafusion v54.0.0 (*)
+|   |   |   |   |           |           |   `-- datafusion-sql feature "default" (*)
+|   |   |   |   |           |           |-- datafusion-sql feature "default"
+|   |   |   |   |           |           |-- datafusion-sql feature "recursive_protection"
+|   |   |   |   |           |           |-- datafusion-sql feature "unicode_expressions"
+|   |   |   |   |           |       `-- datafusion-sql v54.0.0
+|   |   |   |   |           |   `-- datafusion-datasource v54.0.0 (*)
+|   |   |   |   |           |   `-- datafusion-functions-nested feature "sql"
+|   |   |   |   |           |   |-- datafusion v54.0.0 (*)
+|   |   |   |   |           |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |   |           |-- datafusion v54.0.0 (*)
+|   |   |   |   |           |-- datafusion-functions-nested v54.0.0
+|   |   |   |   |           |-- datafusion-physical-expr-adapter v54.0.0
+|   |   |   |   |       `-- arrow feature "prettyprint" (*)
+|   |   |   |   |       `-- datafusion-functions feature "default"
+|   |   |   |   |       `-- datafusion-functions feature "default" (*)
+|   |   |   |   |       `-- datafusion-functions feature "default" (*)
+|   |   |   |   |       `-- vortex-layout v0.75.0 (*)
+|   |   |   |   |   `-- arrow v58.3.0 (*)
+|   |   |   |   |   `-- arrow-cast feature "prettyprint"
+|   |   |   |   |   `-- arrow-ipc feature "lz4" (*)
+|   |   |   |   |   `-- datafusion-functions feature "datetime_expressions"
+|   |   |   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   |   |   `-- datafusion-functions feature "default" (*)
+|   |   |   |   |   `-- datafusion-functions feature "encoding_expressions"
+|   |   |   |   |   `-- datafusion-functions feature "encoding_expressions" (*)
+|   |   |   |   |   `-- datafusion-functions feature "regex_expressions"
+|   |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |   |   `-- vortex-array v0.75.0 (*)
+|   |   |   |   |   `-- vortex-array v0.75.0 (*)
+|   |   |   |   |   `-- vortex-array v0.75.0 (*)
+|   |   |   |   |   `-- vortex-flatbuffers feature "array" (*)
+|   |   |   |   |   `-- vortex-flatbuffers feature "layout"
+|   |   |   |   |   |       `-- arrow v58.3.0 (*)
+|   |   |   |   |   |       `-- arrow v58.3.0 (*)
+|   |   |   |   |   |       `-- vortex-file v0.75.0 (*)
+|   |   |   |   |   |   `-- arrow-csv feature "default"
+|   |   |   |   |   |   `-- arrow-json feature "default"
+|   |   |   |   |   |   `-- vortex-flatbuffers feature "file"
+|   |   |   |   |   |-- arrow v58.3.0 (*)
+|   |   |   |   |   |-- arrow-csv v58.3.0
+|   |   |   |   |   |-- arrow-json v58.3.0
+|   |   |   |   |   |-- datafusion-common v54.0.0 (*)
+|   |   |   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |   |   |-- vortex-flatbuffers feature "ipc"
+|   |   |   |   |-- arrow-cast feature "comfy-table"
+|   |   |   |   |-- arrow-cast feature "default"
+|   |   |   |   |-- arrow-ipc feature "default"
+|   |   |   |   |-- arrow-ipc feature "lz4"
+|   |   |   |   |-- arrow-ipc feature "lz4_flex"
+|   |   |   |   |-- datafusion v54.0.0 (*)
+|   |   |   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |   |   |-- datafusion-functions feature "base64"
+|   |   |   |   |-- datafusion-functions feature "chrono-tz"
+|   |   |   |   |-- datafusion-functions feature "datetime_expressions" (*)
+|   |   |   |   |-- datafusion-functions feature "default" (*)
+|   |   |   |   |-- datafusion-functions feature "encoding_expressions" (*)
+|   |   |   |   |-- datafusion-functions feature "hex"
+|   |   |   |   |-- datafusion-functions feature "math_expressions"
+|   |   |   |   |-- datafusion-functions feature "regex"
+|   |   |   |   |-- datafusion-functions feature "regex_expressions" (*)
+|   |   |   |   |-- datafusion-functions feature "string_expressions"
+|   |   |   |   |-- datafusion-functions feature "unicode_expressions"
+|   |   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |   |   |-- datafusion-functions-table v54.0.0 (*)
+|   |   |   |   |-- datafusion-functions-window v54.0.0 (*)
+|   |   |   |   |-- datafusion-optimizer v54.0.0 (*)
+|   |   |   |   |-- datafusion-physical-expr feature "default"
+|   |   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |   |   |-- vortex-array v0.75.0 (*)
+|   |   |   |   |-- vortex-file v0.75.0 (*)
+|   |   |   |   |-- vortex-flatbuffers feature "array"
+|   |   |   |   |-- vortex-flatbuffers feature "dtype"
+|   |   |   |   |-- vortex-flatbuffers feature "file" (*)
+|   |   |   |   |-- vortex-flatbuffers feature "ipc" (*)
+|   |   |   |   |-- vortex-layout v0.75.0 (*)
+|   |   |   |-- arrow v58.3.0 (*)
+|   |   |   |-- arrow v58.3.0 (*)
+|   |   |   |-- arrow-arith v58.3.0 (*)
+|   |   |   |-- arrow-arith v58.3.0 (*)
+|   |   |   |-- arrow-array v58.3.0 (*)
+|   |   |   |-- arrow-cast v58.3.0
+|   |   |   |-- arrow-cast v58.3.0 (*)
+|   |   |   |-- arrow-csv v58.3.0 (*)
+|   |   |   |-- arrow-ipc v58.3.0
+|   |   |   |-- arrow-ipc v58.3.0 (*)
+|   |   |   |-- arrow-json v58.3.0 (*)
+|   |   |   |-- arrow-ord v58.3.0
+|   |   |   |-- arrow-ord v58.3.0 (*)
+|   |   |   |-- arrow-row v58.3.0
+|   |   |   |-- arrow-row v58.3.0 (*)
+|   |   |   |-- arrow-select v58.3.0
+|   |   |   |-- arrow-select v58.3.0 (*)
+|   |   |   |-- arrow-string v58.3.0 (*)
+|   |   |   |-- arrow-string v58.3.0 (*)
+|   |   |   |-- datafusion v54.0.0 (*)
+|   |   |   |-- datafusion v54.0.0 (*)
+|   |   |   |-- datafusion v54.0.0 (*)
+|   |   |   |-- datafusion v54.0.0 (*)
+|   |   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+|   |   |   |-- datafusion-common v54.0.0 (*)
+|   |   |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |   |-- datafusion-datasource v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |   |-- datafusion-datasource-json v54.0.0 (*)
+|   |   |   |-- datafusion-execution v54.0.0 (*)
+|   |   |   |-- datafusion-execution v54.0.0 (*)
+|   |   |   |-- datafusion-expr feature "recursive_protection"
+|   |   |   |-- datafusion-expr feature "sql"
+|   |   |   |-- datafusion-expr v54.0.0 (*)
+|   |   |   |-- datafusion-expr-common v54.0.0 (*)
+|   |   |   |-- datafusion-functions v54.0.0
+|   |   |   |-- datafusion-functions v54.0.0 (*)
+|   |   |   |-- datafusion-functions v54.0.0 (*)
+|   |   |   |-- datafusion-functions-aggregate v54.0.0
+|   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |   |-- datafusion-functions-table v54.0.0 (*)
+|   |   |   |-- datafusion-functions-table v54.0.0 (*)
+|   |   |   |-- datafusion-functions-window v54.0.0
+|   |   |   |-- datafusion-functions-window v54.0.0 (*)
+|   |   |   |-- datafusion-optimizer v54.0.0
+|   |   |   |-- datafusion-optimizer v54.0.0 (*)
+|   |   |   |-- datafusion-optimizer v54.0.0 (*)
+|   |   |   |-- datafusion-physical-expr v54.0.0
+|   |   |   |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |   |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |   |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |   |-- datafusion-pruning v54.0.0 (*)
+|   |   |   |-- vortex-alp v0.75.0 (*)
+|   |   |   |-- vortex-alp v0.75.0 (*)
+|   |   |   |-- vortex-alp v0.75.0 (*)
+|   |   |   |-- vortex-array v0.75.0 (*)
+|   |   |   |-- vortex-array v0.75.0 (*)
+|   |   |   |-- vortex-btrblocks v0.75.0 (*)
+|   |   |   |-- vortex-btrblocks v0.75.0 (*)
+|   |   |   |-- vortex-buffer feature "arrow"
+|   |   |   |-- vortex-bytebool v0.75.0 (*)
+|   |   |   |-- vortex-bytebool v0.75.0 (*)
+|   |   |   |-- vortex-compressor v0.75.0 (*)
+|   |   |   |-- vortex-compressor v0.75.0 (*)
+|   |   |   |-- vortex-datetime-parts v0.75.0 (*)
+|   |   |   |-- vortex-datetime-parts v0.75.0 (*)
+|   |   |   |-- vortex-decimal-byte-parts v0.75.0 (*)
+|   |   |   |-- vortex-decimal-byte-parts v0.75.0 (*)
+|   |   |   |-- vortex-fastlanes v0.75.0 (*)
+|   |   |   |-- vortex-fastlanes v0.75.0 (*)
+|   |   |   |-- vortex-file v0.75.0 (*)
+|   |   |   |-- vortex-file v0.75.0 (*)
+|   |   |   |-- vortex-flatbuffers v0.75.0
+|   |   |   |-- vortex-fsst v0.75.0 (*)
+|   |   |   |-- vortex-fsst v0.75.0 (*)
+|   |   |   |-- vortex-io v0.75.0 (*)
+|   |   |   |-- vortex-io v0.75.0 (*)
+|   |   |   |-- vortex-layout v0.75.0 (*)
+|   |   |   |-- vortex-layout v0.75.0 (*)
+|   |   |   |-- vortex-pco v0.75.0 (*)
+|   |   |   |-- vortex-pco v0.75.0 (*)
+|   |   |   |-- vortex-runend v0.75.0 (*)
+|   |   |   |-- vortex-runend v0.75.0 (*)
+|   |   |   |-- vortex-scan v0.75.0 (*)
+|   |   |   |-- vortex-scan v0.75.0 (*)
+|   |   |   |-- vortex-sequence v0.75.0 (*)
+|   |   |   |-- vortex-sequence v0.75.0 (*)
+|   |   |   |-- vortex-sparse v0.75.0 (*)
+|   |   |   |-- vortex-sparse v0.75.0 (*)
+|   |   |   |-- vortex-utils feature "dashmap"
+|   |   |-- arrow feature "arrow-csv"
+|   |   |-- arrow feature "arrow-ipc"
+|   |   |-- arrow feature "arrow-json"
+|   |   |-- arrow feature "canonical_extension_types" (*)
+|   |   |-- arrow feature "chrono-tz"
+|   |   |-- arrow feature "csv" (*)
+|   |   |-- arrow feature "default" (*)
+|   |   |-- arrow feature "ipc" (*)
+|   |   |-- arrow feature "json" (*)
+|   |   |-- arrow-array feature "chrono-tz"
+|   |   |-- arrow-array feature "default"
+|   |   |-- arrow-data feature "default"
+|   |   |-- datafusion-catalog v54.0.0 (*)
+|   |   |-- datafusion-common feature "default"
+|   |   |-- datafusion-common feature "object_store"
+|   |   |-- datafusion-common feature "recursive_protection"
+|   |   |-- datafusion-common feature "sql"
+|   |   |-- datafusion-execution v54.0.0
+|   |   |-- datafusion-expr v54.0.0
+|   |   |-- datafusion-expr-common v54.0.0
+|   |   |-- datafusion-functions v54.0.0 (*)
+|   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+|   |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+|   |   |-- datafusion-functions-nested v54.0.0 (*)
+|   |   |-- datafusion-functions-table v54.0.0 (*)
+|   |   |-- datafusion-functions-window v54.0.0 (*)
+|   |   |-- datafusion-functions-window-common v54.0.0 (*)
+|   |   |-- datafusion-physical-expr v54.0.0 (*)
+|   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+|   |   |-- datafusion-physical-expr-common v54.0.0 (*)
+|   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+|   |   |-- datafusion-physical-plan v54.0.0 (*)
+|   |   |-- vortex-alp v0.75.0 (*)
+|   |   |-- vortex-btrblocks v0.75.0 (*)
+|   |   |-- vortex-buffer v0.75.0
+|   |   |-- vortex-bytebool v0.75.0 (*)
+|   |   |-- vortex-compressor v0.75.0 (*)
+|   |   |-- vortex-datetime-parts v0.75.0 (*)
+|   |   |-- vortex-decimal-byte-parts v0.75.0 (*)
+|   |   |-- vortex-fastlanes v0.75.0 (*)
+|   |   |-- vortex-file v0.75.0 (*)
+|   |   |-- vortex-flatbuffers v0.75.0 (*)
+|   |   |-- vortex-fsst v0.75.0 (*)
+|   |   |-- vortex-io v0.75.0 (*)
+|   |   |-- vortex-layout v0.75.0 (*)
+|   |   |-- vortex-mask v0.75.0 (*)
+|   |   |-- vortex-pco v0.75.0 (*)
+|   |   |-- vortex-runend v0.75.0 (*)
+|   |   |-- vortex-scan v0.75.0 (*)
+|   |   |-- vortex-sequence v0.75.0 (*)
+|   |   |-- vortex-session v0.75.0
+|   |   |-- vortex-sparse v0.75.0 (*)
+|   |   |-- vortex-utils v0.75.0
+|   |-- arrow v58.3.0
+|   |-- arrow-arith v58.3.0
+|   |-- arrow-array v58.3.0
+|   |-- arrow-cast v58.3.0 (*)
+|   |-- arrow-csv v58.3.0 (*)
+|   |-- arrow-data v58.3.0
+|   |-- arrow-ipc v58.3.0 (*)
+|   |-- arrow-json v58.3.0 (*)
+|   |-- arrow-ord v58.3.0 (*)
+|   |-- arrow-row v58.3.0 (*)
+|   |-- arrow-select v58.3.0 (*)
+|   |-- arrow-string v58.3.0 (*)
+|   |-- datafusion v54.0.0 (*)
+|   |-- datafusion-common v54.0.0
+|   |-- datafusion-expr v54.0.0 (*)
+|   |-- vortex-array v0.75.0 (*)
+|   |-- vortex-error v0.75.0
+|-- arrow-schema feature "bitflags"
+|-- arrow-schema feature "canonical_extension_types"
+|-- arrow-schema feature "default"

--- a/tessera/tests/feature-snapshots/blake3.txt
+++ b/tessera/tests/feature-snapshots/blake3.txt
@@ -1,0 +1,38 @@
+    `-- blake3 feature "mmap" (*)
+    |-- blake3 feature "default" (*)
+`-- blake3 feature "std"
+blake3 v1.8.5
+|   `-- tessera-io vWORKSPACE (*)
+|   `-- tessera-io vWORKSPACE (*)
+|   `-- tessera-io vWORKSPACE (*)
+|   |       `-- tessera-core feature "full" (command-line)
+|   |   `-- tessera-core feature "table-arrow" (command-line)
+|   |   |       `-- tessera-wasm feature "default" (command-line)
+|   |   |   `-- tessera-core feature "full" (command-line)
+|   |   |   `-- tessera-wasm vWORKSPACE
+|   |   |   |           `-- tessera-py feature "default" (command-line)
+|   |   |   |       `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |   |       `-- tessera-py vWORKSPACE
+|   |   |   |       |-- tessera-cli vWORKSPACE (*)
+|   |   |   |       |-- tessera-ingest vWORKSPACE (*)
+|   |   |   |   `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |   |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|   |   |   |   `-- tessera-io feature "default" (command-line)
+|   |   |   |   |   `-- tessera-cli feature "cloud" (command-line)
+|   |   |   |   |   `-- tessera-cli vWORKSPACE (*)
+|   |   |   |   |-- tessera-cli feature "cloud" (command-line)
+|   |   |   |   |-- tessera-cli feature "default" (command-line)
+|   |   |   |   |-- tessera-cli feature "sql" (command-line)
+|   |   |   |   |-- tessera-ingest feature "default" (command-line)
+|   |   |   |   |-- tessera-io feature "cloud" (command-line)
+|   |   |   |-- tessera-cli vWORKSPACE
+|   |   |   |-- tessera-ingest vWORKSPACE
+|   |   |   |-- tessera-io vWORKSPACE
+|   |   |   |-- tessera-py vWORKSPACE (*)
+|   |   |-- tessera-core feature "array-zarr" (command-line)
+|   |   |-- tessera-core feature "default" (command-line)
+|   |   |-- tessera-core feature "full" (command-line)
+|   |-- tessera-core vWORKSPACE
+|-- blake3 feature "default"
+|-- blake3 feature "mmap"
+|-- blake3 feature "rayon"

--- a/tessera/tests/feature-snapshots/pco.txt
+++ b/tessera/tests/feature-snapshots/pco.txt
@@ -1,0 +1,37 @@
+            `-- tessera-io vWORKSPACE (*)
+        `-- zarrs feature "zstd"
+        |   `-- tessera-io vWORKSPACE (*)
+        |-- zarrs feature "pcodec"
+    `-- zarrs v0.23.13
+    |           `-- tessera-io vWORKSPACE (*)
+    |       `-- tessera-io vWORKSPACE (*)
+    |       `-- vortex-file v0.75.0 (*)
+    |       `-- vortex-layout feature "default"
+    |   `-- vortex-btrblocks feature "pco"
+    |   `-- vortex-file v0.75.0 (*)
+    |   `-- vortex-layout v0.75.0
+    |   |                   `-- tessera-py feature "default" (command-line)
+    |   |               `-- tessera-py vWORKSPACE
+    |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+    |   |               |   `-- tessera-cli feature "static-hdf5" (command-line)
+    |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+    |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+    |   |               |   |-- tessera-cli feature "cloud" (command-line)
+    |   |               |   |-- tessera-cli feature "default" (command-line)
+    |   |               |   |-- tessera-cli feature "sql" (command-line)
+    |   |               |   |-- tessera-ingest feature "default" (command-line)
+    |   |               |-- tessera-cli vWORKSPACE
+    |   |               |-- tessera-ingest vWORKSPACE
+    |   |           `-- tessera-io feature "default" (command-line)
+    |   |           |   `-- tessera-cli feature "cloud" (command-line)
+    |   |           |-- tessera-io feature "cloud" (command-line)
+    |   |       `-- tessera-io vWORKSPACE
+    |   |   `-- tessera-io vWORKSPACE (*)
+    |   |   `-- vortex-file feature "default"
+    |   |-- vortex-btrblocks feature "default"
+    |   |-- vortex-btrblocks v0.75.0 (*)
+    |   |-- vortex-file v0.75.0
+    |-- vortex-btrblocks v0.75.0
+    |-- vortex-pco v0.75.0
+`-- pco feature "default"
+pco v1.0.2

--- a/tessera/tests/feature-snapshots/vortex-array.txt
+++ b/tessera/tests/feature-snapshots/vortex-array.txt
@@ -1,0 +1,77 @@
+    `-- tessera-io vWORKSPACE (*)
+    `-- vortex-file v0.75.0 (*)
+    |-- vortex-btrblocks v0.75.0 (*)
+`-- vortex-array feature "default"
+`-- vortex-zigzag v0.75.0
+vortex-array v0.75.0
+|       `-- tessera-io vWORKSPACE (*)
+|   `-- vortex-btrblocks v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-io feature "default"
+|   `-- vortex-layout v0.75.0 (*)
+|   `-- vortex-layout v0.75.0 (*)
+|   `-- vortex-layout v0.75.0 (*)
+|   `-- vortex-layout v0.75.0 (*)
+|   |           `-- tessera-io vWORKSPACE (*)
+|   |       `-- tessera-io vWORKSPACE (*)
+|   |       `-- vortex-file v0.75.0 (*)
+|   |       `-- vortex-layout feature "default"
+|   |   `-- vortex-btrblocks feature "pco"
+|   |   `-- vortex-layout v0.75.0
+|   |   |                   `-- tessera-py feature "default" (command-line)
+|   |   |               `-- tessera-py vWORKSPACE
+|   |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |               |   `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|   |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+|   |   |               |   |-- tessera-cli feature "cloud" (command-line)
+|   |   |               |   |-- tessera-cli feature "default" (command-line)
+|   |   |               |   |-- tessera-cli feature "sql" (command-line)
+|   |   |               |   |-- tessera-ingest feature "default" (command-line)
+|   |   |               |-- tessera-cli vWORKSPACE
+|   |   |               |-- tessera-ingest vWORKSPACE
+|   |   |           `-- tessera-io feature "default" (command-line)
+|   |   |           |   `-- tessera-cli feature "cloud" (command-line)
+|   |   |           |-- tessera-io feature "cloud" (command-line)
+|   |   |       `-- tessera-io vWORKSPACE
+|   |   |   `-- tessera-io vWORKSPACE (*)
+|   |   |   `-- vortex-file feature "default"
+|   |   |-- vortex-btrblocks feature "default"
+|   |   |-- vortex-file v0.75.0
+|   |-- vortex-alp v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-file v0.75.0 (*)
+|   |-- vortex-file v0.75.0 (*)
+|   |-- vortex-file v0.75.0 (*)
+|   |-- vortex-file v0.75.0 (*)
+|-- vortex-alp v0.75.0
+|-- vortex-btrblocks v0.75.0 (*)
+|-- vortex-bytebool v0.75.0
+|-- vortex-compressor v0.75.0
+|-- vortex-datetime-parts v0.75.0
+|-- vortex-decimal-byte-parts v0.75.0
+|-- vortex-fastlanes v0.75.0
+|-- vortex-file v0.75.0 (*)
+|-- vortex-fsst v0.75.0
+|-- vortex-io v0.75.0
+|-- vortex-layout v0.75.0 (*)
+|-- vortex-pco v0.75.0
+|-- vortex-runend v0.75.0
+|-- vortex-scan v0.75.0
+|-- vortex-sequence v0.75.0
+|-- vortex-sparse v0.75.0

--- a/tessera/tests/feature-snapshots/vortex-btrblocks.txt
+++ b/tessera/tests/feature-snapshots/vortex-btrblocks.txt
@@ -1,0 +1,27 @@
+        `-- tessera-io vWORKSPACE (*)
+    `-- tessera-io vWORKSPACE (*)
+    `-- vortex-file v0.75.0 (*)
+    `-- vortex-layout feature "default"
+`-- vortex-btrblocks feature "pco"
+`-- vortex-layout v0.75.0
+vortex-btrblocks v0.75.0
+|                   `-- tessera-py feature "default" (command-line)
+|               `-- tessera-py vWORKSPACE
+|               |       `-- tessera-cli feature "static-hdf5" (command-line)
+|               |   `-- tessera-cli feature "static-hdf5" (command-line)
+|               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|               |   |   `-- tessera-cli vWORKSPACE (*)
+|               |   |-- tessera-cli feature "cloud" (command-line)
+|               |   |-- tessera-cli feature "default" (command-line)
+|               |   |-- tessera-cli feature "sql" (command-line)
+|               |   |-- tessera-ingest feature "default" (command-line)
+|               |-- tessera-cli vWORKSPACE
+|               |-- tessera-ingest vWORKSPACE
+|           `-- tessera-io feature "default" (command-line)
+|           |   `-- tessera-cli feature "cloud" (command-line)
+|           |-- tessera-io feature "cloud" (command-line)
+|       `-- tessera-io vWORKSPACE
+|   `-- tessera-io vWORKSPACE (*)
+|   `-- vortex-file feature "default"
+|-- vortex-btrblocks feature "default"
+|-- vortex-file v0.75.0

--- a/tessera/tests/feature-snapshots/vortex-buffer.txt
+++ b/tessera/tests/feature-snapshots/vortex-buffer.txt
@@ -1,0 +1,129 @@
+    `-- tessera-io vWORKSPACE (*)
+`-- vortex-buffer feature "default"
+`-- vortex-zigzag v0.75.0 (*)
+vortex-buffer v0.75.0
+|       `-- vortex-zigzag v0.75.0 (*)
+|       |-- vortex-alp v0.75.0 (*)
+|       |-- vortex-array v0.75.0 (*)
+|       |-- vortex-bytebool v0.75.0 (*)
+|       |-- vortex-compressor v0.75.0 (*)
+|       |-- vortex-datetime-parts v0.75.0 (*)
+|       |-- vortex-decimal-byte-parts v0.75.0 (*)
+|       |-- vortex-fastlanes v0.75.0 (*)
+|       |-- vortex-file v0.75.0 (*)
+|       |-- vortex-fsst v0.75.0 (*)
+|       |-- vortex-layout v0.75.0 (*)
+|       |-- vortex-pco v0.75.0 (*)
+|       |-- vortex-runend v0.75.0 (*)
+|       |-- vortex-scan v0.75.0 (*)
+|       |-- vortex-sequence v0.75.0 (*)
+|       |-- vortex-sparse v0.75.0 (*)
+|   `-- vortex-btrblocks v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-file v0.75.0 (*)
+|   `-- vortex-flatbuffers feature "layout" (*)
+|   `-- vortex-mask v0.75.0
+|   |           `-- tessera-io vWORKSPACE (*)
+|   |           `-- tessera-io vWORKSPACE (*)
+|   |           `-- vortex-file v0.75.0 (*)
+|   |           |-- vortex-btrblocks v0.75.0 (*)
+|   |       `-- tessera-io vWORKSPACE (*)
+|   |       `-- vortex-array feature "default"
+|   |       `-- vortex-file v0.75.0 (*)
+|   |       `-- vortex-layout feature "default"
+|   |       `-- vortex-layout v0.75.0 (*)
+|   |       `-- vortex-zigzag v0.75.0
+|   |       |       `-- tessera-io vWORKSPACE (*)
+|   |       |   `-- vortex-file v0.75.0 (*)
+|   |       |   `-- vortex-file v0.75.0 (*)
+|   |       |   `-- vortex-file v0.75.0 (*)
+|   |       |   `-- vortex-io feature "default"
+|   |       |   `-- vortex-layout v0.75.0 (*)
+|   |       |   `-- vortex-layout v0.75.0 (*)
+|   |       |   `-- vortex-layout v0.75.0 (*)
+|   |       |   `-- vortex-layout v0.75.0 (*)
+|   |       |   |-- vortex-btrblocks v0.75.0 (*)
+|   |       |   |-- vortex-btrblocks v0.75.0 (*)
+|   |       |   |-- vortex-btrblocks v0.75.0 (*)
+|   |       |   |-- vortex-btrblocks v0.75.0 (*)
+|   |       |   |-- vortex-btrblocks v0.75.0 (*)
+|   |       |   |-- vortex-file v0.75.0 (*)
+|   |       |   |-- vortex-file v0.75.0 (*)
+|   |       |   |-- vortex-file v0.75.0 (*)
+|   |       |   |-- vortex-file v0.75.0 (*)
+|   |       |-- vortex-alp v0.75.0 (*)
+|   |       |-- vortex-btrblocks v0.75.0 (*)
+|   |       |-- vortex-bytebool v0.75.0 (*)
+|   |       |-- vortex-compressor v0.75.0 (*)
+|   |       |-- vortex-datetime-parts v0.75.0 (*)
+|   |       |-- vortex-decimal-byte-parts v0.75.0 (*)
+|   |       |-- vortex-fastlanes v0.75.0 (*)
+|   |       |-- vortex-file v0.75.0 (*)
+|   |       |-- vortex-fsst v0.75.0
+|   |       |-- vortex-io v0.75.0
+|   |       |-- vortex-layout v0.75.0 (*)
+|   |       |-- vortex-pco v0.75.0
+|   |       |-- vortex-runend v0.75.0
+|   |       |-- vortex-scan v0.75.0
+|   |       |-- vortex-sequence v0.75.0
+|   |       |-- vortex-sparse v0.75.0
+|   |   `-- vortex-array v0.75.0
+|   |   `-- vortex-array v0.75.0 (*)
+|   |   `-- vortex-btrblocks feature "pco"
+|   |   `-- vortex-flatbuffers feature "array" (*)
+|   |   `-- vortex-flatbuffers feature "layout"
+|   |   `-- vortex-layout v0.75.0
+|   |   |                   `-- tessera-py feature "default" (command-line)
+|   |   |               `-- tessera-py vWORKSPACE
+|   |   |               |       `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |               |   `-- tessera-cli feature "static-hdf5" (command-line)
+|   |   |               |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|   |   |               |   |   `-- tessera-cli vWORKSPACE (*)
+|   |   |               |   |-- tessera-cli feature "cloud" (command-line)
+|   |   |               |   |-- tessera-cli feature "default" (command-line)
+|   |   |               |   |-- tessera-cli feature "sql" (command-line)
+|   |   |               |   |-- tessera-ingest feature "default" (command-line)
+|   |   |               |-- tessera-cli vWORKSPACE
+|   |   |               |-- tessera-ingest vWORKSPACE
+|   |   |           `-- tessera-io feature "default" (command-line)
+|   |   |           |   `-- tessera-cli feature "cloud" (command-line)
+|   |   |           |-- tessera-io feature "cloud" (command-line)
+|   |   |       `-- tessera-io vWORKSPACE
+|   |   |       `-- vortex-file v0.75.0 (*)
+|   |   |   `-- tessera-io vWORKSPACE (*)
+|   |   |   `-- vortex-file feature "default"
+|   |   |   `-- vortex-flatbuffers feature "file"
+|   |   |-- vortex-btrblocks feature "default"
+|   |   |-- vortex-file v0.75.0
+|   |   |-- vortex-flatbuffers feature "ipc"
+|   |-- vortex-alp v0.75.0 (*)
+|   |-- vortex-array v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-btrblocks v0.75.0 (*)
+|   |-- vortex-flatbuffers feature "array"
+|   |-- vortex-flatbuffers feature "dtype"
+|   |-- vortex-flatbuffers feature "file" (*)
+|   |-- vortex-flatbuffers feature "ipc" (*)
+|-- vortex-alp v0.75.0
+|-- vortex-btrblocks v0.75.0 (*)
+|-- vortex-buffer feature "arrow"
+|-- vortex-bytebool v0.75.0
+|-- vortex-compressor v0.75.0
+|-- vortex-datetime-parts v0.75.0
+|-- vortex-decimal-byte-parts v0.75.0
+|-- vortex-fastlanes v0.75.0
+|-- vortex-file v0.75.0 (*)
+|-- vortex-flatbuffers v0.75.0
+|-- vortex-fsst v0.75.0 (*)
+|-- vortex-io v0.75.0 (*)
+|-- vortex-layout v0.75.0 (*)
+|-- vortex-pco v0.75.0 (*)
+|-- vortex-runend v0.75.0 (*)
+|-- vortex-scan v0.75.0 (*)
+|-- vortex-sequence v0.75.0 (*)
+|-- vortex-sparse v0.75.0 (*)

--- a/tessera/tests/feature-snapshots/vortex-file.txt
+++ b/tessera/tests/feature-snapshots/vortex-file.txt
@@ -1,0 +1,18 @@
+                `-- tessera-py feature "default" (command-line)
+            `-- tessera-py vWORKSPACE
+            |       `-- tessera-cli feature "static-hdf5" (command-line)
+            |   `-- tessera-cli feature "static-hdf5" (command-line)
+            |   `-- tessera-ingest feature "static-hdf5" (command-line)
+            |   |   `-- tessera-cli vWORKSPACE (*)
+            |   |-- tessera-cli feature "cloud" (command-line)
+            |   |-- tessera-cli feature "default" (command-line)
+            |   |-- tessera-cli feature "sql" (command-line)
+            |   |-- tessera-ingest feature "default" (command-line)
+            |-- tessera-cli vWORKSPACE
+            |-- tessera-ingest vWORKSPACE
+        `-- tessera-io feature "default" (command-line)
+        |   `-- tessera-cli feature "cloud" (command-line)
+        |-- tessera-io feature "cloud" (command-line)
+    `-- tessera-io vWORKSPACE
+`-- vortex-file feature "default"
+vortex-file v0.75.0

--- a/tessera/tests/feature-snapshots/zarrs.txt
+++ b/tessera/tests/feature-snapshots/zarrs.txt
@@ -1,0 +1,20 @@
+    `-- tessera-io vWORKSPACE (*)
+`-- zarrs feature "zstd"
+zarrs v0.23.13
+|               `-- tessera-py feature "default" (command-line)
+|           `-- tessera-py vWORKSPACE
+|           |       `-- tessera-cli feature "static-hdf5" (command-line)
+|           |   `-- tessera-cli feature "static-hdf5" (command-line)
+|           |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|           |   |   `-- tessera-cli vWORKSPACE (*)
+|           |   |-- tessera-cli feature "cloud" (command-line)
+|           |   |-- tessera-cli feature "default" (command-line)
+|           |   |-- tessera-cli feature "sql" (command-line)
+|           |   |-- tessera-ingest feature "default" (command-line)
+|           |-- tessera-cli vWORKSPACE
+|           |-- tessera-ingest vWORKSPACE
+|       `-- tessera-io feature "default" (command-line)
+|       |   `-- tessera-cli feature "cloud" (command-line)
+|       |-- tessera-io feature "cloud" (command-line)
+|   `-- tessera-io vWORKSPACE
+|-- zarrs feature "pcodec"

--- a/tessera/tests/feature-snapshots/zstd.txt
+++ b/tessera/tests/feature-snapshots/zstd.txt
@@ -1,0 +1,365 @@
+        `-- datafusion-physical-plan v54.0.0 (*)
+        |-- datafusion-common v54.0.0 (*)
+        |-- datafusion-datasource-arrow v54.0.0 (*)
+    `-- arrow-ipc feature "zstd"
+    `-- zarrs v0.23.13 (*)
+    |           `-- datafusion-sql v54.0.0 (*)
+    |           |-- datafusion v54.0.0 (*)
+    |           |-- datafusion-catalog v54.0.0 (*)
+    |           |-- datafusion-catalog-listing v54.0.0 (*)
+    |           |-- datafusion-common v54.0.0 (*)
+    |           |-- datafusion-datasource v54.0.0 (*)
+    |           |-- datafusion-datasource-arrow v54.0.0 (*)
+    |           |-- datafusion-datasource-csv v54.0.0 (*)
+    |           |-- datafusion-datasource-json v54.0.0 (*)
+    |           |-- datafusion-execution v54.0.0 (*)
+    |           |-- datafusion-expr v54.0.0 (*)
+    |           |-- datafusion-expr-common v54.0.0 (*)
+    |           |-- datafusion-functions v54.0.0 (*)
+    |           |-- datafusion-functions-aggregate v54.0.0 (*)
+    |           |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |           |-- datafusion-functions-nested v54.0.0 (*)
+    |           |-- datafusion-functions-table v54.0.0 (*)
+    |           |-- datafusion-functions-window v54.0.0 (*)
+    |           |-- datafusion-optimizer v54.0.0 (*)
+    |           |-- datafusion-physical-expr v54.0.0 (*)
+    |           |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |           |-- datafusion-physical-expr-common v54.0.0 (*)
+    |           |-- datafusion-physical-optimizer v54.0.0 (*)
+    |           |-- datafusion-physical-plan v54.0.0 (*)
+    |           |-- datafusion-pruning v54.0.0 (*)
+    |       `-- arrow feature "prettyprint"
+    |       |           `-- datafusion-sql v54.0.0 (*)
+    |       |           `-- tessera-cli feature "static-hdf5" (command-line)
+    |       |           |               `-- datafusion v54.0.0 (*)
+    |       |           |           `-- datafusion-functions-table feature "default"
+    |       |           |       `-- datafusion feature "sql" (*)
+    |       |           |       `-- datafusion-common feature "sql" (*)
+    |       |           |       `-- datafusion-functions-table v54.0.0
+    |       |           |       |       `-- datafusion v54.0.0 (*)
+    |       |           |       |   `-- datafusion-catalog-listing feature "default"
+    |       |           |       |-- datafusion v54.0.0 (*)
+    |       |           |       |-- datafusion-catalog-listing v54.0.0
+    |       |           |   `-- datafusion feature "sqlparser"
+    |       |           |   `-- datafusion-catalog feature "default"
+    |       |           |   `-- datafusion-common feature "sqlparser"
+    |       |           |   `-- datafusion-session v54.0.0 (*)
+    |       |           |   |       `-- datafusion-expr feature "sql" (*)
+    |       |           |   |       `-- datafusion-pruning v54.0.0 (*)
+    |       |           |   |       `-- tessera-cli vWORKSPACE (*)
+    |       |           |   |       |       `-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |       |       |-- datafusion-expr v54.0.0 (*)
+    |       |           |   |       |       |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |   |       |       |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |       |       |-- datafusion-physical-expr v54.0.0 (*)
+    |       |           |   |       |   `-- datafusion-functions-aggregate-common feature "default"
+    |       |           |   |       |   `-- datafusion-pruning v54.0.0 (*)
+    |       |           |   |       |   |       `-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |       |   |       |-- datafusion-expr v54.0.0 (*)
+    |       |           |   |       |   |       |-- datafusion-functions-window v54.0.0 (*)
+    |       |           |   |       |   |   `-- datafusion-functions-window-common feature "default"
+    |       |           |   |       |   |-- datafusion v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-execution v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-expr v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions-window v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-functions-window-common v54.0.0
+    |       |           |   |       |   |-- datafusion-physical-expr v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |       |   |-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |       |-- datafusion v54.0.0 (*)
+    |       |           |   |       |-- datafusion-expr v54.0.0 (*)
+    |       |           |   |       |-- datafusion-functions v54.0.0 (*)
+    |       |           |   |       |-- datafusion-functions-aggregate-common v54.0.0
+    |       |           |   |       |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |       |-- datafusion-optimizer v54.0.0 (*)
+    |       |           |   |       |-- datafusion-physical-expr v54.0.0 (*)
+    |       |           |   |       |-- datafusion-physical-expr-common v54.0.0
+    |       |           |   |       |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |   `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   `-- datafusion feature "sql"
+    |       |           |   |   `-- datafusion feature "sql" (*)
+    |       |           |   |   `-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |   `-- datafusion-expr feature "sqlparser"
+    |       |           |   |   `-- datafusion-expr-common feature "default"
+    |       |           |   |   `-- datafusion-pruning v54.0.0 (*)
+    |       |           |   |   `-- datafusion-session v54.0.0 (*)
+    |       |           |   |   `-- datafusion-session v54.0.0 (*)
+    |       |           |   |   `-- datafusion-sql v54.0.0 (*)
+    |       |           |   |   `-- tessera-cli vWORKSPACE (*)
+    |       |           |   |   |                   `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   |               `-- datafusion-physical-optimizer feature "recursive_protection"
+    |       |           |   |   |               |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |               |-- datafusion-physical-optimizer feature "default"
+    |       |           |   |   |           `-- datafusion-physical-optimizer v54.0.0
+    |       |           |   |   |       `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   |       `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   |       `-- datafusion v54.0.0 (*)
+    |       |           |   |   |       `-- datafusion-functions feature "string_expressions" (*)
+    |       |           |   |   |       `-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |   |       `-- datafusion-pruning feature "default"
+    |       |           |   |   |       |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |   `-- datafusion-functions feature "uuid"
+    |       |           |   |   |   `-- datafusion-functions-aggregate feature "default"
+    |       |           |   |   |   `-- datafusion-functions-nested feature "sql" (*)
+    |       |           |   |   |   `-- datafusion-functions-window feature "default"
+    |       |           |   |   |   `-- datafusion-optimizer feature "recursive_protection"
+    |       |           |   |   |   `-- datafusion-physical-expr feature "recursive_protection"
+    |       |           |   |   |   `-- datafusion-pruning v54.0.0
+    |       |           |   |   |   `-- datafusion-pruning v54.0.0 (*)
+    |       |           |   |   |   `-- datafusion-sql v54.0.0 (*)
+    |       |           |   |   |   |                           `-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |   |   |                           |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |                           |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |   |                           |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |   |                           |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |   |   |                           |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |   |   |                       `-- datafusion-session feature "default"
+    |       |           |   |   |   |                   `-- datafusion-session v54.0.0
+    |       |           |   |   |   |                   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-functions-table v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |   |   |                   |-- datafusion-pruning v54.0.0 (*)
+    |       |           |   |   |   |               `-- datafusion-physical-plan feature "default"
+    |       |           |   |   |   |           `-- datafusion-physical-plan v54.0.0
+    |       |           |   |   |   |           |               `-- datafusion-sql feature "default" (*)
+    |       |           |   |   |   |           |           `-- datafusion-sql feature "unparser"
+    |       |           |   |   |   |           |           |   `-- datafusion feature "recursive_protection" (*)
+    |       |           |   |   |   |           |           |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |           |           |   `-- datafusion-sql feature "default" (*)
+    |       |           |   |   |   |           |           |-- datafusion-sql feature "default"
+    |       |           |   |   |   |           |           |-- datafusion-sql feature "recursive_protection"
+    |       |           |   |   |   |           |           |-- datafusion-sql feature "unicode_expressions"
+    |       |           |   |   |   |           |       `-- datafusion-sql v54.0.0
+    |       |           |   |   |   |           |   `-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |   |           |   `-- datafusion-functions-nested feature "sql"
+    |       |           |   |   |   |           |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |           |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |   |           |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |           |-- datafusion-functions-nested v54.0.0
+    |       |           |   |   |   |           |-- datafusion-physical-expr-adapter v54.0.0
+    |       |           |   |   |   |       `-- datafusion-functions feature "default"
+    |       |           |   |   |   |       `-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |       `-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |   `-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |   `-- datafusion-functions feature "datetime_expressions"
+    |       |           |   |   |   |   `-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |   `-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |   `-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |   `-- datafusion-functions feature "encoding_expressions"
+    |       |           |   |   |   |   `-- datafusion-functions feature "encoding_expressions" (*)
+    |       |           |   |   |   |   `-- datafusion-functions feature "regex_expressions"
+    |       |           |   |   |   |   `-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-datasource-arrow v54.0.0
+    |       |           |   |   |   |-- datafusion-datasource-csv v54.0.0
+    |       |           |   |   |   |-- datafusion-datasource-json v54.0.0
+    |       |           |   |   |   |-- datafusion-functions feature "base64"
+    |       |           |   |   |   |-- datafusion-functions feature "chrono-tz"
+    |       |           |   |   |   |-- datafusion-functions feature "datetime_expressions" (*)
+    |       |           |   |   |   |-- datafusion-functions feature "default" (*)
+    |       |           |   |   |   |-- datafusion-functions feature "encoding_expressions" (*)
+    |       |           |   |   |   |-- datafusion-functions feature "hex"
+    |       |           |   |   |   |-- datafusion-functions feature "math_expressions"
+    |       |           |   |   |   |-- datafusion-functions feature "regex"
+    |       |           |   |   |   |-- datafusion-functions feature "regex_expressions" (*)
+    |       |           |   |   |   |-- datafusion-functions feature "string_expressions"
+    |       |           |   |   |   |-- datafusion-functions feature "unicode_expressions"
+    |       |           |   |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-functions-table v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-functions-window v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-optimizer v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-physical-expr feature "default"
+    |       |           |   |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |           |   |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |-- datafusion v54.0.0 (*)
+    |       |           |   |   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource v54.0.0
+    |       |           |   |   |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |   |-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |   |   |-- datafusion-execution v54.0.0 (*)
+    |       |           |   |   |-- datafusion-expr feature "recursive_protection"
+    |       |           |   |   |-- datafusion-expr feature "sql"
+    |       |           |   |   |-- datafusion-functions v54.0.0
+    |       |           |   |   |-- datafusion-functions v54.0.0 (*)
+    |       |           |   |   |-- datafusion-functions-aggregate v54.0.0
+    |       |           |   |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |   |   |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |   |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |   |-- datafusion-functions-table v54.0.0 (*)
+    |       |           |   |   |-- datafusion-functions-window v54.0.0
+    |       |           |   |   |-- datafusion-optimizer v54.0.0
+    |       |           |   |   |-- datafusion-optimizer v54.0.0 (*)
+    |       |           |   |   |-- datafusion-physical-expr v54.0.0
+    |       |           |   |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |           |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |   |-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |   |-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |   |-- datafusion feature "datafusion-sql"
+    |       |           |   |-- datafusion feature "recursive_protection"
+    |       |           |   |-- datafusion feature "sql" (*)
+    |       |           |   |-- datafusion-catalog v54.0.0 (*)
+    |       |           |   |-- datafusion-common feature "default"
+    |       |           |   |-- datafusion-common feature "object_store"
+    |       |           |   |-- datafusion-common feature "recursive_protection"
+    |       |           |   |-- datafusion-common feature "sql"
+    |       |           |   |-- datafusion-execution v54.0.0
+    |       |           |   |-- datafusion-expr v54.0.0
+    |       |           |   |-- datafusion-expr-common v54.0.0
+    |       |           |   |-- datafusion-functions v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-table v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-window v54.0.0 (*)
+    |       |           |   |-- datafusion-functions-window-common v54.0.0 (*)
+    |       |           |   |-- datafusion-physical-expr v54.0.0 (*)
+    |       |           |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |           |   |-- datafusion-physical-expr-common v54.0.0 (*)
+    |       |           |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |   |-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |-- datafusion v54.0.0
+    |       |           |-- datafusion-catalog v54.0.0
+    |       |           |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |           |-- datafusion-common v54.0.0
+    |       |           |-- datafusion-datasource v54.0.0 (*)
+    |       |           |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |           |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |           |-- datafusion-datasource-json v54.0.0 (*)
+    |       |           |-- datafusion-execution v54.0.0 (*)
+    |       |           |-- datafusion-expr v54.0.0 (*)
+    |       |           |-- datafusion-expr-common v54.0.0 (*)
+    |       |           |-- datafusion-functions v54.0.0 (*)
+    |       |           |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |           |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |       |           |-- datafusion-functions-nested v54.0.0 (*)
+    |       |           |-- datafusion-functions-table v54.0.0 (*)
+    |       |           |-- datafusion-functions-window v54.0.0 (*)
+    |       |           |-- datafusion-optimizer v54.0.0 (*)
+    |       |           |-- datafusion-physical-expr v54.0.0 (*)
+    |       |           |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |           |-- datafusion-physical-expr-common v54.0.0 (*)
+    |       |           |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |           |-- datafusion-physical-plan v54.0.0 (*)
+    |       |           |-- datafusion-pruning v54.0.0 (*)
+    |       |           |-- tessera-cli feature "cloud" (command-line)
+    |       |           |-- tessera-cli feature "default" (command-line)
+    |       |           |-- tessera-cli feature "sql" (command-line)
+    |       |       `-- arrow feature "default"
+    |       |       `-- arrow feature "default" (*)
+    |       |       `-- arrow feature "default" (*)
+    |       |       `-- tessera-cli vWORKSPACE
+    |       |   `-- arrow feature "csv"
+    |       |   `-- arrow feature "ipc"
+    |       |   `-- arrow feature "json"
+    |       |   `-- datafusion-expr v54.0.0 (*)
+    |       |   `-- datafusion-sql v54.0.0 (*)
+    |       |   |-- datafusion v54.0.0 (*)
+    |       |   |-- datafusion-catalog v54.0.0 (*)
+    |       |   |-- datafusion-catalog-listing v54.0.0 (*)
+    |       |   |-- datafusion-common v54.0.0 (*)
+    |       |   |-- datafusion-datasource v54.0.0 (*)
+    |       |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |       |   |-- datafusion-datasource-csv v54.0.0 (*)
+    |       |   |-- datafusion-datasource-json v54.0.0 (*)
+    |       |   |-- datafusion-execution v54.0.0 (*)
+    |       |   |-- datafusion-expr v54.0.0 (*)
+    |       |   |-- datafusion-expr-common v54.0.0 (*)
+    |       |   |-- datafusion-functions v54.0.0 (*)
+    |       |   |-- datafusion-functions-aggregate v54.0.0 (*)
+    |       |   |-- datafusion-functions-aggregate-common v54.0.0 (*)
+    |       |   |-- datafusion-functions-nested v54.0.0 (*)
+    |       |   |-- datafusion-functions-table v54.0.0 (*)
+    |       |   |-- datafusion-functions-window v54.0.0 (*)
+    |       |   |-- datafusion-optimizer v54.0.0 (*)
+    |       |   |-- datafusion-physical-expr v54.0.0 (*)
+    |       |   |-- datafusion-physical-expr-adapter v54.0.0 (*)
+    |       |   |-- datafusion-physical-expr-common v54.0.0 (*)
+    |       |   |-- datafusion-physical-optimizer v54.0.0 (*)
+    |       |   |-- datafusion-physical-plan v54.0.0 (*)
+    |       |   |-- datafusion-pruning v54.0.0 (*)
+    |       |-- arrow feature "arrow-csv"
+    |       |-- arrow feature "arrow-ipc"
+    |       |-- arrow feature "arrow-json"
+    |       |-- arrow feature "canonical_extension_types"
+    |       |-- arrow feature "chrono-tz"
+    |       |-- arrow feature "csv" (*)
+    |       |-- arrow feature "default" (*)
+    |       |-- arrow feature "ipc" (*)
+    |       |-- arrow feature "json" (*)
+    |   `-- arrow v58.3.0
+    |   `-- arrow-ipc feature "lz4" (*)
+    |   `-- datafusion-physical-plan v54.0.0 (*)
+    |   |-- datafusion-common v54.0.0 (*)
+    |   |-- datafusion-datasource-arrow v54.0.0 (*)
+    |-- arrow-ipc feature "default"
+    |-- arrow-ipc feature "lz4"
+    |-- arrow-ipc feature "lz4_flex"
+`-- arrow-ipc v58.3.0
+`-- zstd feature "zstdmt"
+zstd v0.13.3
+|               `-- tessera-io vWORKSPACE (*)
+|           `-- zarrs feature "zstd"
+|           |               `-- tessera-py feature "default" (command-line)
+|           |           `-- tessera-py vWORKSPACE
+|           |           |       `-- tessera-cli feature "static-hdf5" (command-line)
+|           |           |   `-- tessera-ingest feature "static-hdf5" (command-line)
+|           |           |   |   `-- tessera-cli vWORKSPACE (*)
+|           |           |   |-- tessera-ingest feature "default" (command-line)
+|           |           |-- tessera-cli vWORKSPACE (*)
+|           |           |-- tessera-ingest vWORKSPACE
+|           |       `-- tessera-io feature "default" (command-line)
+|           |       |   `-- tessera-cli feature "cloud" (command-line)
+|           |       |-- tessera-io feature "cloud" (command-line)
+|           |   `-- tessera-io vWORKSPACE
+|           |-- zarrs feature "pcodec"
+|       `-- zarrs v0.23.13
+|   `-- zarrs v0.23.13 (*)
+|   `-- zstd feature "default"
+|   `-- zstd feature "default" (*)
+|   `-- zstd feature "default" (*)
+|-- zstd feature "arrays"
+|-- zstd feature "default" (*)
+|-- zstd feature "experimental"
+|-- zstd feature "legacy"
+|-- zstd feature "zdict_builder"


### PR DESCRIPTION
## ADR-0057 Phase 0

Implements the Landing plan's Phase 0 exactly — `tessera info` + Gate B — plus the `static-hdf5`
clippy exclusion the ADR's Consequences section calls for. **Gate A and the §5 feature graph are
Phase 1 and are deliberately not here.**

Three commits, each independently green.

---

### 1. `build(ci)`: drop `static-hdf5` from the PR clippy matrix — #402

`workspace-clippy` ran `--all-targets --all-features`, and `--all-features` pulls
`tessera-cli/static-hdf5 → tessera-ingest/static-hdf5 → hdf5-metno/static`, which builds libhdf5
2.2.0 from vendored source through CMake (`hdf5-metno-src`).

Replaced with an explicit `workspaceFeatures` — every feature declared anywhere in the workspace
except `static-hdf5`, in cargo's `package/feature` form so one invocation from the virtual-manifest
root still covers every member:

```
tessera-core/full (array-zarr + table-arrow) · tessera-io/cloud · tessera-cli/cloud · tessera-cli/sql
```

**Coverage loss is nil, and that is measured rather than asserted.** A full package diff of the two
resolved graphs shows exactly one package difference:

```
$ diff <(cargo tree --features <new set> --prefix none --no-dedupe | sort -u) \
       <(cargo tree --all-features        --prefix none --no-dedupe | sort -u)
219a220
> hdf5-metno-src v0.10.3
```

One crate — the vendored HDF5 CMake build. `static-hdf5` only switches how libhdf5 *links*; there is
not one `#[cfg(feature = "static-hdf5")]` in the tree, and nix supplies libhdf5 from the closure
(`buildInputs`), so every line of hdf5 code still compiles under clippy.

`static-hdf5` stays exercised release-only: `dist-workspace.toml` already sets
`features = ["static-hdf5"]` for the cargo-dist broad channel, which fires on the release-plz tag.

**Baseline for #402's "record the before/after"** — the two most recent full CI runs on `dev`
(docs-only PRs, i.e. cold builds of the same tree):

| run | x86_64-linux | aarch64-linux |
| --- | --- | --- |
| 32351568192 (ADR-0057) | **63m 49s** | 49m 14s |
| 32272709927 | **46m 40s** | 46m 19s |

This PR's own CI run is the "after" number, on both arches.

> **#402 P1 stays open, and it is the other half of this change:** a PR can now break the vendored
> HDF5 build and go green, because `dist` only *plans* on PRs and only *builds* on a release tag. The
> scheduled/release-gated static build named in #402 P1 should follow.

### 2. `test(ci)`: Gate B — the feature-snapshot determinism gate — #400

Cargo feature unification is monotonic: enabling a feature anywhere can only *add* features. So an
optional feature on an apparently unrelated crate can silently change what the encoder does. Two live
instances, both named by ADR-0057 §5:

- the optional `sql` feature already turns on `arrow-array/chrono-tz` — ADR-0056 hazard **H1** (tzdb
  as a compiled-in dependency vs. the host's `/usr/share/zoneinfo`), rated *high × fatal* — arriving
  through a **feature** rather than through a host, the one door §5 had not closed;
- the workspace pins `vortex-btrblocks = { features = ["pco"] }` specifically to **exclude** ALP,
  which was not byte-deterministic (#380/#384).

Gate A (Phase 1) tells you the day the goldens moved. Gate B tells you the day the *risk* was
introduced, on the PR that introduced it.

- `scripts/feature-snapshots.sh` — the single source of truth for the seal-path crate list and the
  invocation, for both the CI check and a developer regenerating the baseline.
- `tessera/tests/feature-snapshots/*.txt` — the baseline against today's graph, which **deliberately
  captures `arrow-array feature "chrono-tz"`** rather than leaving it to be found later. Plus a
  README stating that a changed snapshot is a *deliberate corpus event*, reviewed like a change to
  `corpus/corpus.json`.
- a `feature-snapshots` flake check that regenerates into a temp dir and `diff`s — the hermetic
  equivalent of the ADR's `git diff --exit-code` (there is no `.git` inside the nix sandbox). It
  compiles nothing (`cargoArtifacts = null`), so it is nearly free.
- `tests/feature-snapshots/` added to the crane source filter, so the baseline is actually visible to
  the check — the same trap that once made the trycmd docs-as-tests run **zero** cases.

Determinism of the invocation (#400's "must not flap"): `LC_ALL=C`, `--charset ascii`, `--locked`,
`--offline`, `| sort`, **`--target all`** (otherwise `cargo tree` resolves `cfg()` against the host
triple and the two-arch CI matrix could disagree), absolute path-dependency paths stripped, and
workspace-member versions pinned to `vWORKSPACE` so a release-plz bump is not a Gate B event.

### 3. `feat(cli)`: `tessera info` — #401

```
$ tessera info
tessera 0.1.0-alpha.1  (format tessera_version 0.0.0)
backends:   blob · dicom 0.9.1 · dicom-series 0.9.1 · hdf-compound 1.14.6 · nifti · raw
disabled:   (none)
build:      static-hdf5=no · cloud=no · sql=no
```

`--json` emits the same facts keyed for embedding in `aux/provenance.json`.

Backed by `tessera_ingest::backends`: `BACKENDS_ALL` (build-invariant, because ADR-0057 §6 keeps
`FormatOptions` closed **and total** so a spec's `spec_hash` cannot depend on which binary read it)
and `BACKENDS_ENABLED` (compiled-in subset — today equal, so `disabled:` is `(none)`). The enabled
list is already written in the shape Phase 1 needs: gating a decoder is one `#[cfg(feature = "…")]`
attribute per element, and nothing downstream changes.

Decoder versions come from the two places that actually know: `hdf-compound` reports the libhdf5
**actually linked** (queried at runtime — that number differs between a nix build and a `static-hdf5`
release binary, which a compile-time pin could not distinguish), and `dicom` reports the pin
`build.rs` reads from the workspace `Cargo.lock`. The lockfile scan is deliberately dependency-free:
a `[build-dependencies]` entry would move the resolved feature graph, i.e. trip Gate B — a
disproportionate price for reading one string. Without a workspace lockfile the version is simply
absent; a missing diagnostic must never fail a build.

**The flavor is not sealed.** ADR-0056 §6.2 seals `ingest_decoder`, which is what determined the
bytes. ADR-0042's line holds: sealed = what changed the bytes; `aux/` = who was in the room.

---

## Verification

- **`nix flake check -L --keep-going` green on x86_64-linux** with all three commits (aarch64 is
  CI's leg).
- Commit 1: `nix build .#checks.x86_64-linux.workspace-clippy` green under `-D warnings`; build log
  shows no CMake/HDF5-from-source leg and still checks tessera-core/-io/-ingest/-cli (with
  datafusion + cloud) and tessera-py. Package-delta diff above.
- Commit 2: the check is **negatively tested** — appending a fake `vortex-btrblocks feature "alp"`
  line to the baseline fails the build with the diff plus regeneration instructions. Snapshots
  generated inside the nix sandbox match those generated in a git worktree, which is what proves the
  path normalisation. All 11 verified byte-identical under host / `--target aarch64-unknown-linux-gnu`
  / `--target all`. `shellcheck -x` clean.
- Commit 3: 4 unit tests in `info.rs` (build modes asserted against `cfg!`, not hard-coded) + 5 in
  `backends.rs`, including an anti-drift guard that reads the variant list out of **serde's own**
  "unknown variant" error so a new `FormatOptions` variant fails until registered; plus
  `tests/cmd/info.trycmd` with versions wildcarded (#401's stated churn pitfall) and the `info` row
  added to the grouped help.

## Judgment calls

1. **`pcodec` → `pco`.** ADR-0057 §5 and #400 spell the snapshot entry `pcodec`, which is the project
   name; the crate in `Cargo.lock` is `pco`, so that is what `cargo tree -i` is given.
2. **`--target all`** added to the `cargo tree` invocation beyond the ADR's literal command, so the
   snapshot is host-independent across the two-arch CI matrix. Output is byte-identical today.
3. **`(format tessera_version 0.0.0)`** rather than §7's `v0` shorthand — the literal value this
   build stamps into a manifest is the number a reader can actually compare against.
4. **`--all-features` is still what Gate B snapshots**, per §5, so the `static-hdf5` corner of the
   feature space stays under structural watch even though the clippy gate no longer builds it.

## Not in scope (deliberately)

Gate A, the §5 feature graph, `static-hdf5` folding into `hdf5`, the `IngestOutput` seam, the §7
missing-backend errors — all Phase 1+. #402 P1 (the scheduled vendored-HDF5 build) is flagged above.

Refs: #400, #401, #402
